### PR TITLE
[feature] Implement DROP PARTITION command

### DIFF
--- a/src/main/antlr4/io/indextables/spark/sql/parser/IndexTables4SparkSqlBase.g4
+++ b/src/main/antlr4/io/indextables/spark/sql/parser/IndexTables4SparkSqlBase.g4
@@ -51,6 +51,8 @@ statement
         (OLDER THAN retentionNumber=INTEGER_VALUE retentionUnit=(DAYS | HOURS))?
         (TRANSACTION LOG RETENTION txLogRetentionNumber=INTEGER_VALUE txLogRetentionUnit=(DAYS | HOURS))?
         (DRY RUN)?                                              #purgeIndexTable
+    | DROP indexTablesKeyword PARTITIONS FROM (path=STRING | table=qualifiedName)
+        WHERE whereClause=predicateToken                        #dropPartitions
     | REPAIR INDEXFILES TRANSACTION LOG sourcePath=STRING
         AT LOCATION targetPath=STRING                           #repairIndexFilesTransactionLog
     | FLUSH indexTablesKeyword SEARCHER CACHE                       #flushIndexTablesCache
@@ -90,7 +92,7 @@ quotedIdentifier
 nonReserved
     : CACHE | SEARCHER | TANTIVY4SPARK | INDEXTABLES | INDEXTABLE | FOR | TRANSACTION | LOG | MAX | GROUPS
     | REPAIR | INDEXFILES | AT | LOCATION | PURGE | OLDER | THAN | DAYS | HOURS | DRY | RUN
-    | RETENTION | DESCRIBE | INCLUDE | ALL
+    | RETENTION | DESCRIBE | INCLUDE | ALL | DROP | PARTITIONS | FROM
     ;
 
 // Keywords (case-insensitive)
@@ -127,6 +129,9 @@ RETENTION: [Rr][Ee][Tt][Ee][Nn][Tt][Ii][Oo][Nn];
 DESCRIBE: [Dd][Ee][Ss][Cc][Rr][Ii][Bb][Ee];
 INCLUDE: [Ii][Nn][Cc][Ll][Uu][Dd][Ee];
 ALL: [Aa][Ll][Ll];
+DROP: [Dd][Rr][Oo][Pp];
+PARTITIONS: [Pp][Aa][Rr][Tt][Ii][Tt][Ii][Oo][Nn][Ss];
+FROM: [Ff][Rr][Oo][Mm];
 
 // Literals
 STRING

