### PR TITLE
[bugfix] Add maxBatchBufferSize configuration to prevent native 100MB buffer limit errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ mvn test-compile scalatest:test -DwildcardSuites='io.indextables.spark.core.Date
 // Index Writer
 spark.indextables.indexWriter.heapSize: "100M" (supports "2G", "500M", "1024K")
 spark.indextables.indexWriter.batchSize: 10000
+spark.indextables.indexWriter.maxBatchBufferSize: "90M" (default: 90MB, prevents native 100MB limit errors)
 spark.indextables.indexWriter.threads: 2
 
 // Split Conversion (controls parallelism of tantivy index -> quickwit split conversion)

--- a/README.md
+++ b/README.md
@@ -911,6 +911,7 @@ The system supports several configuration options for performance tuning:
 | `spark.indextables.indexWriter.heapSize` | `100000000` | Index writer heap size in bytes (100MB default, supports "2G", "500M", "1024K") |
 | `spark.indextables.indexWriter.threads` | `2` | Number of indexing threads (2 threads default) |
 | `spark.indextables.indexWriter.batchSize` | `10000` | Batch size for bulk document indexing (10,000 documents default) |
+| `spark.indextables.indexWriter.maxBatchBufferSize` | `90M` | Maximum batch buffer size before flushing (90MB default, prevents native 100MB limit errors with large documents) |
 | `spark.indextables.indexWriter.useBatch` | `true` | Enable batch writing for better performance (enabled by default) |
 | `spark.indextables.indexWriter.tempDirectoryPath` | auto-detect `/local_disk0` | Custom temp directory for index creation (auto-detects optimal location) |
 | `spark.indextables.merge.tempDirectoryPath` | auto-detect `/local_disk0` | Custom temp directory for split merging (auto-detects optimal location) |

