### PR TITLE
Fix ClassCastException in GROUP BY queries with Date/Timestamp partitions

### DIFF
--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkScanBuilder.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkScanBuilder.scala
@@ -245,7 +245,8 @@ class IndexTables4SparkScanBuilder(
         options,
         config,
         Some(groupByColumns), // Pass GROUP BY columns for grouped aggregation
-        hasAggregations       // Indicate if this has aggregations or is just DISTINCT
+        hasAggregations,      // Indicate if this has aggregations or is just DISTINCT
+        Some(schema)          // Pass schema for proper type handling (fixes Date partition ClassCastException)
       )
     } else {
       // Regular GROUP BY scan using tantivy aggregations
@@ -378,7 +379,16 @@ class IndexTables4SparkScanBuilder(
 
   /** Create a specialized scan that returns count from transaction log. */
   private def createTransactionLogCountScan(aggregation: Aggregation, effectiveFilters: Array[Filter]): Scan =
-    new TransactionLogCountScan(sparkSession, transactionLog, effectiveFilters, options, config)
+    new TransactionLogCountScan(
+      sparkSession,
+      transactionLog,
+      effectiveFilters,
+      options,
+      config,
+      None,        // No GROUP BY columns for simple COUNT
+      true,        // Has aggregations
+      Some(schema) // Pass schema for proper type handling
+    )
 
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
     import org.apache.spark.sql.sources._

--- a/src/test/scala/io/indextables/spark/core/DatePartitionGroupByBugTest.scala
+++ b/src/test/scala/io/indextables/spark/core/DatePartitionGroupByBugTest.scala
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.core
+
+import java.sql.Date
+
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.Row
+
+import io.indextables.spark.TestBase
+import org.scalatest.matchers.should.Matchers._
+
+/**
+ * Test case to replicate ClassCastException when running GROUP BY on both a Date-type
+ * partition column and a non-partition column.
+ *
+ * Schema: [part_date (Date, partition key), part_hour (String), value (String)]
+ *
+ * Query: SELECT part_date, part_hour, COUNT(*) FROM table GROUP BY 1, 2 ORDER BY 1, 2
+ */
+class DatePartitionGroupByBugTest extends TestBase {
+
+  test("GROUP BY Date partition column and non-partition column should not throw ClassCastException") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/date_partition_groupby_bug"
+
+      // Create schema with Date type for partition column, String for part_hour
+      val schema = StructType(Seq(
+        StructField("part_date", DateType, nullable = false),
+        StructField("part_hour", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      // Create test data with multiple dates and hours (part_hour as String)
+      val testData = Seq(
+        Row(Date.valueOf("2024-01-01"), "10", "value1"),
+        Row(Date.valueOf("2024-01-01"), "10", "value2"),
+        Row(Date.valueOf("2024-01-01"), "11", "value3"),
+        Row(Date.valueOf("2024-01-01"), "11", "value4"),
+        Row(Date.valueOf("2024-01-01"), "11", "value5"),
+        Row(Date.valueOf("2024-01-02"), "10", "value6"),
+        Row(Date.valueOf("2024-01-02"), "10", "value7"),
+        Row(Date.valueOf("2024-01-02"), "12", "value8"),
+        Row(Date.valueOf("2024-01-03"), "10", "value9"),
+        Row(Date.valueOf("2024-01-03"), "11", "value10")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      println(s"Test data schema: ${df.schema}")
+      println(s"Test data count: ${df.count()}")
+      df.show()
+
+      // Write with part_date as the only partition key
+      // Using default fast fields config (all columns become fast fields)
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("part_date")
+        .mode("overwrite")
+        .save(tablePath)
+
+      // Read the data back
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      // Register as temp view for SQL query
+      readDf.createOrReplaceTempView("my_table")
+
+      println("\n=== Running the problematic query ===")
+      println("Query: SELECT part_date, part_hour, COUNT(*) FROM my_table GROUP BY 1, 2 ORDER BY 1, 2")
+
+      // This is the query that causes ClassCastException in production
+      // GROUP BY both a Date-type partition column and a non-partition fast field
+      val result = spark.sql(
+        """
+          |SELECT part_date, part_hour, COUNT(*) as cnt
+          |FROM my_table
+          |GROUP BY 1, 2
+          |ORDER BY 1, 2
+        """.stripMargin
+      )
+
+      // Collect results - this is where the ClassCastException would occur
+      val rows = result.collect()
+
+      println("\n=== Results ===")
+      rows.foreach { row =>
+        println(s"  ${row.getDate(0)}, ${row.getString(1)}, ${row.getLong(2)}")
+      }
+
+      // Verify expected results
+      rows.length should be(6)
+
+      // 2024-01-01, hour 10: 2 records
+      rows(0).getDate(0) should be(Date.valueOf("2024-01-01"))
+      rows(0).getString(1) should be("10")
+      rows(0).getLong(2) should be(2)
+
+      // 2024-01-01, hour 11: 3 records
+      rows(1).getDate(0) should be(Date.valueOf("2024-01-01"))
+      rows(1).getString(1) should be("11")
+      rows(1).getLong(2) should be(3)
+
+      // 2024-01-02, hour 10: 2 records
+      rows(2).getDate(0) should be(Date.valueOf("2024-01-02"))
+      rows(2).getString(1) should be("10")
+      rows(2).getLong(2) should be(2)
+
+      // 2024-01-02, hour 12: 1 record
+      rows(3).getDate(0) should be(Date.valueOf("2024-01-02"))
+      rows(3).getString(1) should be("12")
+      rows(3).getLong(2) should be(1)
+
+      // 2024-01-03, hour 10: 1 record
+      rows(4).getDate(0) should be(Date.valueOf("2024-01-03"))
+      rows(4).getString(1) should be("10")
+      rows(4).getLong(2) should be(1)
+
+      // 2024-01-03, hour 11: 1 record
+      rows(5).getDate(0) should be(Date.valueOf("2024-01-03"))
+      rows(5).getString(1) should be("11")
+      rows(5).getLong(2) should be(1)
+    }
+  }
+
+  test("GROUP BY Date partition column and non-partition column using DataFrame API") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/date_partition_groupby_bug_df"
+
+      val schema = StructType(Seq(
+        StructField("part_date", DateType, nullable = false),
+        StructField("part_hour", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(Date.valueOf("2024-01-01"), "10", "value1"),
+        Row(Date.valueOf("2024-01-01"), "10", "value2"),
+        Row(Date.valueOf("2024-01-01"), "11", "value3"),
+        Row(Date.valueOf("2024-01-02"), "10", "value4"),
+        Row(Date.valueOf("2024-01-02"), "11", "value5")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("part_date")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      println("\n=== Running GROUP BY via DataFrame API ===")
+
+      // Same query using DataFrame API
+      val result = readDf
+        .groupBy("part_date", "part_hour")
+        .agg(count("*").as("cnt"))
+        .orderBy("part_date", "part_hour")
+
+      val rows = result.collect()
+
+      println("\n=== Results ===")
+      rows.foreach { row =>
+        println(s"  ${row.getDate(0)}, ${row.getString(1)}, ${row.getLong(2)}")
+      }
+
+      rows.length should be(4)
+
+      // 2024-01-01, hour 10: 2 records
+      rows(0).getDate(0) should be(Date.valueOf("2024-01-01"))
+      rows(0).getString(1) should be("10")
+      rows(0).getLong(2) should be(2)
+
+      // 2024-01-01, hour 11: 1 record
+      rows(1).getDate(0) should be(Date.valueOf("2024-01-01"))
+      rows(1).getString(1) should be("11")
+      rows(1).getLong(2) should be(1)
+
+      // 2024-01-02, hour 10: 1 record
+      rows(2).getDate(0) should be(Date.valueOf("2024-01-02"))
+      rows(2).getString(1) should be("10")
+      rows(2).getLong(2) should be(1)
+
+      // 2024-01-02, hour 11: 1 record
+      rows(3).getDate(0) should be(Date.valueOf("2024-01-02"))
+      rows(3).getString(1) should be("11")
+      rows(3).getLong(2) should be(1)
+    }
+  }
+
+  test("GROUP BY Date partition column only should work") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/date_partition_only"
+
+      val schema = StructType(Seq(
+        StructField("part_date", DateType, nullable = false),
+        StructField("part_hour", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(Date.valueOf("2024-01-01"), "10", "value1"),
+        Row(Date.valueOf("2024-01-01"), "11", "value2"),
+        Row(Date.valueOf("2024-01-02"), "10", "value3")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("part_date")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      println("\n=== GROUP BY part_date only ===")
+
+      val result = readDf
+        .groupBy("part_date")
+        .agg(count("*").as("cnt"))
+        .orderBy("part_date")
+        .collect()
+
+      result.foreach { row =>
+        println(s"  ${row.getDate(0)}, ${row.getLong(1)}")
+      }
+
+      result.length should be(2)
+      result(0).getDate(0) should be(Date.valueOf("2024-01-01"))
+      result(0).getLong(1) should be(2)
+      result(1).getDate(0) should be(Date.valueOf("2024-01-02"))
+      result(1).getLong(1) should be(1)
+    }
+  }
+
+  test("GROUP BY non-partition column only with Date partition should work") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/non_partition_only"
+
+      val schema = StructType(Seq(
+        StructField("part_date", DateType, nullable = false),
+        StructField("part_hour", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(Date.valueOf("2024-01-01"), "10", "value1"),
+        Row(Date.valueOf("2024-01-01"), "11", "value2"),
+        Row(Date.valueOf("2024-01-02"), "10", "value3"),
+        Row(Date.valueOf("2024-01-02"), "10", "value4")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("part_date")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      println("\n=== GROUP BY part_hour only (non-partition column) ===")
+
+      val result = readDf
+        .groupBy("part_hour")
+        .agg(count("*").as("cnt"))
+        .orderBy("part_hour")
+        .collect()
+
+      result.foreach { row =>
+        println(s"  hour ${row.getString(0)}, count ${row.getLong(1)}")
+      }
+
+      result.length should be(2)
+      result(0).getString(0) should be("10")
+      result(0).getLong(1) should be(3)
+      result(1).getString(0) should be("11")
+      result(1).getLong(1) should be(1)
+    }
+  }
+
+  test("simple COUNT without GROUP BY on Date partitioned table should work") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/simple_count"
+
+      val schema = StructType(Seq(
+        StructField("part_date", DateType, nullable = false),
+        StructField("part_hour", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(Date.valueOf("2024-01-01"), "10", "value1"),
+        Row(Date.valueOf("2024-01-01"), "11", "value2"),
+        Row(Date.valueOf("2024-01-02"), "10", "value3")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("part_date")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      println("\n=== Simple COUNT(*) ===")
+
+      val count = readDf.count()
+      println(s"  Total count: $count")
+      count should be(3)
+    }
+  }
+}

--- a/src/test/scala/io/indextables/spark/core/PartitionColumnGroupByTest.scala
+++ b/src/test/scala/io/indextables/spark/core/PartitionColumnGroupByTest.scala
@@ -1,0 +1,995 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.core
+
+import java.sql.{Date, Timestamp}
+
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.Row
+
+import io.indextables.spark.TestBase
+import org.scalatest.matchers.should.Matchers._
+
+/**
+ * Comprehensive test suite for GROUP BY queries on partition columns of all supported types.
+ * Tests both partition-only GROUP BY and mixed partition + non-partition GROUP BY scenarios.
+ *
+ * Supported partition column types:
+ * - StringType
+ * - IntegerType
+ * - LongType
+ * - DateType
+ * - TimestampType
+ */
+class PartitionColumnGroupByTest extends TestBase {
+
+  // ===================================================================================
+  // StringType partition column tests
+  // ===================================================================================
+
+  test("GROUP BY String partition column and non-partition column") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/string_partition_groupby"
+
+      val schema = StructType(Seq(
+        StructField("region", StringType, nullable = false),
+        StructField("category", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row("us-east", "electronics", "item1"),
+        Row("us-east", "electronics", "item2"),
+        Row("us-east", "clothing", "item3"),
+        Row("us-west", "electronics", "item4"),
+        Row("us-west", "clothing", "item5"),
+        Row("us-west", "clothing", "item6"),
+        Row("eu-west", "electronics", "item7")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("region")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.createOrReplaceTempView("string_table")
+
+      val result = spark.sql(
+        """
+          |SELECT region, category, COUNT(*) as cnt
+          |FROM string_table
+          |GROUP BY 1, 2
+          |ORDER BY 1, 2
+        """.stripMargin
+      ).collect()
+
+      result.length should be(5)
+
+      // eu-west, electronics: 1
+      result(0).getString(0) should be("eu-west")
+      result(0).getString(1) should be("electronics")
+      result(0).getLong(2) should be(1)
+
+      // us-east, clothing: 1
+      result(1).getString(0) should be("us-east")
+      result(1).getString(1) should be("clothing")
+      result(1).getLong(2) should be(1)
+
+      // us-east, electronics: 2
+      result(2).getString(0) should be("us-east")
+      result(2).getString(1) should be("electronics")
+      result(2).getLong(2) should be(2)
+
+      // us-west, clothing: 2
+      result(3).getString(0) should be("us-west")
+      result(3).getString(1) should be("clothing")
+      result(3).getLong(2) should be(2)
+
+      // us-west, electronics: 1
+      result(4).getString(0) should be("us-west")
+      result(4).getString(1) should be("electronics")
+      result(4).getLong(2) should be(1)
+    }
+  }
+
+  test("GROUP BY String partition column only") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/string_partition_only"
+
+      val schema = StructType(Seq(
+        StructField("region", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row("us-east", "item1"),
+        Row("us-east", "item2"),
+        Row("us-west", "item3"),
+        Row("eu-west", "item4"),
+        Row("eu-west", "item5"),
+        Row("eu-west", "item6")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("region")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      val result = readDf
+        .groupBy("region")
+        .agg(count("*").as("cnt"))
+        .orderBy("region")
+        .collect()
+
+      result.length should be(3)
+      result(0).getString(0) should be("eu-west")
+      result(0).getLong(1) should be(3)
+      result(1).getString(0) should be("us-east")
+      result(1).getLong(1) should be(2)
+      result(2).getString(0) should be("us-west")
+      result(2).getLong(1) should be(1)
+    }
+  }
+
+  // ===================================================================================
+  // IntegerType partition column tests
+  // ===================================================================================
+
+  test("GROUP BY Integer partition column and non-partition column") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/int_partition_groupby"
+
+      val schema = StructType(Seq(
+        StructField("year", IntegerType, nullable = false),
+        StructField("category", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(2022, "A", "item1"),
+        Row(2022, "A", "item2"),
+        Row(2022, "B", "item3"),
+        Row(2023, "A", "item4"),
+        Row(2023, "B", "item5"),
+        Row(2023, "B", "item6"),
+        Row(2024, "A", "item7")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("year")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.createOrReplaceTempView("int_table")
+
+      val result = spark.sql(
+        """
+          |SELECT year, category, COUNT(*) as cnt
+          |FROM int_table
+          |GROUP BY 1, 2
+          |ORDER BY 1, 2
+        """.stripMargin
+      ).collect()
+
+      result.length should be(5)
+
+      // 2022, A: 2
+      result(0).getInt(0) should be(2022)
+      result(0).getString(1) should be("A")
+      result(0).getLong(2) should be(2)
+
+      // 2022, B: 1
+      result(1).getInt(0) should be(2022)
+      result(1).getString(1) should be("B")
+      result(1).getLong(2) should be(1)
+
+      // 2023, A: 1
+      result(2).getInt(0) should be(2023)
+      result(2).getString(1) should be("A")
+      result(2).getLong(2) should be(1)
+
+      // 2023, B: 2
+      result(3).getInt(0) should be(2023)
+      result(3).getString(1) should be("B")
+      result(3).getLong(2) should be(2)
+
+      // 2024, A: 1
+      result(4).getInt(0) should be(2024)
+      result(4).getString(1) should be("A")
+      result(4).getLong(2) should be(1)
+    }
+  }
+
+  test("GROUP BY Integer partition column only") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/int_partition_only"
+
+      val schema = StructType(Seq(
+        StructField("year", IntegerType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(2022, "item1"),
+        Row(2022, "item2"),
+        Row(2023, "item3"),
+        Row(2024, "item4"),
+        Row(2024, "item5"),
+        Row(2024, "item6")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("year")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      val result = readDf
+        .groupBy("year")
+        .agg(count("*").as("cnt"))
+        .orderBy("year")
+        .collect()
+
+      result.length should be(3)
+      result(0).getInt(0) should be(2022)
+      result(0).getLong(1) should be(2)
+      result(1).getInt(0) should be(2023)
+      result(1).getLong(1) should be(1)
+      result(2).getInt(0) should be(2024)
+      result(2).getLong(1) should be(3)
+    }
+  }
+
+  // ===================================================================================
+  // LongType partition column tests
+  // ===================================================================================
+
+  test("GROUP BY Long partition column and non-partition column") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/long_partition_groupby"
+
+      val schema = StructType(Seq(
+        StructField("epoch_day", LongType, nullable = false),
+        StructField("category", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(19723L, "A", "item1"),  // 2024-01-01
+        Row(19723L, "A", "item2"),
+        Row(19723L, "B", "item3"),
+        Row(19724L, "A", "item4"),  // 2024-01-02
+        Row(19724L, "B", "item5"),
+        Row(19725L, "A", "item6")   // 2024-01-03
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("epoch_day")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.createOrReplaceTempView("long_table")
+
+      val result = spark.sql(
+        """
+          |SELECT epoch_day, category, COUNT(*) as cnt
+          |FROM long_table
+          |GROUP BY 1, 2
+          |ORDER BY 1, 2
+        """.stripMargin
+      ).collect()
+
+      result.length should be(5)
+
+      // 19723, A: 2
+      result(0).getLong(0) should be(19723L)
+      result(0).getString(1) should be("A")
+      result(0).getLong(2) should be(2)
+
+      // 19723, B: 1
+      result(1).getLong(0) should be(19723L)
+      result(1).getString(1) should be("B")
+      result(1).getLong(2) should be(1)
+
+      // 19724, A: 1
+      result(2).getLong(0) should be(19724L)
+      result(2).getString(1) should be("A")
+      result(2).getLong(2) should be(1)
+
+      // 19724, B: 1
+      result(3).getLong(0) should be(19724L)
+      result(3).getString(1) should be("B")
+      result(3).getLong(2) should be(1)
+
+      // 19725, A: 1
+      result(4).getLong(0) should be(19725L)
+      result(4).getString(1) should be("A")
+      result(4).getLong(2) should be(1)
+    }
+  }
+
+  test("GROUP BY Long partition column only") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/long_partition_only"
+
+      val schema = StructType(Seq(
+        StructField("epoch_day", LongType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(19723L, "item1"),
+        Row(19723L, "item2"),
+        Row(19724L, "item3"),
+        Row(19725L, "item4"),
+        Row(19725L, "item5"),
+        Row(19725L, "item6")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("epoch_day")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      val result = readDf
+        .groupBy("epoch_day")
+        .agg(count("*").as("cnt"))
+        .orderBy("epoch_day")
+        .collect()
+
+      result.length should be(3)
+      result(0).getLong(0) should be(19723L)
+      result(0).getLong(1) should be(2)
+      result(1).getLong(0) should be(19724L)
+      result(1).getLong(1) should be(1)
+      result(2).getLong(0) should be(19725L)
+      result(2).getLong(1) should be(3)
+    }
+  }
+
+  // ===================================================================================
+  // DateType partition column tests
+  // ===================================================================================
+
+  test("GROUP BY Date partition column and non-partition column") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/date_partition_groupby"
+
+      val schema = StructType(Seq(
+        StructField("part_date", DateType, nullable = false),
+        StructField("category", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(Date.valueOf("2024-01-01"), "A", "item1"),
+        Row(Date.valueOf("2024-01-01"), "A", "item2"),
+        Row(Date.valueOf("2024-01-01"), "B", "item3"),
+        Row(Date.valueOf("2024-01-02"), "A", "item4"),
+        Row(Date.valueOf("2024-01-02"), "B", "item5"),
+        Row(Date.valueOf("2024-01-02"), "B", "item6"),
+        Row(Date.valueOf("2024-01-03"), "A", "item7")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("part_date")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.createOrReplaceTempView("date_table")
+
+      val result = spark.sql(
+        """
+          |SELECT part_date, category, COUNT(*) as cnt
+          |FROM date_table
+          |GROUP BY 1, 2
+          |ORDER BY 1, 2
+        """.stripMargin
+      ).collect()
+
+      result.length should be(5)
+
+      // 2024-01-01, A: 2
+      result(0).getDate(0) should be(Date.valueOf("2024-01-01"))
+      result(0).getString(1) should be("A")
+      result(0).getLong(2) should be(2)
+
+      // 2024-01-01, B: 1
+      result(1).getDate(0) should be(Date.valueOf("2024-01-01"))
+      result(1).getString(1) should be("B")
+      result(1).getLong(2) should be(1)
+
+      // 2024-01-02, A: 1
+      result(2).getDate(0) should be(Date.valueOf("2024-01-02"))
+      result(2).getString(1) should be("A")
+      result(2).getLong(2) should be(1)
+
+      // 2024-01-02, B: 2
+      result(3).getDate(0) should be(Date.valueOf("2024-01-02"))
+      result(3).getString(1) should be("B")
+      result(3).getLong(2) should be(2)
+
+      // 2024-01-03, A: 1
+      result(4).getDate(0) should be(Date.valueOf("2024-01-03"))
+      result(4).getString(1) should be("A")
+      result(4).getLong(2) should be(1)
+    }
+  }
+
+  test("GROUP BY Date partition column only") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/date_partition_only"
+
+      val schema = StructType(Seq(
+        StructField("part_date", DateType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(Date.valueOf("2024-01-01"), "item1"),
+        Row(Date.valueOf("2024-01-01"), "item2"),
+        Row(Date.valueOf("2024-01-02"), "item3"),
+        Row(Date.valueOf("2024-01-03"), "item4"),
+        Row(Date.valueOf("2024-01-03"), "item5"),
+        Row(Date.valueOf("2024-01-03"), "item6")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("part_date")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      val result = readDf
+        .groupBy("part_date")
+        .agg(count("*").as("cnt"))
+        .orderBy("part_date")
+        .collect()
+
+      result.length should be(3)
+      result(0).getDate(0) should be(Date.valueOf("2024-01-01"))
+      result(0).getLong(1) should be(2)
+      result(1).getDate(0) should be(Date.valueOf("2024-01-02"))
+      result(1).getLong(1) should be(1)
+      result(2).getDate(0) should be(Date.valueOf("2024-01-03"))
+      result(2).getLong(1) should be(3)
+    }
+  }
+
+  // ===================================================================================
+  // TimestampType partition column tests
+  // ===================================================================================
+
+  test("GROUP BY Timestamp partition column and non-partition column") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/timestamp_partition_groupby"
+
+      val schema = StructType(Seq(
+        StructField("event_time", TimestampType, nullable = false),
+        StructField("category", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(Timestamp.valueOf("2024-01-01 10:00:00"), "A", "item1"),
+        Row(Timestamp.valueOf("2024-01-01 10:00:00"), "A", "item2"),
+        Row(Timestamp.valueOf("2024-01-01 10:00:00"), "B", "item3"),
+        Row(Timestamp.valueOf("2024-01-01 11:00:00"), "A", "item4"),
+        Row(Timestamp.valueOf("2024-01-01 11:00:00"), "B", "item5"),
+        Row(Timestamp.valueOf("2024-01-01 12:00:00"), "A", "item6")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("event_time")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.createOrReplaceTempView("timestamp_table")
+
+      val result = spark.sql(
+        """
+          |SELECT event_time, category, COUNT(*) as cnt
+          |FROM timestamp_table
+          |GROUP BY 1, 2
+          |ORDER BY 1, 2
+        """.stripMargin
+      ).collect()
+
+      result.length should be(5)
+
+      // 10:00:00, A: 2
+      result(0).getTimestamp(0) should be(Timestamp.valueOf("2024-01-01 10:00:00"))
+      result(0).getString(1) should be("A")
+      result(0).getLong(2) should be(2)
+
+      // 10:00:00, B: 1
+      result(1).getTimestamp(0) should be(Timestamp.valueOf("2024-01-01 10:00:00"))
+      result(1).getString(1) should be("B")
+      result(1).getLong(2) should be(1)
+
+      // 11:00:00, A: 1
+      result(2).getTimestamp(0) should be(Timestamp.valueOf("2024-01-01 11:00:00"))
+      result(2).getString(1) should be("A")
+      result(2).getLong(2) should be(1)
+
+      // 11:00:00, B: 1
+      result(3).getTimestamp(0) should be(Timestamp.valueOf("2024-01-01 11:00:00"))
+      result(3).getString(1) should be("B")
+      result(3).getLong(2) should be(1)
+
+      // 12:00:00, A: 1
+      result(4).getTimestamp(0) should be(Timestamp.valueOf("2024-01-01 12:00:00"))
+      result(4).getString(1) should be("A")
+      result(4).getLong(2) should be(1)
+    }
+  }
+
+  test("GROUP BY Timestamp partition column only") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/timestamp_partition_only"
+
+      val schema = StructType(Seq(
+        StructField("event_time", TimestampType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(Timestamp.valueOf("2024-01-01 10:00:00"), "item1"),
+        Row(Timestamp.valueOf("2024-01-01 10:00:00"), "item2"),
+        Row(Timestamp.valueOf("2024-01-01 11:00:00"), "item3"),
+        Row(Timestamp.valueOf("2024-01-01 12:00:00"), "item4"),
+        Row(Timestamp.valueOf("2024-01-01 12:00:00"), "item5"),
+        Row(Timestamp.valueOf("2024-01-01 12:00:00"), "item6")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("event_time")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      val result = readDf
+        .groupBy("event_time")
+        .agg(count("*").as("cnt"))
+        .orderBy("event_time")
+        .collect()
+
+      result.length should be(3)
+      result(0).getTimestamp(0) should be(Timestamp.valueOf("2024-01-01 10:00:00"))
+      result(0).getLong(1) should be(2)
+      result(1).getTimestamp(0) should be(Timestamp.valueOf("2024-01-01 11:00:00"))
+      result(1).getLong(1) should be(1)
+      result(2).getTimestamp(0) should be(Timestamp.valueOf("2024-01-01 12:00:00"))
+      result(2).getLong(1) should be(3)
+    }
+  }
+
+  // ===================================================================================
+  // Multiple partition columns tests
+  // ===================================================================================
+
+  test("GROUP BY multiple partition columns (Date + String)") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/multi_partition_groupby"
+
+      val schema = StructType(Seq(
+        StructField("part_date", DateType, nullable = false),
+        StructField("region", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(Date.valueOf("2024-01-01"), "us-east", "item1"),
+        Row(Date.valueOf("2024-01-01"), "us-east", "item2"),
+        Row(Date.valueOf("2024-01-01"), "us-west", "item3"),
+        Row(Date.valueOf("2024-01-02"), "us-east", "item4"),
+        Row(Date.valueOf("2024-01-02"), "us-west", "item5"),
+        Row(Date.valueOf("2024-01-02"), "us-west", "item6")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("part_date", "region")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.createOrReplaceTempView("multi_partition_table")
+
+      val result = spark.sql(
+        """
+          |SELECT part_date, region, COUNT(*) as cnt
+          |FROM multi_partition_table
+          |GROUP BY 1, 2
+          |ORDER BY 1, 2
+        """.stripMargin
+      ).collect()
+
+      result.length should be(4)
+
+      // 2024-01-01, us-east: 2
+      result(0).getDate(0) should be(Date.valueOf("2024-01-01"))
+      result(0).getString(1) should be("us-east")
+      result(0).getLong(2) should be(2)
+
+      // 2024-01-01, us-west: 1
+      result(1).getDate(0) should be(Date.valueOf("2024-01-01"))
+      result(1).getString(1) should be("us-west")
+      result(1).getLong(2) should be(1)
+
+      // 2024-01-02, us-east: 1
+      result(2).getDate(0) should be(Date.valueOf("2024-01-02"))
+      result(2).getString(1) should be("us-east")
+      result(2).getLong(2) should be(1)
+
+      // 2024-01-02, us-west: 2
+      result(3).getDate(0) should be(Date.valueOf("2024-01-02"))
+      result(3).getString(1) should be("us-west")
+      result(3).getLong(2) should be(2)
+    }
+  }
+
+  test("GROUP BY multiple partition columns (Integer + String)") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/multi_partition_int_string"
+
+      val schema = StructType(Seq(
+        StructField("year", IntegerType, nullable = false),
+        StructField("region", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(2023, "us-east", "item1"),
+        Row(2023, "us-east", "item2"),
+        Row(2023, "us-west", "item3"),
+        Row(2024, "us-east", "item4"),
+        Row(2024, "us-west", "item5"),
+        Row(2024, "us-west", "item6")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("year", "region")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.createOrReplaceTempView("multi_partition_int_table")
+
+      val result = spark.sql(
+        """
+          |SELECT year, region, COUNT(*) as cnt
+          |FROM multi_partition_int_table
+          |GROUP BY 1, 2
+          |ORDER BY 1, 2
+        """.stripMargin
+      ).collect()
+
+      result.length should be(4)
+
+      // 2023, us-east: 2
+      result(0).getInt(0) should be(2023)
+      result(0).getString(1) should be("us-east")
+      result(0).getLong(2) should be(2)
+
+      // 2023, us-west: 1
+      result(1).getInt(0) should be(2023)
+      result(1).getString(1) should be("us-west")
+      result(1).getLong(2) should be(1)
+
+      // 2024, us-east: 1
+      result(2).getInt(0) should be(2024)
+      result(2).getString(1) should be("us-east")
+      result(2).getLong(2) should be(1)
+
+      // 2024, us-west: 2
+      result(3).getInt(0) should be(2024)
+      result(3).getString(1) should be("us-west")
+      result(3).getLong(2) should be(2)
+    }
+  }
+
+  // ===================================================================================
+  // Simple COUNT(*) tests for each type
+  // ===================================================================================
+
+  test("simple COUNT(*) on String partitioned table") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/string_count"
+
+      val schema = StructType(Seq(
+        StructField("region", StringType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row("us-east", "item1"),
+        Row("us-east", "item2"),
+        Row("us-west", "item3")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("region")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.count() should be(3)
+    }
+  }
+
+  test("simple COUNT(*) on Integer partitioned table") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/int_count"
+
+      val schema = StructType(Seq(
+        StructField("year", IntegerType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(2022, "item1"),
+        Row(2023, "item2"),
+        Row(2024, "item3")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("year")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.count() should be(3)
+    }
+  }
+
+  test("simple COUNT(*) on Long partitioned table") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/long_count"
+
+      val schema = StructType(Seq(
+        StructField("epoch_day", LongType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(19723L, "item1"),
+        Row(19724L, "item2"),
+        Row(19725L, "item3")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("epoch_day")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.count() should be(3)
+    }
+  }
+
+  test("simple COUNT(*) on Date partitioned table") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/date_count"
+
+      val schema = StructType(Seq(
+        StructField("part_date", DateType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(Date.valueOf("2024-01-01"), "item1"),
+        Row(Date.valueOf("2024-01-02"), "item2"),
+        Row(Date.valueOf("2024-01-03"), "item3")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("part_date")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.count() should be(3)
+    }
+  }
+
+  test("simple COUNT(*) on Timestamp partitioned table") {
+    withTempPath { tempDir =>
+      val tablePath = s"$tempDir/timestamp_count"
+
+      val schema = StructType(Seq(
+        StructField("event_time", TimestampType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      ))
+
+      val testData = Seq(
+        Row(Timestamp.valueOf("2024-01-01 10:00:00"), "item1"),
+        Row(Timestamp.valueOf("2024-01-01 11:00:00"), "item2"),
+        Row(Timestamp.valueOf("2024-01-01 12:00:00"), "item3")
+      )
+
+      val df = spark.createDataFrame(
+        spark.sparkContext.parallelize(testData),
+        schema
+      )
+
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .partitionBy("event_time")
+        .mode("overwrite")
+        .save(tablePath)
+
+      val readDf = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      readDf.count() should be(3)
+    }
+  }
+}


### PR DESCRIPTION
## Fix ClassCastException in GROUP BY queries with Date/Timestamp partition columns

### Problem

Running GROUP BY queries on tables with Date or Timestamp partition columns throws a `ClassCastException`:

```sql
SELECT part_date, part_hour, COUNT(*)
FROM my_table
GROUP BY 1, 2
ORDER BY 1, 2
```

Error:
```
java.lang.ClassCastException: class org.apache.spark.unsafe.types.UTF8String
cannot be cast to class java.lang.Integer
```

This occurred when:
- The partition column is DateType or TimestampType
- GROUP BY includes both partition and non-partition columns
- Aggregate pushdown is enabled (default)

### Root Cause

Two issues in the aggregate pushdown code path:

1. **Missing type conversion in `IndexTables4SparkGroupByAggregateScan`**: The `convertBucketKeyToSpark()` and `convertStringValueToSpark()` methods had no handling for DateType or TimestampType. Values fell through to the default case returning UTF8String, but the schema declared the proper type (DateType expects Int, TimestampType expects Long).

2. **Hardcoded StringType in `TransactionLogCountScan`**: The `readSchema()` method hardcoded StringType for all GROUP BY columns instead of preserving the original column types from the table schema.

### Solution

#### 1. Added DateType handling
Converts date strings to days since epoch (Int) as Spark expects:
- Handles `YYYY-MM-DD` format
- Handles ISO datetime format `2024-01-02T00:00:00Z` (extracts date part)
- Handles `LocalDateTime` format `2024-01-02T00:00:00`
- Uses format detection (checking for `T` character) to avoid expensive exception-based control flow

#### 2. Added TimestampType handling
Converts timestamp values to microseconds since epoch (Long) as Spark expects:
- Handles numeric microseconds format (already in correct format from tantivy)
- Handles ISO instant format `2024-01-01T10:00:00Z`
- Handles URL-encoded strings `2024-01-01T15%3A00%3A00Z` (partition paths encode colons)
- Handles `LocalDateTime` format
- Uses format detection to avoid exception overhead

#### 3. Schema propagation in TransactionLogCountScan
- Added `tableSchema` parameter to preserve original column types
- Updated `readSchema()` to use actual field types from schema
- Propagated schema through `TransactionLogCountBatch` and partition classes

### Files Changed

| File | Changes |
|------|---------|
| `IndexTables4SparkGroupByAggregateScan.scala` | Added DateType/TimestampType handling in `convertBucketKeyToSpark()` and `convertStringValueToSpark()` |
| `TransactionLogCountScan.scala` | Added `tableSchema` parameter, proper type conversion in `convertPartitionValue()` |
| `IndexTables4SparkScanBuilder.scala` | Pass schema to `TransactionLogCountScan` constructor |

### Testing

Added comprehensive test coverage for GROUP BY on all supported partition column types:

**New test files:**
- `DatePartitionGroupByBugTest.scala` - 5 tests reproducing the original bug
- `PartitionColumnGroupByTest.scala` - 17 tests covering all types

**Test matrix:**

| Partition Type | GROUP BY partition + non-partition | GROUP BY partition only | Simple COUNT(*) |
|----------------|-----------------------------------|------------------------|-----------------|
| StringType | ✅ | ✅ | ✅ |
| IntegerType | ✅ | ✅ | ✅ |
| LongType | ✅ | ✅ | ✅ |
| DateType | ✅ | ✅ | ✅ |
| TimestampType | ✅ | ✅ | ✅ |
| Multi-partition (Date + String) | ✅ | - | - |
| Multi-partition (Int + String) | ✅ | - | - |

**All 22 new tests pass.**

### Error Handling

Changed from silently returning incorrect default values (0 for dates = 1970-01-01) to throwing `IllegalArgumentException` with clear error messages. This ensures malformed data surfaces immediately rather than producing incorrect query results.

### Performance Considerations

- Uses format detection (string character checks) instead of exception-based control flow
- Only one parsing attempt per value in the happy path
- URL decoding only performed when needed (when `%` detected or non-numeric format)

### Backward Compatibility

Fully backward compatible:
- No changes to public APIs
- No changes to file formats or transaction log
- Existing queries continue to work
- New `tableSchema` parameter has default value `None`