--- a/src/main/scala/io/indextables/spark/sql/DropPartitionsCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/DropPartitionsCommand.scala
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sql
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, UnaryNode}
+import org.apache.spark.sql.execution.command.RunnableCommand
+import org.apache.spark.sql.types.{LongType, StringType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import org.apache.hadoop.fs.Path
+
+import io.indextables.spark.transaction.{PartitionPredicateUtils, RemoveAction, TransactionLogFactory}
+import org.slf4j.LoggerFactory
+
+/**
+ * SQL command to drop (remove) partitions from an IndexTable.
+ *
+ * Syntax: DROP INDEXTABLES PARTITIONS FROM ('/path/to/table' | table_name) WHERE partition_predicates
+ *
+ * Examples:
+ *   - DROP INDEXTABLES PARTITIONS FROM '/path/to/table' WHERE year = '2023'
+ *   - DROP INDEXTABLES PARTITIONS FROM my_table WHERE date = '2024-01-01'
+ *   - DROP INDEXTABLES PARTITIONS FROM 's3://bucket/table' WHERE region = 'us-east' AND year > '2020'
+ *   - DROP INDEXTABLES PARTITIONS FROM my_db.my_table WHERE status = 'inactive' OR created < '2023-01-01'
+ *   - DROP INDEXTABLES PARTITIONS FROM my_table WHERE month BETWEEN 1 AND 6
+ *
+ * This command:
+ *   1. Parses and validates the WHERE clause to ensure only partition columns are referenced
+ *   2. Finds all splits matching the partition predicates
+ *   3. Adds RemoveAction entries to the transaction log for matching splits
+ *   4. Does NOT physically delete the split files (use PURGE INDEXTABLE for that)
+ *   5. Removed splits become eligible for cleanup after retention period expires
+ *
+ * Requirements:
+ *   - WHERE clause is mandatory
+ *   - WHERE clause must reference only partition columns
+ *   - At least one partition column must be referenced
+ *   - Table must have partition columns defined
+ */
+case class DropPartitionsCommand(
+  override val child: LogicalPlan,
+  userPartitionPredicates: Seq[String])
+    extends RunnableCommand
+    with UnaryNode {
+
+  private val logger = LoggerFactory.getLogger(classOf[DropPartitionsCommand])
+
+  override val output: Seq[Attribute] = Seq(
+    AttributeReference("table_path", StringType)(),
+    AttributeReference("status", StringType)(),
+    AttributeReference("partitions_dropped", LongType)(),
+    AttributeReference("splits_removed", LongType)(),
+    AttributeReference("total_size_bytes", LongType)(),
+    AttributeReference("message", StringType)()
+  )
+
+  override protected def withNewChildInternal(newChild: LogicalPlan): DropPartitionsCommand =
+    copy(child = newChild)
+
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+
+    // Validate that WHERE clause is provided
+    if (userPartitionPredicates.isEmpty) {
+      throw new IllegalArgumentException(
+        "DROP INDEXTABLES PARTITIONS requires a WHERE clause. " +
+          "Use PURGE INDEXTABLE to remove all data or specify partition predicates."
+      )
+    }
+
+    // Resolve table path from child logical plan
+    val tablePath =
+      try
+        resolveTablePath(child, sparkSession)
+      catch {
+        case e: IllegalArgumentException =>
+          val pathStr = child match {
+            case resolved: UnresolvedDeltaPathOrIdentifier =>
+              resolved.path.getOrElse(resolved.tableIdentifier.map(_.toString).getOrElse("unknown"))
+            case _ => "unknown"
+          }
+          logger.info(s"Table or path not found: $pathStr")
+          return Seq(Row(pathStr, "error", null, null, null, s"Table or path does not exist: ${e.getMessage}"))
+      }
+
+    // Create transaction log
+    val transactionLog =
+      TransactionLogFactory.create(tablePath, sparkSession, new CaseInsensitiveStringMap(java.util.Collections.emptyMap()))
+
+    try {
+      // Check if transaction log is initialized
+      val metadata =
+        try
+          transactionLog.getMetadata()
+        catch {
+          case _: Exception =>
+            logger.info(s"No transaction log found at: $tablePath")
+            return Seq(Row(tablePath.toString, "error", null, null, null, "Not a valid IndexTables4Spark table"))
+        }
+
+      // Validate table has partition columns
+      if (metadata.partitionColumns.isEmpty) {
+        throw new IllegalArgumentException(
+          s"Cannot drop partitions from non-partitioned table. " +
+            s"Table at $tablePath has no partition columns defined."
+        )
+      }
+
+      logger.info(s"Found ${metadata.partitionColumns.size} partition columns: ${metadata.partitionColumns.mkString(", ")}")
+
+      // Build partition schema
+      val partitionSchema = PartitionPredicateUtils.buildPartitionSchema(metadata.partitionColumns)
+
+      // Parse and validate predicates (will throw if invalid columns are referenced)
+      val parsedPredicates = PartitionPredicateUtils.parseAndValidatePredicates(
+        userPartitionPredicates,
+        partitionSchema,
+        sparkSession
+      )
+
+      // Get all current files
+      val allFiles = transactionLog.listFiles()
+      if (allFiles.isEmpty) {
+        logger.info(s"No files found in table: $tablePath")
+        return Seq(Row(tablePath.toString, "no_action", 0L, 0L, 0L, "Table is empty"))
+      }
+
+      logger.info(s"Found ${allFiles.length} split files in transaction log")
+
+      // Filter files by partition predicates
+      val matchingFiles = PartitionPredicateUtils.filterAddActionsByPredicates(
+        allFiles,
+        partitionSchema,
+        parsedPredicates
+      )
+
+      if (matchingFiles.isEmpty) {
+        logger.info(s"No partitions match the specified predicates: ${userPartitionPredicates.mkString(", ")}")
+        return Seq(Row(
+          tablePath.toString,
+          "no_action",
+          0L,
+          0L,
+          0L,
+          s"No partitions match predicates: ${userPartitionPredicates.mkString(", ")}"
+        ))
+      }
+
+      // Count unique partitions being dropped
+      val uniquePartitions = matchingFiles.map(_.partitionValues).distinct
+      logger.info(s"Dropping ${uniquePartitions.size} partitions containing ${matchingFiles.length} splits")
+
+      // Log details of files to be removed
+      uniquePartitions.foreach { partitionValues =>
+        val filesInPartition = matchingFiles.filter(_.partitionValues == partitionValues)
+        val totalSize        = filesInPartition.map(_.size).sum
+        logger.info(s"  Partition $partitionValues: ${filesInPartition.length} splits, ${totalSize} bytes")
+      }
+
+      // Create RemoveActions for all matching files
+      val deletionTimestamp = System.currentTimeMillis()
+      val removeActions = matchingFiles.map { file =>
+        RemoveAction(
+          path = file.path,
+          deletionTimestamp = Some(deletionTimestamp),
+          dataChange = true, // This is a data change operation
+          extendedFileMetadata = Some(true),
+          partitionValues = Some(file.partitionValues),
+          size = Some(file.size),
+          tags = file.tags
+        )
+      }
+
+      // Commit the remove actions to transaction log
+      val version = transactionLog.commitRemoveActions(removeActions)
+      val totalSize = matchingFiles.map(_.size).sum
+
+      logger.info(
+        s"Successfully dropped ${uniquePartitions.size} partitions (${matchingFiles.length} splits, $totalSize bytes) in transaction version $version"
+      )
+
+      Seq(Row(
+        tablePath.toString,
+        "success",
+        uniquePartitions.size.toLong,
+        matchingFiles.length.toLong,
+        totalSize,
+        s"Dropped ${uniquePartitions.size} partitions containing ${matchingFiles.length} splits. " +
+          s"Files will be eligible for cleanup after retention period expires. " +
+          s"Run PURGE INDEXTABLE to physically delete the files."
+      ))
+
+    } finally
+      transactionLog.close()
+  }
+
+  /** Resolve table path from logical plan child. */
+  private def resolveTablePath(child: LogicalPlan, sparkSession: SparkSession): Path =
+    child match {
+      case resolved: UnresolvedDeltaPathOrIdentifier =>
+        resolved.path match {
+          case Some(pathStr) => new Path(pathStr)
+          case None =>
+            resolved.tableIdentifier match {
+              case Some(tableId) =>
+                val catalog = sparkSession.sessionState.catalog
+                if (catalog.tableExists(tableId)) {
+                  val tableMetadata = catalog.getTableMetadata(tableId)
+                  new Path(tableMetadata.location)
+                } else {
+                  throw new IllegalArgumentException(s"Table not found: $tableId")
+                }
+              case None =>
+                throw new IllegalArgumentException("Either path or table identifier must be specified")
+            }
+        }
+      case _ =>
+        throw new IllegalArgumentException(s"Unsupported child plan type: ${child.getClass.getSimpleName}")
+    }
+}
+
+object DropPartitionsCommand {
+
+  /**
+   * Create a DropPartitionsCommand from path or table identifier.
+   */
+  def apply(
+    path: Option[String],
+    tableIdentifier: Option[org.apache.spark.sql.catalyst.TableIdentifier],
+    userPartitionPredicates: Seq[String]
+  ): DropPartitionsCommand = {
+    val plan = UnresolvedDeltaPathOrIdentifier(path, tableIdentifier, "DROP PARTITIONS")
+    DropPartitionsCommand(plan, userPartitionPredicates)
+  }
+}

