### PR TITLE
Added CI/CD pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
             platform: linux-x86_64


### PR DESCRIPTION
This is a DRAFT pr to add CI/CD, @schenksj should this isntead use the standalone script to run the tests?

Also at the moment the tests exit with an OOM 

 Split metadata validation passed for '/tmp/prewarm_integration_test_16395168591358069648/part-00000-0-933b38d8-5b52-4f4e-8bc0-8468c847ee8b.split': footerOffsets=3636-8910
🔍 Java SplitSearcher.getSchema called with nativePtr=7
🔍 Java getSchemaFromNative returned schemaPtr=8
🔍 Java SplitSearcher.getSchema called with nativePtr=7
🔍 Java getSchemaFromNative returned schemaPtr=9
🔍 Java SplitSearcher.getSchema called with nativePtr=7
🔍 Java getSchemaFromNative returned schemaPtr=11
🔍 Java SplitSearcher.getSchema called with nativePtr=7
🔍 Java getSchemaFromNative returned schemaPtr=13
memory allocation of 85899345880 bytes failed


do you have a workaround for this? maybe using smaller test data?