### PR TITLE
perf: update split conversion parallelism to use the number of cores

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ spark.indextables.indexWriter.maxBatchBufferSize: "90M" (default: 90MB, prevents
 spark.indextables.indexWriter.threads: 2
 
 // Split Conversion (controls parallelism of tantivy index -> quickwit split conversion)
-spark.indextables.splitConversion.maxParallelism: <auto> (default: max(1, availableProcessors / 4))
+spark.indextables.splitConversion.maxParallelism: <auto> (default: max(1, availableProcessors))
 
 // Transaction Log
 spark.indextables.checkpoint.enabled: true

--- a/README.md
+++ b/README.md
@@ -923,7 +923,7 @@ The system supports several configuration options for performance tuning:
 | `spark.indextables.indexWriter.maxBatchBufferSize` | `90M` | Maximum batch buffer size before flushing (90MB default, prevents native 100MB limit errors with large documents) |
 | `spark.indextables.indexWriter.useBatch` | `true` | Enable batch writing for better performance (enabled by default) |
 | `spark.indextables.indexWriter.tempDirectoryPath` | auto-detect `/local_disk0` | Custom temp directory for index creation (auto-detects optimal location) |
-| `spark.indextables.splitConversion.maxParallelism` | `max(1, availableProcessors / 4)` | Maximum concurrent split conversions per executor (controls parallelism of tantivy index → quickwit split conversion) |
+| `spark.indextables.splitConversion.maxParallelism` | `max(1, availableProcessors)` | Maximum concurrent split conversions per executor (controls parallelism of tantivy index → quickwit split conversion) |
 | `spark.indextables.merge.tempDirectoryPath` | auto-detect `/local_disk0` | Custom temp directory for split merging (auto-detects optimal location) |
 | `spark.indextables.merge.batchSize` | `defaultParallelism` | Number of merge groups per batch (defaults to Spark's defaultParallelism) |
 | `spark.indextables.merge.maxConcurrentBatches` | `2` | Maximum number of batches to process concurrently |

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkBatchWrite.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkBatchWrite.scala
@@ -44,11 +44,11 @@ class IndexTables4SparkBatchWrite(
     logger.info(s"Creating batch writer factory for ${info.numPartitions} partitions")
 
     // Set split conversion max parallelism if not already configured
-    // Default: max(1, availableProcessors / 4)
+    // Default: max(1, availableProcessors)
     val configKey = io.indextables.spark.config.IndexTables4SparkSQLConf.TANTIVY4SPARK_SPLIT_CONVERSION_MAX_PARALLELISM
     val computedMaxParallelism = if (options.get(configKey) == null) {
       val availableProcessors = Runtime.getRuntime.availableProcessors()
-      val maxParallelism      = Math.max(1, availableProcessors / 4)
+      val maxParallelism      = Math.max(1, availableProcessors)
       logger.info(s"Auto-configuring split conversion max parallelism: $maxParallelism (from availableProcessors=$availableProcessors)")
       Some(maxParallelism)
     } else {

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkWriteBuilder.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkWriteBuilder.scala
@@ -61,11 +61,11 @@ class IndexTables4SparkWriteBuilder(
     var serializedOptions = options.entrySet().asScala.map(entry => entry.getKey -> entry.getValue).toMap
 
     // Set split conversion max parallelism if not already configured
-    // Default: max(1, availableProcessors / 4)
+    // Default: max(1, availableProcessors)
     val configKey = io.indextables.spark.config.IndexTables4SparkSQLConf.TANTIVY4SPARK_SPLIT_CONVERSION_MAX_PARALLELISM
     if (!serializedOptions.contains(configKey)) {
       val availableProcessors = Runtime.getRuntime.availableProcessors()
-      val maxParallelism      = Math.max(1, availableProcessors / 4)
+      val maxParallelism      = Math.max(1, availableProcessors)
       logger.info(s"Auto-configuring split conversion max parallelism: $maxParallelism (from availableProcessors=$availableProcessors)")
       serializedOptions = serializedOptions + (configKey -> maxParallelism.toString)
     }

--- a/src/test/scala/io/indextables/spark/TestBase.scala
+++ b/src/test/scala/io/indextables/spark/TestBase.scala
@@ -57,7 +57,7 @@ trait TestBase extends AnyFunSuite with Matchers with BeforeAndAfterAll with Bef
 
     // Initialize SplitConversionThrottle for tests
     _root_.io.indextables.spark.storage.SplitConversionThrottle.initialize(
-      maxParallelism = Runtime.getRuntime.availableProcessors() / 4 max 1
+      maxParallelism = Runtime.getRuntime.availableProcessors() max 1
     )
   }
 

--- a/src/test/scala/io/indextables/spark/core/SplitConversionThrottleTest.scala
+++ b/src/test/scala/io/indextables/spark/core/SplitConversionThrottleTest.scala
@@ -29,7 +29,7 @@ import io.indextables.spark.TestBase
  * Tests for split conversion throttling functionality.
  *
  * The throttle limits the parallelism of tantivy index -> quickwit split conversions to prevent resource exhaustion.
- * Default: max(1, availableProcessors / 4)
+ * Default: max(1, availableProcessors)
  */
 class SplitConversionThrottleTest extends TestBase {
 
@@ -55,7 +55,7 @@ class SplitConversionThrottleTest extends TestBase {
     readDf.count() shouldBe 1000
 
     // Verify throttle was initialized
-    val expectedMaxParallelism = Math.max(1, Runtime.getRuntime.availableProcessors() / 4)
+    val expectedMaxParallelism = Math.max(1, Runtime.getRuntime.availableProcessors())
     println(s"✅ V2 write completed with auto-configured throttle (expected: $expectedMaxParallelism based on ${Runtime.getRuntime.availableProcessors()} processors)")
   }
 
@@ -205,9 +205,9 @@ class SplitConversionThrottleTest extends TestBase {
     println(s"✅ Created ${splitFiles.length} split files with maxParallelism=1 throttling")
   }
 
-  test("Default calculation should use availableProcessors/4") {
+  test("Default calculation should use availableProcessors") {
     val availableProcessors = Runtime.getRuntime.availableProcessors()
-    val expectedDefault     = Math.max(1, availableProcessors / 4)
+    val expectedDefault     = Math.max(1, availableProcessors)
 
     println(s"Available processors: $availableProcessors")
     println(s"Expected default throttle: $expectedDefault")
@@ -258,7 +258,7 @@ class SplitConversionThrottleTest extends TestBase {
 
     readDf.count() shouldBe 1000
 
-    val expectedMaxParallelism = Math.max(1, Runtime.getRuntime.availableProcessors() / 4)
+    val expectedMaxParallelism = Math.max(1, Runtime.getRuntime.availableProcessors())
     println(s"✅ BatchWrite completed with auto-configured throttle (expected: $expectedMaxParallelism)")
   }
 


### PR DESCRIPTION
# PR: Increase Split Conversion Parallelism Default

## Summary

- Remove the `/4` divisor from split conversion parallelism calculation
- Default is now `max(1, availableProcessors)` instead of `max(1, availableProcessors / 4)`
- Enables full CPU utilization for tantivy index to quickwit split conversions

## Background

The split conversion parallelism setting controls how many concurrent tantivy index to quickwit split conversions can run per executor. Previously, this was limited to 1/4 of available processors as a conservative default to avoid resource exhaustion issues.

A bug that was causing concurrency issues has been fixed, so the conservative limit is no longer necessary. This change allows the system to utilize all available CPU cores for split conversion, significantly improving write throughput.

## Changes

### Source Files
- `IndexTables4SparkBatchWrite.scala`: Updated auto-configuration logic
- `IndexTables4SparkWriteBuilder.scala`: Updated auto-configuration logic

### Test Files
- `SplitConversionThrottleTest.scala`: Updated test expectations and documentation
- `TestBase.scala`: Updated test initialization

### Documentation
- `README.md`: Updated configuration table
- `CLAUDE.md`: Updated configuration reference

## Configuration

The setting `spark.indextables.splitConversion.maxParallelism` now defaults to:
- **Before**: `max(1, availableProcessors / 4)` (e.g., 2 on an 8-core machine)
- **After**: `max(1, availableProcessors)` (e.g., 8 on an 8-core machine)

Users can still override this setting if needed:
```scala
df.write
  .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
  .option("spark.indextables.splitConversion.maxParallelism", "4")
  .save("s3://bucket/path")
```

## Expected Impact

- **Write Performance**: Up to 4x improvement in split conversion throughput on multi-core systems
- **Resource Usage**: Higher CPU utilization during write operations (expected behavior)
- **Backwards Compatibility**: Fully backwards compatible; explicit configuration overrides still work

## Test Plan

- [ ] Run `SplitConversionThrottleTest` to verify new defaults
- [ ] Verify write operations complete successfully with increased parallelism
- [ ] Monitor CPU and memory usage during write operations on multi-core systems