--- a/src/main/scala/io/indextables/spark/transaction/PartitionPredicateUtils.scala
+++ b/src/main/scala/io/indextables/spark/transaction/PartitionPredicateUtils.scala
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.transaction
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.unsafe.types.UTF8String
+
+import org.slf4j.LoggerFactory
+
+/**
+ * Utilities for parsing, validating, and evaluating partition predicates. This class extracts common logic used by
+ * commands that need to filter partitions based on WHERE clauses (e.g., MERGE SPLITS, DROP PARTITIONS).
+ */
+object PartitionPredicateUtils {
+
+  private val logger = LoggerFactory.getLogger(PartitionPredicateUtils.getClass)
+
+  /**
+   * Parse partition predicates from raw WHERE clause text and validate that they only reference partition columns.
+   *
+   * @param predicates
+   *   Raw predicate strings from the WHERE clause
+   * @param partitionSchema
+   *   Schema defining the partition columns
+   * @param sparkSession
+   *   SparkSession for parsing expressions
+   * @return
+   *   Sequence of parsed and validated Expression objects
+   * @throws IllegalArgumentException
+   *   if predicates reference non-partition columns or cannot be parsed
+   */
+  def parseAndValidatePredicates(
+    predicates: Seq[String],
+    partitionSchema: StructType,
+    sparkSession: SparkSession
+  ): Seq[Expression] = {
+
+    // If no partition columns are defined, reject any WHERE clauses
+    if (partitionSchema.isEmpty && predicates.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"WHERE clause not supported for non-partitioned tables. Partition predicates: ${predicates.mkString(", ")}"
+      )
+    }
+
+    predicates.flatMap { predicate =>
+      try {
+        val expression = sparkSession.sessionState.sqlParser.parseExpression(predicate)
+        validatePartitionColumnReferences(expression, partitionSchema)
+        Some(expression)
+      } catch {
+        case ex: IllegalArgumentException =>
+          // Re-throw validation errors as-is
+          throw ex
+        case ex: Exception =>
+          logger.error(s"Failed to parse partition predicate: $predicate", ex)
+          throw new IllegalArgumentException(s"Invalid partition predicate: $predicate", ex)
+      }
+    }
+  }
+
+  /**
+   * Validate that the expression only references partition columns.
+   *
+   * @param expression
+   *   The expression to validate
+   * @param partitionSchema
+   *   Schema defining the valid partition columns
+   * @throws IllegalArgumentException
+   *   if the expression references non-partition columns
+   */
+  def validatePartitionColumnReferences(expression: Expression, partitionSchema: StructType): Unit = {
+    val partitionColumns  = partitionSchema.fieldNames.toSet
+    val referencedColumns = expression.references.map(_.name).toSet
+
+    // Check if any referenced columns are not partition columns
+    val invalidColumns = referencedColumns -- partitionColumns
+    if (invalidColumns.nonEmpty) {
+      throw new IllegalArgumentException(
+        s"WHERE clause references non-partition columns: ${invalidColumns.mkString(", ")}. " +
+          s"Only partition columns are allowed: ${partitionColumns.mkString(", ")}"
+      )
+    }
+
+    // Check if WHERE clause is empty (no column references)
+    if (referencedColumns.isEmpty) {
+      throw new IllegalArgumentException(
+        s"WHERE clause must reference at least one partition column. " +
+          s"Available partition columns: ${partitionColumns.mkString(", ")}"
+      )
+    }
+  }
+
+  /**
+   * Create an InternalRow from partition values for predicate evaluation.
+   *
+   * @param partitionValues
+   *   Map of partition column names to values
+   * @param partitionSchema
+   *   Schema defining the partition columns
+   * @return
+   *   InternalRow with partition values
+   */
+  def createRowFromPartitionValues(
+    partitionValues: Map[String, String],
+    partitionSchema: StructType
+  ): InternalRow = {
+    val values = partitionSchema.fieldNames.map { fieldName =>
+      partitionValues.get(fieldName) match {
+        case Some(value) => UTF8String.fromString(value)
+        case None        => null
+      }
+    }
+    InternalRow.fromSeq(values)
+  }
+
+  /**
+   * Resolve an expression against a schema to handle UnresolvedAttribute references and cast literals to UTF8String.
+   *
+   * @param expression
+   *   The expression to resolve
+   * @param schema
+   *   Schema to resolve against
+   * @return
+   *   Resolved expression ready for evaluation
+   */
+  def resolveExpression(expression: Expression, schema: StructType): Expression =
+    expression.transform {
+      case unresolvedAttr: org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute =>
+        val fieldName  = unresolvedAttr.name
+        val fieldIndex = schema.fieldIndex(fieldName)
+        val field      = schema(fieldIndex)
+        org.apache.spark.sql.catalyst.expressions.BoundReference(fieldIndex, field.dataType, field.nullable)
+      case literal: org.apache.spark.sql.catalyst.expressions.Literal =>
+        // Cast all literals to UTF8String since partition values are stored as strings
+        literal.dataType match {
+          case StringType => literal
+          case _ =>
+            // Convert non-string literals to UTF8String for comparison with partition values
+            org.apache.spark.sql.catalyst.expressions.Literal(UTF8String.fromString(literal.value.toString), StringType)
+        }
+    }
+
+  /**
+   * Evaluate whether a partition matches the given predicates.
+   *
+   * @param partitionValues
+   *   The partition values to evaluate
+   * @param partitionSchema
+   *   Schema defining the partition columns
+   * @param predicates
+   *   Parsed predicate expressions
+   * @return
+   *   true if the partition matches all predicates
+   */
+  def evaluatePredicates(
+    partitionValues: Map[String, String],
+    partitionSchema: StructType,
+    predicates: Seq[Expression]
+  ): Boolean = {
+    if (predicates.isEmpty) return true
+
+    val row = createRowFromPartitionValues(partitionValues, partitionSchema)
+    predicates.forall { predicate =>
+      try {
+        val resolvedPredicate = resolveExpression(predicate, partitionSchema)
+        resolvedPredicate.eval(row).asInstanceOf[Boolean]
+      } catch {
+        case ex: Exception =>
+          logger.warn(s"Failed to evaluate predicate against partition $partitionValues: ${ex.getMessage}")
+          false // Conservative: exclude partition if evaluation fails
+      }
+    }
+  }
+
+  /**
+   * Filter AddActions by partition predicates.
+   *
+   * @param addActions
+   *   The AddActions to filter
+   * @param partitionSchema
+   *   Schema defining the partition columns
+   * @param predicates
+   *   Parsed predicate expressions
+   * @return
+   *   AddActions that match the predicates
+   */
+  def filterAddActionsByPredicates(
+    addActions: Seq[AddAction],
+    partitionSchema: StructType,
+    predicates: Seq[Expression]
+  ): Seq[AddAction] = {
+    if (predicates.isEmpty) return addActions
+
+    val filtered = addActions.filter { action =>
+      evaluatePredicates(action.partitionValues, partitionSchema, predicates)
+    }
+
+    val prunedCount = addActions.length - filtered.length
+    if (prunedCount > 0) {
+      logger.info(s"Partition predicate filtering: matched ${filtered.length} of ${addActions.length} splits")
+    }
+
+    filtered
+  }
+
+  /**
+   * Build a partition schema from partition column names. All partition columns are treated as StringType for
+   * evaluation purposes since partition values are stored as strings in the transaction log.
+   *
+   * @param partitionColumns
+   *   Sequence of partition column names
+   * @return
+   *   StructType with all columns as StringType
+   */
+  def buildPartitionSchema(partitionColumns: Seq[String]): StructType =
+    StructType(partitionColumns.map(name => StructField(name, StringType, nullable = true)))
+}

