### PR TITLE
features: prioritize small splits and set re-merge thresholds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -467,6 +467,10 @@ MERGE SPLITS 's3://bucket/path' TARGET SIZE 1G MAX DEST SPLITS 5 MAX SOURCE SPLI
 - `MAX DEST SPLITS`: Limits the number of destination (merged) splits to process (oldest first)
 - `MAX SOURCE SPLITS PER MERGE`: Maximum number of source splits that can be merged into a single destination split (default: 1000)
   - Configuration: `spark.indextables.merge.maxSourceSplitsPerMerge: 1000`
+- **Skip Split Threshold**: Splits already at or above this size are excluded from merge consideration
+  - Configuration: `spark.indextables.merge.skipSplitThreshold: 0.45` (default: 45% of target size)
+  - Range: 0.0 to 1.0 (percentage of target size)
+  - Example: With 5GB target and 0.45 threshold, splits >= 2.25GB are skipped
 
 ### Purge IndexTable
 ```sql

--- a/README.md
+++ b/README.md
@@ -2286,6 +2286,9 @@ spark.sql("MERGE SPLITS 's3://bucket/path' WHERE year = 2023 TARGET SIZE 100M")
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `spark.indextables.merge.maxSourceSplitsPerMerge` | 1000 | Maximum number of source splits that can be merged into a single destination split |
+| `spark.indextables.merge.skipSplitThreshold` | 0.45 | Splits >= this percentage of target size are skipped from merge (0.0 to 1.0) |
+
+**Skip Split Threshold**: Splits that are already close to the target size are excluded from merge consideration. With the default 0.45 (45%), a merge with TARGET SIZE 5G will skip any splits >= 2.25GB. This prevents wasting resources merging already-large splits.
 
 #### Dropping Partitions with DROP INDEXTABLES PARTITIONS
 


### PR DESCRIPTION
# PR: Merge Algorithm Improvements

## Summary

This PR introduces two improvements to the MERGE SPLITS algorithm:

1. **Priority-based merge ordering**: Merge groups with the largest number of source splits are now processed first
2. **Skip split threshold**: Already-large splits are excluded from merge consideration based on a configurable threshold

## Changes

### 1. Priority-Based Merge Ordering

Merge groups are now sorted by source split count in descending order before processing. This ensures high-impact merges (e.g., 1000 splits -> 1) are processed before low-impact merges (e.g., 2 splits -> 1).

**Benefits:**
- Prioritizes merges that reduce file count the most
- Ensures critical merges complete first if resource limits are reached
- Improves observability - largest merges appear first in logs

**Example log output:**
```
Sorted merge groups by source split count: 1000, 500, 100, 50, 2
```

### 2. Skip Split Threshold

Splits that are already close to the target size are now excluded from merge consideration. This prevents wasting resources on merging already-large files.

**Configuration:**
```scala
spark.indextables.merge.skipSplitThreshold: 0.45  // default: 45% of target size
```

**Example:**
- With TARGET SIZE 5G and threshold 0.45 (default)
- Splits >= 2.25GB are skipped from merge
- Only smaller splits are considered for consolidation

**Benefits:**
- Reduces unnecessary I/O and compute for already-optimal splits
- Focuses merge resources on truly fragmented files
- Configurable for different workload patterns

## Configuration

| Setting | Default | Description |
|---------|---------|-------------|
| `spark.indextables.merge.skipSplitThreshold` | 0.45 | Percentage of target size above which splits are skipped (0.0 to 1.0) |

## Files Changed

- `src/main/scala/io/indextables/spark/sql/MergeSplitsCommand.scala` - Core algorithm changes
- `src/test/scala/io/indextables/spark/sql/MergeSplitsCommandTest.scala` - New tests
- `CLAUDE.md` - Documentation update
- `README.md` - Documentation update

## Testing

Added two new tests:
1. `MERGE SPLITS should skip splits above skipSplitThreshold` - Validates threshold filtering
2. `skipSplitThreshold configuration should be respected` - Validates configuration is read correctly

All existing merge tests continue to pass (16 tests total).

## Usage Examples

### Default Behavior (45% threshold)
```scala
// Splits >= 2.25GB skipped when target is 5GB
spark.sql("MERGE SPLITS 's3://bucket/path' TARGET SIZE 5G")
```

### Custom Threshold
```scala
// Skip splits >= 30% of target (1.5GB for 5GB target)
spark.conf.set("spark.indextables.merge.skipSplitThreshold", "0.30")
spark.sql("MERGE SPLITS 's3://bucket/path' TARGET SIZE 5G")
```

### Aggressive Merging (lower threshold)
```scala
// Only skip splits >= 80% of target (4GB for 5GB target)
spark.conf.set("spark.indextables.merge.skipSplitThreshold", "0.80")
spark.sql("MERGE SPLITS 's3://bucket/path' TARGET SIZE 5G")
```

### Disable Threshold (merge everything)
```scala
// Set to 1.0 to include all splits regardless of size
spark.conf.set("spark.indextables.merge.skipSplitThreshold", "1.0")
spark.sql("MERGE SPLITS 's3://bucket/path' TARGET SIZE 5G")
```

## Backward Compatibility

These changes are backward compatible:
- Default threshold of 0.45 is slightly more aggressive than the previous behavior (which skipped at 100%)
- Existing merge operations will work without configuration changes
- The sorting change only affects processing order, not results