--- a/src/main/scala/io/indextables/spark/config/IndexTables4SparkSQLConf.scala
+++ b/src/main/scala/io/indextables/spark/config/IndexTables4SparkSQLConf.scala
@@ -52,11 +52,12 @@ object IndexTables4SparkSQLConf {
   // Index Writer Configuration
   /////////////////////
 
-  val TANTIVY4SPARK_INDEX_WRITER_HEAP_SIZE           = "spark.indextables.indexWriter.heapSize"
-  val TANTIVY4SPARK_INDEX_WRITER_THREADS             = "spark.indextables.indexWriter.threads"
-  val TANTIVY4SPARK_INDEX_WRITER_BATCH_SIZE          = "spark.indextables.indexWriter.batchSize"
-  val TANTIVY4SPARK_INDEX_WRITER_USE_BATCH           = "spark.indextables.indexWriter.useBatch"
-  val TANTIVY4SPARK_SPLIT_CONVERSION_MAX_PARALLELISM = "spark.indextables.splitConversion.maxParallelism"
+  val TANTIVY4SPARK_INDEX_WRITER_HEAP_SIZE             = "spark.indextables.indexWriter.heapSize"
+  val TANTIVY4SPARK_INDEX_WRITER_THREADS               = "spark.indextables.indexWriter.threads"
+  val TANTIVY4SPARK_INDEX_WRITER_BATCH_SIZE            = "spark.indextables.indexWriter.batchSize"
+  val TANTIVY4SPARK_INDEX_WRITER_MAX_BATCH_BUFFER_SIZE = "spark.indextables.indexWriter.maxBatchBufferSize"
+  val TANTIVY4SPARK_INDEX_WRITER_USE_BATCH             = "spark.indextables.indexWriter.useBatch"
+  val TANTIVY4SPARK_SPLIT_CONVERSION_MAX_PARALLELISM   = "spark.indextables.splitConversion.maxParallelism"
 
   /////////////////////
   // General Configuration


### PR DESCRIPTION
# Add maxBatchBufferSize configuration to prevent native 100MB buffer limit errors

## Summary

- Adds `spark.indextables.indexWriter.maxBatchBufferSize` configuration (default: 90MB)
- Prevents intermittent "Buffer too large: exceeds 100MB limit" errors during batch indexing
- Flushes batches based on **both** document count AND buffer size thresholds

## Problem

During batch indexing, tasks intermittently fail with:

```
java.lang.RuntimeException: Buffer too large: exceeds 100MB limit
  at io.indextables.tantivy4java.core.IndexWriter.nativeAddDocumentsByBuffer(Native Method)
```

**Root cause**: The native tantivy4java layer has a hard-coded 100MB buffer limit, but `spark.indextables.indexWriter.batchSize` only controls document count (default: 10,000), not buffer size. When documents are large (JSON fields, long text, binary data), a batch can exceed 100MB before reaching the document count threshold.

## Solution

Add size-based flushing alongside document count-based flushing:

1. New configuration `spark.indextables.indexWriter.maxBatchBufferSize` (default: 90MB)
2. Modified `flushBatchIfNeeded()` to check buffer size using existing `BatchDocumentBuilder.getEstimatedSize()` API
3. Batches flush when **either** threshold is reached, whichever comes first

## Changes

| File | Change |
|------|--------|
| `IndexTables4SparkSQLConf.scala` | Added `TANTIVY4SPARK_INDEX_WRITER_MAX_BATCH_BUFFER_SIZE` constant |
| `IndexTablesDirectInterface.scala` | Added `maxBatchBufferSize` config and modified `flushBatchIfNeeded()` |
| `IndexWriterConfigTest.scala` | Added 6 new test cases for buffer size-based flushing |
| `CLAUDE.md` | Documented new configuration option |
| `README.md` | Added to configuration table |

## Configuration

```scala
// Default: 90MB (10MB safety margin under native 100MB limit)
spark.indextables.indexWriter.maxBatchBufferSize: "90M"

// Supports size formats: "90M", "90m", "92160K", "94371840"
```

## Usage Examples

```scala
// Default behavior - no changes needed for most workloads
df.write.format("io.indextables.spark.core.IndexTables4SparkTableProvider")
  .save("s3://bucket/path")

// For workloads with very large documents, lower the threshold
df.write.format("io.indextables.spark.core.IndexTables4SparkTableProvider")
  .option("spark.indextables.indexWriter.maxBatchBufferSize", "50M")
  .save("s3://bucket/path")

// Session-level configuration
spark.conf.set("spark.indextables.indexWriter.maxBatchBufferSize", "70M")
```

## Test Plan

- [x] `should use default maxBatchBufferSize configuration (90MB)` - Verifies default works
- [x] `should support custom maxBatchBufferSize configuration` - Verifies custom values work
- [x] `should flush early when buffer size exceeds maxBatchBufferSize with large documents` - Verifies size-based flushing triggers before count-based
- [x] `should handle very large documents that individually approach buffer limit` - Stress test with 500KB documents
- [x] `should respect maxBatchBufferSize with size string formats` - Verifies "50M" format parsing
- [x] All existing `IndexWriterConfigTest` tests continue to pass (12/12)

```
Run completed in 12 seconds, 478 milliseconds.
Total number of tests run: 12
Suites: completed 2, aborted 0
Tests: succeeded 12, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| 10,000 small docs (~1KB each, ~10MB total) | Flush at 10,000 docs | Flush at 10,000 docs (no change) |
| 5,000 large docs (~20KB each, ~100MB total) | **FAILS** at native layer | Flushes early at ~90MB (~4,500 docs) |
| 1,000 very large docs (~100KB each) | **FAILS** at native layer | Flushes early at ~90MB (~900 docs) |

## Logging

When early flush is triggered by buffer size (not document count), an INFO log is emitted:

```
Flushed batch early due to buffer size: 4523 documents, ~90MB (threshold: 90MB)
```

Normal flushes continue to log at DEBUG level:

```
Flushed batch with 10000 documents (~45000KB)
```

## Backward Compatibility

- Fully backward compatible
- Default 90MB threshold prevents existing workloads from hitting the 100MB limit
- No changes required for existing configurations
- Existing `batchSize` configuration continues to work as before

## Related

- Native limit location: `tantivy4java/native/src/searcher.rs:2279`