--- a/src/main/scala/io/indextables/spark/transaction/TransactionLogInterface.scala
+++ b/src/main/scala/io/indextables/spark/transaction/TransactionLogInterface.scala
@@ -221,4 +221,20 @@ trait TransactionLogInterface extends AutoCloseable {
     // Default implementation: create a single transaction with removes followed by adds
     // Both TransactionLog and OptimizedTransactionLog override this with custom implementations
     throw new UnsupportedOperationException("commitMergeSplits must be implemented by subclass")
+
+  /**
+   * Commits remove actions to mark files as logically deleted.
+   *
+   * This operation marks files as removed in the transaction log without physically deleting them. The files become
+   * invisible to queries but remain on disk for recovery and time-travel purposes. Physical deletion occurs when
+   * running PURGE INDEXTABLE after the retention period expires.
+   *
+   * @param removeActions
+   *   Sequence of remove actions for files to mark as deleted
+   * @return
+   *   The transaction version number for this operation
+   */
+  def commitRemoveActions(removeActions: Seq[RemoveAction]): Long =
+    // Default implementation can be overridden by subclasses
+    throw new UnsupportedOperationException("commitRemoveActions must be implemented by subclass")
 }

--- a/src/test/scala/io/indextables/spark/sql/DropPartitionsIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/DropPartitionsIntegrationTest.scala
@@ -1,0 +1,457 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sql
+
+import java.io.File
+import java.nio.file.Files
+
+import org.apache.spark.sql.SparkSession
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Integration tests for DROP INDEXTABLES PARTITIONS command. */
+class DropPartitionsIntegrationTest extends AnyFunSuite with BeforeAndAfterEach {
+
+  var spark: SparkSession = _
+  var tempDir: String     = _
+  var fs: FileSystem      = _
+
+  override def beforeEach(): Unit = {
+    spark = SparkSession
+      .builder()
+      .master("local[4]")
+      .appName("DropPartitionsIntegrationTest")
+      .config("spark.ui.enabled", "false")
+      .config("spark.sql.extensions", "io.indextables.spark.extensions.IndexTables4SparkExtensions")
+      .config("spark.indextables.purge.retentionCheckEnabled", "true")
+      .getOrCreate()
+
+    tempDir = Files.createTempDirectory("drop_partitions_test").toString
+    fs = new Path(tempDir).getFileSystem(spark.sparkContext.hadoopConfiguration)
+  }
+
+  override def afterEach(): Unit = {
+    if (spark != null) {
+      spark.stop()
+      spark = null
+    }
+    // Cleanup temp directory
+    if (tempDir != null) {
+      val dir = new File(tempDir)
+      if (dir.exists()) {
+        deleteRecursively(dir)
+      }
+    }
+  }
+
+  private def deleteRecursively(file: File): Unit = {
+    if (file.isDirectory) {
+      file.listFiles().foreach(deleteRecursively)
+    }
+    file.delete()
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should logically remove partitions matching equality predicate") {
+    val tablePath = s"$tempDir/partitioned_table"
+
+    // Write partitioned data
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val data = Seq(
+      (1, "Alice", "2023", "01"),
+      (2, "Bob", "2023", "01"),
+      (3, "Charlie", "2023", "02"),
+      (4, "Diana", "2024", "01"),
+      (5, "Eve", "2024", "02")
+    ).toDF("id", "name", "year", "month")
+
+    data.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .partitionBy("year", "month")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // Verify initial data
+    val beforeDrop = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tablePath)
+    assert(beforeDrop.count() == 5)
+
+    // Drop partitions for year = '2023'
+    val result = spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE year = '2023'").collect()
+    assert(result.length == 1)
+    assert(result(0).getString(1) == "success")
+    assert(result(0).getLong(2) == 2) // 2 partitions dropped (01 and 02 for 2023)
+
+    // Verify data after drop - should only see 2024 data
+    val afterDrop = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tablePath)
+    assert(afterDrop.count() == 2)
+    assert(afterDrop.filter($"year" === "2024").count() == 2)
+    assert(afterDrop.filter($"year" === "2023").count() == 0)
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should logically remove partitions matching range predicate") {
+    val tablePath = s"$tempDir/range_test"
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val data = Seq(
+      (1, "A", "2020"),
+      (2, "B", "2021"),
+      (3, "C", "2022"),
+      (4, "D", "2023"),
+      (5, "E", "2024")
+    ).toDF("id", "name", "year")
+
+    data.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .partitionBy("year")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // Drop partitions where year < '2022'
+    val result = spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE year < '2022'").collect()
+    assert(result.length == 1)
+    assert(result(0).getString(1) == "success")
+
+    // Verify data after drop - should only see 2022, 2023, 2024 data
+    val afterDrop = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tablePath)
+    assert(afterDrop.count() == 3)
+    assert(afterDrop.filter($"year" >= "2022").count() == 3)
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should logically remove partitions matching compound AND predicate") {
+    val tablePath = s"$tempDir/compound_and_test"
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val data = Seq(
+      (1, "A", "2023", "Q1"),
+      (2, "B", "2023", "Q2"),
+      (3, "C", "2023", "Q3"),
+      (4, "D", "2024", "Q1"),
+      (5, "E", "2024", "Q2")
+    ).toDF("id", "name", "year", "quarter")
+
+    data.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .partitionBy("year", "quarter")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // Drop partitions where year = '2023' AND quarter = 'Q1'
+    val result = spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE year = '2023' AND quarter = 'Q1'").collect()
+    assert(result.length == 1)
+    assert(result(0).getString(1) == "success")
+    assert(result(0).getLong(2) == 1) // Only 1 partition dropped
+
+    // Verify data after drop
+    val afterDrop = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tablePath)
+    assert(afterDrop.count() == 4)
+    assert(afterDrop.filter($"year" === "2023" && $"quarter" === "Q1").count() == 0)
+    assert(afterDrop.filter($"year" === "2023" && $"quarter" =!= "Q1").count() == 2)
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should fail when WHERE clause references non-partition columns") {
+    val tablePath = s"$tempDir/non_partition_error"
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val data = Seq(
+      (1, "Alice", "2023"),
+      (2, "Bob", "2024")
+    ).toDF("id", "name", "year")
+
+    data.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .partitionBy("year")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // Try to drop using non-partition column 'name'
+    val ex = intercept[Exception] {
+      spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE name = 'Alice'").collect()
+    }
+
+    assert(ex.getMessage.contains("non-partition") || ex.getMessage.contains("Only partition columns"))
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should fail on non-partitioned table") {
+    val tablePath = s"$tempDir/non_partitioned"
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val data = Seq(
+      (1, "Alice"),
+      (2, "Bob")
+    ).toDF("id", "name")
+
+    data.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // Try to drop partitions from non-partitioned table
+    val ex = intercept[Exception] {
+      spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE id = 1").collect()
+    }
+
+    assert(ex.getMessage.contains("non-partitioned") || ex.getMessage.contains("no partition columns"))
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should return no_action when no partitions match") {
+    val tablePath = s"$tempDir/no_match_test"
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val data = Seq(
+      (1, "Alice", "2023"),
+      (2, "Bob", "2024")
+    ).toDF("id", "name", "year")
+
+    data.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .partitionBy("year")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // Drop partitions for year = '2025' (doesn't exist)
+    val result = spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE year = '2025'").collect()
+    assert(result.length == 1)
+    assert(result(0).getString(1) == "no_action")
+    assert(result(0).getLong(2) == 0) // 0 partitions dropped
+    assert(result(0).getLong(3) == 0) // 0 splits removed
+  }
+
+  test("DESCRIBE TRANSACTION LOG should show remove actions after DROP PARTITIONS") {
+    val tablePath = s"$tempDir/describe_test"
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val data = Seq(
+      (1, "Alice", "2023"),
+      (2, "Bob", "2024")
+    ).toDF("id", "name", "year")
+
+    data.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .partitionBy("year")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // Drop 2023 partitions
+    spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE year = '2023'").collect()
+
+    // Use DESCRIBE TRANSACTION LOG to verify remove actions
+    // Schema: version, log_file_path, action_type, path, partition_values, ...
+    val describeResult = spark.sql(s"DESCRIBE INDEXTABLES TRANSACTION LOG '$tablePath' INCLUDE ALL").collect()
+
+    // Should have at least one remove action for the dropped partition
+    // action_type is at index 2
+    val removeActions = describeResult.filter(_.getString(2) == "remove")
+    assert(removeActions.length >= 1, s"Expected at least one remove action, got: ${removeActions.length}")
+
+    // The 'path' column (index 3) should contain the split file path
+    val removeActionPath = removeActions(0).getString(3)
+    assert(
+      removeActionPath != null && removeActionPath.endsWith(".split"),
+      s"Expected remove action for a .split file, got: $removeActionPath"
+    )
+  }
+
+  test("PURGE INDEXTABLE should clean up files from dropped partitions after retention") {
+    val tablePath = s"$tempDir/purge_after_drop"
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val data = Seq(
+      (1, "Alice", "2023"),
+      (2, "Bob", "2023"),
+      (3, "Charlie", "2024")
+    ).toDF("id", "name", "year")
+
+    data.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .partitionBy("year")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // Get the split files before drop
+    val splitFiles = fs.listStatus(new Path(tablePath))
+      .flatMap { status =>
+        if (status.isDirectory && status.getPath.getName.startsWith("year=")) {
+          fs.listStatus(status.getPath).filter(_.getPath.getName.endsWith(".split"))
+        } else {
+          Array.empty[org.apache.hadoop.fs.FileStatus]
+        }
+      }
+
+    val year2023Splits = splitFiles.filter(_.getPath.toString.contains("year=2023"))
+    assert(year2023Splits.nonEmpty, "Should have splits for 2023 partition")
+
+    // Drop 2023 partitions
+    val dropResult = spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE year = '2023'").collect()
+    assert(dropResult(0).getString(1) == "success")
+
+    // Verify data is logically removed
+    val afterDrop = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tablePath)
+    assert(afterDrop.count() == 1)
+    assert(afterDrop.filter($"year" === "2023").count() == 0)
+
+    // The files should still physically exist
+    val year2023Dir = new Path(s"$tablePath/year=2023")
+    assert(fs.exists(year2023Dir) || year2023Splits.exists(s => fs.exists(s.getPath)))
+
+    // Set the modification time of dropped files to be old enough for purge
+    // First, find all .split files
+    val allSplitFiles = fs.listStatus(new Path(tablePath))
+      .flatMap { status =>
+        if (status.isDirectory && status.getPath.getName.startsWith("year=")) {
+          fs.listStatus(status.getPath)
+        } else {
+          Array.empty[org.apache.hadoop.fs.FileStatus]
+        }
+      }
+
+    // Set modification time to 8 days ago for 2023 partition files
+    val oldTime = System.currentTimeMillis() - (8L * 24 * 60 * 60 * 1000)
+    allSplitFiles.filter(_.getPath.toString.contains("year=2023")).foreach { status =>
+      fs.setTimes(status.getPath, oldTime, -1)
+    }
+
+    // Run PURGE to clean up orphaned files
+    val purgeResult = spark.sql(s"PURGE INDEXTABLE '$tablePath' OLDER THAN 7 DAYS").collect()
+    assert(purgeResult.length == 1)
+
+    // Verify the 2024 data is still intact
+    val afterPurge = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tablePath)
+    assert(afterPurge.count() == 1)
+    assert(afterPurge.filter($"year" === "2024").count() == 1)
+  }
+
+  test("DROP INDEXTABLES PARTITIONS with OR compound predicate") {
+    val tablePath = s"$tempDir/or_compound_test"
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val data = Seq(
+      (1, "A", "2022"),
+      (2, "B", "2023"),
+      (3, "C", "2024"),
+      (4, "D", "2025")
+    ).toDF("id", "name", "year")
+
+    data.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .partitionBy("year")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // Drop partitions where year = '2022' OR year = '2024'
+    val result = spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE year = '2022' OR year = '2024'").collect()
+    assert(result.length == 1)
+    assert(result(0).getString(1) == "success")
+    assert(result(0).getLong(2) == 2) // 2 partitions dropped
+
+    // Verify data after drop - should only see 2023 and 2025 data
+    val afterDrop = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tablePath)
+    assert(afterDrop.count() == 2)
+    assert(afterDrop.filter($"year" === "2023").count() == 1)
+    assert(afterDrop.filter($"year" === "2025").count() == 1)
+  }
+
+  test("DROP INDEXTABLES PARTITIONS with BETWEEN predicate") {
+    val tablePath = s"$tempDir/between_test"
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val data = Seq(
+      (1, "A", 1),
+      (2, "B", 2),
+      (3, "C", 3),
+      (4, "D", 4),
+      (5, "E", 5),
+      (6, "F", 6)
+    ).toDF("id", "name", "month")
+
+    data.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .partitionBy("month")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // Drop partitions where month BETWEEN 2 AND 4
+    val result = spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE month BETWEEN 2 AND 4").collect()
+    assert(result.length == 1)
+    assert(result(0).getString(1) == "success")
+
+    // Verify data after drop - should only see months 1, 5, 6
+    val afterDrop = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tablePath)
+    assert(afterDrop.count() == 3)
+    assert(afterDrop.filter($"month" === 1).count() == 1)
+    assert(afterDrop.filter($"month" === 5).count() == 1)
+    assert(afterDrop.filter($"month" === 6).count() == 1)
+  }
+
+  test("Multiple DROP INDEXTABLES PARTITIONS operations should be cumulative") {
+    val tablePath = s"$tempDir/cumulative_test"
+
+    val sparkSession = spark
+    import sparkSession.implicits._
+    val data = Seq(
+      (1, "A", "2020"),
+      (2, "B", "2021"),
+      (3, "C", "2022"),
+      (4, "D", "2023"),
+      (5, "E", "2024")
+    ).toDF("id", "name", "year")
+
+    data.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .partitionBy("year")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // First drop: 2020
+    val result1 = spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE year = '2020'").collect()
+    assert(result1(0).getString(1) == "success")
+
+    // Verify
+    val afterDrop1 = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tablePath)
+    assert(afterDrop1.count() == 4)
+
+    // Second drop: 2021
+    val result2 = spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE year = '2021'").collect()
+    assert(result2(0).getString(1) == "success")
+
+    // Verify
+    val afterDrop2 = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tablePath)
+    assert(afterDrop2.count() == 3)
+
+    // Third drop: 2022
+    val result3 = spark.sql(s"DROP INDEXTABLES PARTITIONS FROM '$tablePath' WHERE year = '2022'").collect()
+    assert(result3(0).getString(1) == "success")
+
+    // Verify final state
+    val afterDrop3 = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tablePath)
+    assert(afterDrop3.count() == 2)
+    assert(afterDrop3.filter($"year" === "2023").count() == 1)
+    assert(afterDrop3.filter($"year" === "2024").count() == 1)
+  }
+}

--- a/src/test/scala/io/indextables/spark/sql/DropPartitionsParsingTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/DropPartitionsParsingTest.scala
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sql
+
+import org.apache.spark.sql.SparkSession
+
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funsuite.AnyFunSuite
+
+/** Parsing tests for DROP INDEXTABLES PARTITIONS command. */
+class DropPartitionsParsingTest extends AnyFunSuite with BeforeAndAfterEach {
+
+  var spark: SparkSession = _
+
+  override def beforeEach(): Unit =
+    spark = SparkSession
+      .builder()
+      .master("local[2]")
+      .appName("DropPartitionsParsingTest")
+      .config("spark.ui.enabled", "false")
+      .config("spark.sql.extensions", "io.indextables.spark.extensions.IndexTables4SparkExtensions")
+      .getOrCreate()
+
+  override def afterEach(): Unit =
+    if (spark != null) {
+      spark.stop()
+      spark = null
+    }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with path and simple equality predicate") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM '/tmp/test_table' WHERE year = '2023'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+
+    val cmd = plan.asInstanceOf[DropPartitionsCommand]
+    assert(cmd.userPartitionPredicates.nonEmpty)
+    assert(cmd.userPartitionPredicates.head.contains("year"))
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with greater than predicate") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM '/tmp/test_table' WHERE year > '2020'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with less than predicate") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM '/tmp/test_table' WHERE month < 6"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with BETWEEN predicate") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM '/tmp/test_table' WHERE month BETWEEN 1 AND 6"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+
+    val cmd = plan.asInstanceOf[DropPartitionsCommand]
+    assert(cmd.userPartitionPredicates.head.contains("BETWEEN") || cmd.userPartitionPredicates.head.contains("between"))
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with AND compound predicate") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM '/tmp/test_table' WHERE year = '2023' AND month = '01'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+
+    val cmd = plan.asInstanceOf[DropPartitionsCommand]
+    assert(cmd.userPartitionPredicates.head.contains("AND") || cmd.userPartitionPredicates.head.contains("and"))
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with OR compound predicate") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM '/tmp/test_table' WHERE year = '2023' OR year = '2024'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+
+    val cmd = plan.asInstanceOf[DropPartitionsCommand]
+    assert(cmd.userPartitionPredicates.head.contains("OR") || cmd.userPartitionPredicates.head.contains("or"))
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with complex compound predicate") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM '/tmp/test_table' WHERE region = 'us-east' AND year > '2020' OR status = 'inactive'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with S3 path") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM 's3://bucket/table' WHERE partition_key = 'value'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse case-insensitive keywords") {
+    val sql  = "drop indextables partitions from '/tmp/test_table' where year = '2023'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+  }
+
+  test("DROP TANTIVY4SPARK PARTITIONS should also work") {
+    val sql  = "DROP TANTIVY4SPARK PARTITIONS FROM '/tmp/test_table' WHERE year = '2023'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with table identifier") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM my_table WHERE year = '2023'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with qualified table identifier") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM my_db.my_table WHERE year = '2023'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should fail without WHERE clause") {
+    val sql = "DROP INDEXTABLES PARTITIONS FROM '/tmp/test_table'"
+    val ex  = intercept[Exception] {
+      spark.sessionState.sqlParser.parsePlan(sql)
+    }
+    // The parsing should fail because WHERE is required - Spark's parser gives a syntax error
+    assert(
+      ex.getMessage.contains("WHERE") ||
+        ex.getMessage.contains("mismatched input") ||
+        ex.getMessage.contains("PARSE_SYNTAX_ERROR") ||
+        ex.getMessage.contains("Syntax error")
+    )
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with IN predicate") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM '/tmp/test_table' WHERE region IN ('us-east', 'us-west', 'eu-west')"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with greater than or equal predicate") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM '/tmp/test_table' WHERE year >= '2020'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+  }
+
+  test("DROP INDEXTABLES PARTITIONS should parse with less than or equal predicate") {
+    val sql  = "DROP INDEXTABLES PARTITIONS FROM '/tmp/test_table' WHERE month <= 6"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DropPartitionsCommand])
+  }
+}


### PR DESCRIPTION
# DROP INDEXTABLES PARTITIONS SQL Command

## Summary

This PR implements a new SQL command `DROP INDEXTABLES PARTITIONS` that allows users to logically remove data from specific partitions of an IndexTable. The command adds `RemoveAction` entries to the transaction log without physically deleting the files, which can then be cleaned up using the existing `PURGE INDEXTABLE` command after the retention period expires.

## Key Features

- **WHERE clause required**: Prevents accidental full table drops
- **Partition columns only**: Validates that WHERE clause references only partition columns
- **Support for compound predicates**: AND, OR, BETWEEN, >, <, >=, <=, IN, =
- **Logical deletion**: Adds RemoveAction entries without physical deletion
- **Integration with PURGE**: Dropped partitions are cleaned up by PURGE after retention
- **DESCRIBE verification**: RemoveActions visible via DESCRIBE TRANSACTION LOG

## Syntax

```sql
-- Basic partition drop
DROP INDEXTABLES PARTITIONS FROM 's3://bucket/path' WHERE year = '2023';
DROP INDEXTABLES PARTITIONS FROM my_table WHERE date = '2024-01-01';

-- Range predicates
DROP INDEXTABLES PARTITIONS FROM 's3://bucket/path' WHERE year > '2020';
DROP INDEXTABLES PARTITIONS FROM 's3://bucket/path' WHERE month BETWEEN 1 AND 6;

-- Compound predicates
DROP INDEXTABLES PARTITIONS FROM 's3://bucket/path' WHERE region = 'us-east' AND year > '2020';
DROP INDEXTABLES PARTITIONS FROM 's3://bucket/path' WHERE year = '2022' OR year = '2023';

-- Also works with TANTIVY4SPARK keyword
DROP TANTIVY4SPARK PARTITIONS FROM 's3://bucket/path' WHERE partition_key = 'value';
```

## Implementation Details

### New Files
- `src/main/scala/io/indextables/spark/sql/DropPartitionsCommand.scala` - Command implementation
- `src/main/scala/io/indextables/spark/transaction/PartitionPredicateUtils.scala` - Shared utility for partition predicate parsing and validation
- `src/test/scala/io/indextables/spark/sql/DropPartitionsParsingTest.scala` - Parsing tests (16 tests)
- `src/test/scala/io/indextables/spark/sql/DropPartitionsIntegrationTest.scala` - Integration tests (11 tests)

### Modified Files
- `src/main/antlr4/io/indextables/spark/sql/parser/IndexTables4SparkSqlBase.g4` - ANTLR grammar
- `src/main/scala/io/indextables/spark/sql/parser/IndexTables4SparkSqlAstBuilder.scala` - AST builder visitor
- `src/main/scala/io/indextables/spark/transaction/TransactionLogInterface.scala` - Added `commitRemoveActions` method
- `src/main/scala/io/indextables/spark/transaction/TransactionLog.scala` - Implemented `commitRemoveActions`
- `src/main/scala/io/indextables/spark/transaction/OptimizedTransactionLog.scala` - Implemented `commitRemoveActions` and `commitMergeSplits`
- `CLAUDE.md` - Documentation
- `README.md` - Documentation

### Output Schema

The command returns a single row with the following columns:
- `table_path` (String): The resolved table path
- `status` (String): "success", "no_action", or "error"
- `partitions_dropped` (Long): Number of unique partitions dropped
- `splits_removed` (Long): Number of split files removed
- `total_size_bytes` (Long): Total size of removed files
- `message` (String): Detailed message about the operation

## Error Handling

The command validates:
1. WHERE clause is required (fails parsing without it)
2. All referenced columns must be partition columns
3. At least one partition column must be referenced
4. Table must have partition columns defined

## Example Workflow

```scala
// 1. Drop old partitions
spark.sql("DROP INDEXTABLES PARTITIONS FROM 's3://bucket/table' WHERE year < '2022'").show()

// 2. Verify with DESCRIBE (optional)
spark.sql("DESCRIBE INDEXTABLES TRANSACTION LOG 's3://bucket/table' INCLUDE ALL")
  .filter($"action_type" === "remove")
  .show()

// 3. After retention period, clean up physical files
spark.sql("PURGE INDEXTABLE 's3://bucket/table' OLDER THAN 7 DAYS").show()
```

## Test Plan

- [x] Parsing tests for all supported syntax variations (16 tests)
- [x] Integration tests for partition dropping (11 tests):
  - [x] Equality predicate
  - [x] Range predicates (>, <, BETWEEN)
  - [x] Compound predicates (AND, OR)
  - [x] Error handling for non-partition columns
  - [x] Error handling for non-partitioned tables
  - [x] No-action when no partitions match
  - [x] DESCRIBE TRANSACTION LOG verification
  - [x] PURGE integration for file cleanup
  - [x] Multiple cumulative drop operations

## Breaking Changes

None. This is a new feature that doesn't affect existing functionality.

## Documentation

- Updated CLAUDE.md with:
  - Core features list
  - Detailed syntax examples
  - Workflow example
  - Error handling documentation
- Updated README.md with:
  - Complete SQL syntax section
  - Scala/DataFrame API examples
  - Workflow example with expected output
