### PR TITLE
feature: Add TRUNCATE TIME TRAVEL SQL Command

### DIFF
--- a/src/main/antlr4/io/indextables/spark/sql/parser/IndexTables4SparkSqlBase.g4
+++ b/src/main/antlr4/io/indextables/spark/sql/parser/IndexTables4SparkSqlBase.g4
@@ -71,6 +71,9 @@ statement
         (WITH PERWORKER PARALLELISM OF parallelism=INTEGER_VALUE)?
         (WHERE whereClause=predicateToken)?                     #prewarmCache
     | CHECKPOINT indexTablesKeyword (path=STRING | table=qualifiedName)   #checkpointIndexTable
+    | TRUNCATE indexTablesKeyword TIME TRAVEL
+        (path=STRING | table=qualifiedName)
+        (DRY RUN)?                                              #truncateTimeTravel
     | .*?                                                       #passThrough
     ;
 
@@ -109,7 +112,7 @@ nonReserved
     | REPAIR | INDEXFILES | AT | LOCATION | PURGE | OLDER | THAN | DAYS | HOURS | DRY | RUN
     | RETENTION | DESCRIBE | INCLUDE | ALL | DROP | PARTITIONS | FROM | DISK | WITH
     | PREWARM | SEGMENTS | FIELDS | PERWORKER | PARALLELISM | OF | ON | STORAGE | STATS
-    | DEST | SOURCE | PER | ENVIRONMENT | CHECKPOINT
+    | DEST | SOURCE | PER | ENVIRONMENT | CHECKPOINT | TRUNCATE | TIME | TRAVEL
     ;
 
 // Keywords (case-insensitive)
@@ -165,6 +168,9 @@ SOURCE: [Ss][Oo][Uu][Rr][Cc][Ee];
 PER: [Pp][Ee][Rr];
 ENVIRONMENT: [Ee][Nn][Vv][Ii][Rr][Oo][Nn][Mm][Ee][Nn][Tt];
 CHECKPOINT: [Cc][Hh][Ee][Cc][Kk][Pp][Oo][Ii][Nn][Tt];
+TRUNCATE: [Tt][Rr][Uu][Nn][Cc][Aa][Tt][Ee];
+TIME: [Tt][Ii][Mm][Ee];
+TRAVEL: [Tt][Rr][Aa][Vv][Ee][Ll];
 
 // Literals
 STRING

--- a/src/main/scala/io/indextables/spark/sql/DescribeTransactionLogCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/DescribeTransactionLogCommand.scala
@@ -85,6 +85,7 @@ case class DescribeTransactionLogCommand(
     AttributeReference("delete_opstamp", LongType, nullable = true)(),
     AttributeReference("num_merge_ops", IntegerType, nullable = true)(),
     AttributeReference("doc_mapping_json", StringType, nullable = true)(),
+    AttributeReference("doc_mapping_ref", StringType, nullable = true)(),
     AttributeReference("uncompressed_size_bytes", LongType, nullable = true)(),
 
     // RemoveAction specific fields

--- a/src/main/scala/io/indextables/spark/sql/DescribeTransactionLogExecutor.scala
+++ b/src/main/scala/io/indextables/spark/sql/DescribeTransactionLogExecutor.scala
@@ -147,6 +147,7 @@ class DescribeTransactionLogExecutor(
           toLongOrNull(add.deleteOpstamp),
           add.numMergeOps.orNull,
           add.docMappingJson.orNull,
+          add.docMappingRef.orNull,
           toLongOrNull(add.uncompressedSizeBytes),
           // RemoveAction specific fields
           null,
@@ -188,6 +189,7 @@ class DescribeTransactionLogExecutor(
           remove.dataChange,
           remove.tags.map(toJsonString).orNull,
           // AddAction specific fields
+          null,
           null,
           null,
           null,
@@ -262,6 +264,7 @@ class DescribeTransactionLogExecutor(
           null,
           null,
           null,
+          null,
           // RemoveAction specific fields
           null,
           null,
@@ -302,6 +305,7 @@ class DescribeTransactionLogExecutor(
           null,
           null,
           // AddAction specific fields
+          null,
           null,
           null,
           null,
@@ -376,6 +380,7 @@ class DescribeTransactionLogExecutor(
           null,
           null,
           null,
+          null,
           // RemoveAction specific fields
           null,
           null,
@@ -412,6 +417,9 @@ class DescribeTransactionLogExecutor(
           logFilePath,
           "unknown",
           // All other fields null
+          null,
+          null,
+          null,
           null,
           null,
           null,

--- a/src/main/scala/io/indextables/spark/sql/TruncateTimeTravelCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/TruncateTimeTravelCommand.scala
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sql
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.types.{LongType, StringType}
+
+import org.apache.hadoop.fs.Path
+
+import scala.jdk.CollectionConverters._
+
+import io.indextables.spark.io.CloudStorageProviderFactory
+import io.indextables.spark.transaction.{TransactionLogCheckpoint, TransactionLogFactory}
+import io.indextables.spark.util.{ConfigNormalization, ConfigUtils}
+import org.slf4j.LoggerFactory
+
+/**
+ * SQL command to truncate time travel data from an IndexTables table.
+ *
+ * This command removes all historical transaction log versions, keeping only the current
+ * state (latest checkpoint). After truncation, time travel to earlier versions is no
+ * longer possible.
+ *
+ * Syntax:
+ *   - TRUNCATE INDEXTABLES TIME TRAVEL '/path/to/table'
+ *   - TRUNCATE INDEXTABLES TIME TRAVEL '/path/to/table' DRY RUN
+ *   - TRUNCATE TANTIVY4SPARK TIME TRAVEL table_name
+ *
+ * This command:
+ *   1. Creates a checkpoint at the current version (if none exists)
+ *   2. Deletes all transaction log version files older than the checkpoint
+ *   3. Deletes all older checkpoint files (keeps only the latest)
+ *   4. Preserves all data files (splits) - only metadata is affected
+ *
+ * Use this command to:
+ *   - Reduce transaction log storage overhead
+ *   - Clean up after many small write operations
+ *   - Prepare a table for archival (remove history)
+ */
+case class TruncateTimeTravelCommand(
+  tablePath: String,
+  dryRun: Boolean = false
+) extends LeafRunnableCommand {
+
+  private val logger = LoggerFactory.getLogger(classOf[TruncateTimeTravelCommand])
+
+  // Regex patterns for file detection (from PurgeOrphanedSplitsExecutor)
+  private val VersionFilePattern = """^(\d{20})\.json$""".r
+  private val ManifestPattern = """^(\d{20})\.checkpoint\.json$""".r
+  private val PartFilePattern = """^(\d{20})\.checkpoint\.([a-f0-9]+)\.(\d{5})\.json$""".r
+
+  override val output: Seq[Attribute] = Seq(
+    AttributeReference("table_path", StringType)(),
+    AttributeReference("status", StringType)(),
+    AttributeReference("checkpoint_version", LongType)(),
+    AttributeReference("versions_deleted", LongType)(),
+    AttributeReference("checkpoints_deleted", LongType)(),
+    AttributeReference("files_preserved", LongType)(),
+    AttributeReference("message", StringType)()
+  )
+
+  override def run(sparkSession: SparkSession): Seq[Row] =
+    try {
+      // Resolve the table path
+      val resolvedPath = resolveTablePath(tablePath, sparkSession)
+      logger.info(s"Truncating time travel data for table: $resolvedPath (dryRun=$dryRun)")
+
+      // Extract and merge configuration with proper precedence (consistent with PURGE command)
+      val hadoopConf = sparkSession.sparkContext.hadoopConfiguration
+      val sparkConfigs = ConfigNormalization.extractTantivyConfigsFromSpark(sparkSession)
+      val hadoopConfigs = ConfigNormalization.extractTantivyConfigsFromHadoop(hadoopConf)
+      val mergedConfigs = ConfigNormalization.mergeWithPrecedence(hadoopConfigs, sparkConfigs)
+
+      // Resolve credentials from custom provider on driver if configured
+      // This fetches actual AWS/Azure credentials so transaction log operations work
+      val resolvedConfigs = ConfigUtils.resolveCredentialsFromProviderOnDriver(mergedConfigs, resolvedPath.toString)
+
+      // Create options map with resolved credentials
+      val options = new org.apache.spark.sql.util.CaseInsensitiveStringMap(resolvedConfigs.asJava)
+
+      // Create transaction log instance with resolved credentials
+      val transactionLog = TransactionLogFactory.create(resolvedPath, sparkSession, options)
+
+      try {
+        // Get current versions
+        val versions = transactionLog.getVersions()
+        if (versions.isEmpty) {
+          return Seq(Row(
+            resolvedPath.toString,
+            "ERROR",
+            0L,
+            0L,
+            0L,
+            0L,
+            "No transaction log versions found"
+          ))
+        }
+
+        val currentVersion = versions.max
+        logger.info(s"Current transaction log version: $currentVersion, total versions: ${versions.size}")
+
+        // Check if checkpoint exists, create one if not
+        val checkpointVersion = transactionLog.getLastCheckpointVersion() match {
+          case Some(cpVersion) if cpVersion == currentVersion =>
+            logger.info(s"Checkpoint already exists at current version $cpVersion")
+            cpVersion
+          case Some(cpVersion) =>
+            // Checkpoint exists but not at current version - create new one
+            logger.info(s"Existing checkpoint at v$cpVersion, creating new checkpoint at v$currentVersion")
+            createCheckpointAtCurrentVersion(sparkSession, resolvedPath, options)
+          case None =>
+            // No checkpoint exists - create one
+            logger.info(s"No checkpoint exists, creating checkpoint at v$currentVersion")
+            createCheckpointAtCurrentVersion(sparkSession, resolvedPath, options)
+        }
+
+        // Now delete old transaction log files
+        val transactionLogPath = new Path(resolvedPath, "_transaction_log")
+        val cloudProvider = CloudStorageProviderFactory.createProvider(
+          transactionLogPath.toString,
+          options,
+          sparkSession.sparkContext.hadoopConfiguration
+        )
+
+        try {
+          // List all files in transaction log directory
+          val allFiles = cloudProvider.listFiles(transactionLogPath.toString, recursive = false)
+
+          // Categorize files
+          val versionFiles = scala.collection.mutable.ListBuffer[(Long, String)]()
+          val checkpointFiles = scala.collection.mutable.ListBuffer[(Long, String)]()
+          val partFiles = scala.collection.mutable.ListBuffer[(Long, String, String)]() // (version, uuid, path)
+
+          allFiles.foreach { f =>
+            val fileName = new Path(f.path).getName
+            fileName match {
+              case VersionFilePattern(versionStr) =>
+                val version = versionStr.toLong
+                versionFiles += ((version, f.path))
+              case ManifestPattern(versionStr) =>
+                val version = versionStr.toLong
+                checkpointFiles += ((version, f.path))
+              case PartFilePattern(versionStr, uuid, _) =>
+                val version = versionStr.toLong
+                partFiles += ((version, uuid, f.path))
+              case _ => // Ignore other files (like _last_checkpoint)
+            }
+          }
+
+          logger.info(s"Found ${versionFiles.size} version files, ${checkpointFiles.size} checkpoints, ${partFiles.size} checkpoint parts")
+
+          // Identify files to delete:
+          // - Version files with version < checkpointVersion
+          // - Checkpoint files with version < checkpointVersion
+          // - Part files with version < checkpointVersion
+          val versionsToDelete = versionFiles.filter(_._1 < checkpointVersion)
+          val checkpointsToDelete = checkpointFiles.filter(_._1 < checkpointVersion)
+          val partsToDelete = partFiles.filter(_._1 < checkpointVersion)
+
+          val totalFilesToDelete = versionsToDelete.size + checkpointsToDelete.size + partsToDelete.size
+
+          logger.info(s"Files to delete: ${versionsToDelete.size} versions, ${checkpointsToDelete.size} checkpoints, ${partsToDelete.size} parts")
+
+          if (totalFilesToDelete == 0) {
+            return Seq(Row(
+              resolvedPath.toString,
+              if (dryRun) "DRY_RUN" else "SUCCESS",
+              checkpointVersion,
+              0L,
+              0L,
+              transactionLog.listFiles().size.toLong,
+              "No old transaction log files to delete - table already at minimal state"
+            ))
+          }
+
+          if (dryRun) {
+            // Preview mode - don't actually delete
+            logger.info(s"DRY RUN: Would delete ${versionsToDelete.size} version files, ${checkpointsToDelete.size} checkpoint files, ${partsToDelete.size} checkpoint parts")
+
+            Seq(Row(
+              resolvedPath.toString,
+              "DRY_RUN",
+              checkpointVersion,
+              versionsToDelete.size.toLong,
+              (checkpointsToDelete.size + partsToDelete.size).toLong,
+              transactionLog.listFiles().size.toLong,
+              s"Would delete ${versionsToDelete.size} version files and ${checkpointsToDelete.size + partsToDelete.size} checkpoint files (DRY RUN - no changes made)"
+            ))
+          } else {
+            // Actually delete the files
+            var deletedVersions = 0L
+            var deletedCheckpoints = 0L
+
+            // Delete version files
+            versionsToDelete.foreach { case (version, path) =>
+              try {
+                if (cloudProvider.deleteFile(path)) {
+                  deletedVersions += 1
+                  logger.debug(s"Deleted version file: v$version")
+                }
+              } catch {
+                case e: Exception =>
+                  logger.warn(s"Failed to delete version file v$version: ${e.getMessage}")
+              }
+            }
+
+            // Delete checkpoint manifests/legacy checkpoints
+            checkpointsToDelete.foreach { case (version, path) =>
+              try {
+                if (cloudProvider.deleteFile(path)) {
+                  deletedCheckpoints += 1
+                  logger.debug(s"Deleted checkpoint file: v$version")
+                }
+              } catch {
+                case e: Exception =>
+                  logger.warn(s"Failed to delete checkpoint file v$version: ${e.getMessage}")
+              }
+            }
+
+            // Delete checkpoint parts
+            partsToDelete.foreach { case (version, uuid, path) =>
+              try {
+                if (cloudProvider.deleteFile(path)) {
+                  deletedCheckpoints += 1
+                  logger.debug(s"Deleted checkpoint part: v$version (uuid=$uuid)")
+                }
+              } catch {
+                case e: Exception =>
+                  logger.warn(s"Failed to delete checkpoint part v$version: ${e.getMessage}")
+              }
+            }
+
+            logger.info(s"Truncation complete: deleted $deletedVersions version files, $deletedCheckpoints checkpoint files")
+
+            Seq(Row(
+              resolvedPath.toString,
+              "SUCCESS",
+              checkpointVersion,
+              deletedVersions,
+              deletedCheckpoints,
+              transactionLog.listFiles().size.toLong,
+              s"Successfully truncated time travel data. Deleted $deletedVersions version files and $deletedCheckpoints checkpoint files. Table now at v$checkpointVersion."
+            ))
+          }
+        } finally {
+          cloudProvider.close()
+        }
+      } finally {
+        transactionLog.close()
+      }
+    } catch {
+      case e: Exception =>
+        val errorMsg = s"Failed to truncate time travel data: ${e.getMessage}"
+        logger.error(errorMsg, e)
+        Seq(Row(
+          tablePath,
+          "ERROR",
+          0L,
+          0L,
+          0L,
+          0L,
+          errorMsg
+        ))
+    }
+
+  /**
+   * Create a checkpoint at the current version.
+   * Returns the checkpoint version.
+   */
+  private def createCheckpointAtCurrentVersion(
+    sparkSession: SparkSession,
+    resolvedPath: Path,
+    options: org.apache.spark.sql.util.CaseInsensitiveStringMap
+  ): Long = {
+    val transactionLog = TransactionLogFactory.create(resolvedPath, sparkSession, options)
+    try {
+      val versions = transactionLog.getVersions()
+      val currentVersion = versions.max
+
+      // Get all current actions (file state)
+      val allFiles = transactionLog.listFiles()
+      val metadata = transactionLog.getMetadata()
+      val protocol = transactionLog.getProtocol()
+
+      // Build complete action list for checkpoint
+      val allActions = Seq(protocol) ++ Seq(metadata) ++ allFiles
+
+      logger.info(s"Creating checkpoint at version $currentVersion with ${allActions.length} actions")
+
+      // Create checkpoint handler
+      val transactionLogPath = new Path(resolvedPath, "_transaction_log")
+      val cloudProvider = CloudStorageProviderFactory.createProvider(
+        transactionLogPath.toString,
+        options,
+        sparkSession.sparkContext.hadoopConfiguration
+      )
+
+      try {
+        val checkpoint = new TransactionLogCheckpoint(transactionLogPath, cloudProvider, options)
+        checkpoint.createCheckpoint(currentVersion, allActions)
+        checkpoint.close()
+        logger.info(s"Created checkpoint at version $currentVersion")
+        currentVersion
+      } finally {
+        cloudProvider.close()
+      }
+    } finally {
+      transactionLog.close()
+    }
+  }
+
+  /** Resolve table path from string path or table identifier. */
+  private def resolveTablePath(pathOrTable: String, sparkSession: SparkSession): Path =
+    if (
+      pathOrTable.startsWith("/") || pathOrTable.startsWith("s3://") || pathOrTable.startsWith("s3a://") ||
+      pathOrTable.startsWith("hdfs://") || pathOrTable.startsWith("file://") ||
+      pathOrTable.startsWith("abfss://") || pathOrTable.startsWith("wasbs://")
+    ) {
+      // It's a path
+      new Path(pathOrTable)
+    } else {
+      // Try to resolve as table identifier
+      try {
+        val tableIdentifier = sparkSession.sessionState.sqlParser.parseTableIdentifier(pathOrTable)
+        val catalog         = sparkSession.sessionState.catalog
+        if (catalog.tableExists(tableIdentifier)) {
+          val tableMetadata = catalog.getTableMetadata(tableIdentifier)
+          new Path(tableMetadata.location)
+        } else {
+          throw new IllegalArgumentException(s"Table not found: $pathOrTable")
+        }
+      } catch {
+        case _: Exception =>
+          // If it fails as a table identifier, treat it as a path
+          new Path(pathOrTable)
+      }
+    }
+}

--- a/src/test/scala/io/indextables/spark/sql/RealS3TruncateTimeTravelTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/RealS3TruncateTimeTravelTest.scala
@@ -1,0 +1,397 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sql
+
+import java.io.File
+import java.util.{Properties, UUID}
+
+import scala.util.Using
+
+import org.apache.hadoop.fs.{FileSystem, Path}
+
+import io.indextables.spark.RealS3TestBase
+
+/**
+ * Real AWS S3 integration tests for TRUNCATE INDEXTABLES TIME TRAVEL command.
+ *
+ * Tests critical functionality specific to S3:
+ *   - Transaction log file deletion on S3
+ *   - Checkpoint creation and preservation on S3
+ *   - Credential handling for cloud operations
+ *   - Data integrity after truncation on S3
+ *
+ * Credentials are loaded from ~/.aws/credentials file.
+ */
+class RealS3TruncateTimeTravelTest extends RealS3TestBase {
+
+  private val S3_BUCKET    = "test-tantivy4sparkbucket"
+  private val S3_REGION    = "us-east-2"
+  private val S3_BASE_PATH = s"s3a://$S3_BUCKET"
+
+  // Generate unique test run ID to avoid conflicts
+  private val testRunId    = UUID.randomUUID().toString.substring(0, 8)
+  private val testBasePath = s"$S3_BASE_PATH/truncate-time-travel-test-$testRunId"
+
+  // AWS credentials loaded from ~/.aws/credentials
+  private var awsCredentials: Option[(String, String)] = None
+  private var fs: FileSystem                           = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    // Load AWS credentials from ~/.aws/credentials
+    awsCredentials = loadAwsCredentials()
+
+    if (awsCredentials.isDefined) {
+      val (accessKey, secretKey) = awsCredentials.get
+
+      // Configure Hadoop config FIRST before creating FileSystem
+      val hadoopConf = spark.sparkContext.hadoopConfiguration
+
+      // Set standard S3A properties for Hadoop FileSystem
+      hadoopConf.set("fs.s3a.access.key", accessKey)
+      hadoopConf.set("fs.s3a.secret.key", secretKey)
+      hadoopConf.set("fs.s3a.endpoint.region", S3_REGION)
+
+      // Also set indextables properties for CloudStorageProvider
+      hadoopConf.set("spark.indextables.aws.accessKey", accessKey)
+      hadoopConf.set("spark.indextables.aws.secretKey", secretKey)
+      hadoopConf.set("spark.indextables.aws.region", S3_REGION)
+
+      // Configure Spark for real S3 access
+      spark.conf.set("spark.indextables.aws.accessKey", accessKey)
+      spark.conf.set("spark.indextables.aws.secretKey", secretKey)
+      spark.conf.set("spark.indextables.aws.region", S3_REGION)
+
+      // Set checkpoint interval low for testing
+      spark.conf.set("spark.indextables.checkpoint.interval", "5")
+
+      // Initialize FileSystem AFTER setting Hadoop config
+      val testPath = new Path(testBasePath)
+      fs = testPath.getFileSystem(hadoopConf)
+
+      println(s"🔐 AWS credentials loaded successfully")
+      println(s"🌊 Configured Spark for S3 access to bucket: $S3_BUCKET in region: $S3_REGION")
+      println(s"📍 Test base path: $testBasePath")
+    } else {
+      println(s"⚠️  No AWS credentials found in ~/.aws/credentials - tests will be skipped")
+    }
+  }
+
+  override def afterAll(): Unit = {
+    // Clean up test data
+    if (awsCredentials.isDefined && fs != null) {
+      try {
+        val basePath = new Path(testBasePath)
+        if (fs.exists(basePath)) {
+          fs.delete(basePath, true)
+          println(s"🗑️  Cleaned up test data at $testBasePath")
+        }
+      } catch {
+        case ex: Exception =>
+          println(s"⚠️  Failed to clean up test data: ${ex.getMessage}")
+      }
+    }
+    super.afterAll()
+  }
+
+  /** Load AWS credentials from ~/.aws/credentials file. */
+  private def loadAwsCredentials(): Option[(String, String)] =
+    try {
+      val home     = System.getProperty("user.home")
+      val credFile = new File(s"$home/.aws/credentials")
+
+      if (!credFile.exists()) {
+        println(s"AWS credentials file not found at: ${credFile.getAbsolutePath}")
+        return None
+      }
+
+      Using(new java.io.FileInputStream(credFile)) { fis =>
+        val props = new Properties()
+        props.load(fis)
+
+        val accessKey = props.getProperty("aws_access_key_id")
+        val secretKey = props.getProperty("aws_secret_access_key")
+
+        if (accessKey != null && secretKey != null) {
+          Some((accessKey, secretKey))
+        } else {
+          println(s"AWS credentials not found in ~/.aws/credentials")
+          None
+        }
+      }.toOption.flatten
+    } catch {
+      case ex: Exception =>
+        println(s"Failed to read AWS credentials: ${ex.getMessage}")
+        None
+    }
+
+  /** Count transaction log files in S3. */
+  private def countTransactionLogFiles(tablePath: String): (Int, Int) = {
+    val txLogPath = new Path(tablePath, "_transaction_log")
+    if (!fs.exists(txLogPath)) {
+      return (0, 0)
+    }
+
+    val files = fs.listStatus(txLogPath)
+    val versionPattern = """^\d{20}\.json$""".r
+    val checkpointPattern = """^\d{20}\.checkpoint.*\.json$""".r
+
+    val versionCount = files.count(f => versionPattern.findFirstIn(f.getPath.getName).isDefined)
+    val checkpointCount = files.count(f => checkpointPattern.findFirstIn(f.getPath.getName).isDefined)
+
+    (versionCount, checkpointCount)
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should work on real S3") {
+    assume(awsCredentials.isDefined, "AWS credentials required for this test")
+
+    val tablePath = s"$testBasePath/truncate_basic_test"
+
+    // Write data with multiple transactions
+    val sparkSession = spark
+    import sparkSession.implicits._
+
+    // Write 8 transactions to create version files
+    for (i <- 1 to 8) {
+      val data = Seq((i, s"value_$i")).toDF("id", "value")
+      data.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .mode(if (i == 1) "overwrite" else "append")
+        .save(tablePath)
+    }
+
+    println(s"✅ Created table with 8 transactions at $tablePath")
+
+    // Verify we have version files before truncation
+    val (versionsBefore, _) = countTransactionLogFiles(tablePath)
+    println(s"📊 Version files before truncation: $versionsBefore")
+    versionsBefore should be >= 8
+
+    // Truncate time travel
+    val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'")
+    val row = result.collect().head
+
+    println(s"📋 Truncation result: status=${row.getString(1)}, versions_deleted=${row.getLong(3)}")
+
+    row.getString(1) shouldBe "SUCCESS"
+    row.getLong(2) should be >= 0L // checkpoint_version
+    row.getLong(3) should be >= 0L // versions_deleted
+
+    // Verify version files were deleted
+    val (versionsAfter, checkpointsAfter) = countTransactionLogFiles(tablePath)
+    println(s"📊 Version files after truncation: $versionsAfter, checkpoints: $checkpointsAfter")
+    versionsAfter should be < versionsBefore
+    checkpointsAfter should be >= 1 // At least one checkpoint should remain
+
+    // Verify data integrity
+    val finalCount = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(tablePath)
+      .count()
+    finalCount shouldBe 8
+    println(s"✅ Data integrity verified: $finalCount records")
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL DRY RUN should not delete files on S3") {
+    assume(awsCredentials.isDefined, "AWS credentials required for this test")
+
+    val tablePath = s"$testBasePath/truncate_dry_run_test"
+
+    // Write data with multiple transactions
+    val sparkSession = spark
+    import sparkSession.implicits._
+
+    for (i <- 1 to 6) {
+      val data = Seq((i, s"value_$i")).toDF("id", "value")
+      data.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .mode(if (i == 1) "overwrite" else "append")
+        .save(tablePath)
+    }
+
+    println(s"✅ Created table with 6 transactions at $tablePath")
+
+    val (versionsBefore, _) = countTransactionLogFiles(tablePath)
+
+    // Run DRY RUN
+    val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath' DRY RUN")
+    val row = result.collect().head
+
+    println(s"📋 DRY RUN result: status=${row.getString(1)}, would_delete=${row.getLong(3)}")
+
+    row.getString(1) shouldBe "DRY_RUN"
+
+    // Verify NO files were deleted
+    val (versionsAfter, _) = countTransactionLogFiles(tablePath)
+    versionsAfter shouldBe versionsBefore
+    println(s"✅ DRY RUN verified: no files deleted (before=$versionsBefore, after=$versionsAfter)")
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should preserve data integrity on S3 with many transactions") {
+    assume(awsCredentials.isDefined, "AWS credentials required for this test")
+
+    val tablePath = s"$testBasePath/truncate_integrity_test"
+
+    // Write data with many transactions to trigger multiple checkpoints
+    val sparkSession = spark
+    import sparkSession.implicits._
+
+    for (i <- 1 to 15) {
+      val data = Seq((i, s"value_$i", i * 10.0)).toDF("id", "value", "score")
+      data.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .mode(if (i == 1) "overwrite" else "append")
+        .save(tablePath)
+    }
+
+    println(s"✅ Created table with 15 transactions at $tablePath")
+
+    // Get data before truncation
+    val dataBefore = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(tablePath)
+
+    val countBefore = dataBefore.count()
+    val sumBefore = dataBefore.agg(Map("score" -> "sum")).collect().head.getDouble(0)
+
+    // Truncate
+    val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'")
+    val row = result.collect().head
+
+    println(s"📋 Truncation result: status=${row.getString(1)}, versions_deleted=${row.getLong(3)}")
+    row.getString(1) shouldBe "SUCCESS"
+
+    // Verify data integrity
+    val dataAfter = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(tablePath)
+
+    val countAfter = dataAfter.count()
+    val sumAfter = dataAfter.agg(Map("score" -> "sum")).collect().head.getDouble(0)
+
+    countAfter shouldBe countBefore
+    sumAfter shouldBe sumBefore
+    countAfter shouldBe 15
+    sumAfter shouldBe 1200.0
+
+    println(s"✅ Data integrity verified after truncation:")
+    println(s"   - Count: before=$countBefore, after=$countAfter")
+    println(s"   - Sum(score): before=$sumBefore, after=$sumAfter")
+  }
+
+  test("TRUNCATE should handle multiple existing checkpoints with uncheckpointed version on S3") {
+    assume(awsCredentials.isDefined, "AWS credentials required for this test")
+
+    val tablePath = s"$testBasePath/truncate_multi_checkpoint_test"
+
+    // Use checkpoint interval of 10 for this test
+    spark.conf.set("spark.indextables.checkpoint.interval", "10")
+
+    try {
+      val sparkSession = spark
+      import sparkSession.implicits._
+
+      // Write 21 transactions to create:
+      // - Checkpoint at version 10
+      // - Checkpoint at version 20
+      // - Version 21 (uncheckpointed - the "extra" version after checkpoint)
+      for (i <- 1 to 21) {
+        val data = Seq((i, s"value_$i", i * 100.0)).toDF("id", "value", "amount")
+        data.write
+          .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+          .mode(if (i == 1) "overwrite" else "append")
+          .save(tablePath)
+      }
+
+      println(s"✅ Created table with 21 transactions at $tablePath")
+
+      // Verify we have multiple checkpoints before truncation
+      val (versionsBefore, checkpointsBefore) = countTransactionLogFiles(tablePath)
+      println(s"📊 Before truncation: $versionsBefore version files, $checkpointsBefore checkpoint files")
+      versionsBefore should be >= 21
+      checkpointsBefore should be >= 2 // Should have checkpoints at v10 and v20
+
+      // Get data state before truncation
+      val dataBefore = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+      val countBefore = dataBefore.count()
+      val sumBefore = dataBefore.agg(Map("amount" -> "sum")).collect().head.getDouble(0)
+      val idsBefore = dataBefore.select("id").collect().map(_.getInt(0)).sorted
+
+      println(s"📊 Data before truncation: count=$countBefore, sum(amount)=$sumBefore")
+      countBefore shouldBe 21
+      sumBefore shouldBe 23100.0 // sum of 100+200+...+2100 = 100*(1+2+...+21) = 100*231 = 23100
+
+      // Truncate time travel
+      val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'")
+      val row = result.collect().head
+
+      println(s"📋 Truncation result:")
+      println(s"   - status: ${row.getString(1)}")
+      println(s"   - checkpoint_version: ${row.getLong(2)}")
+      println(s"   - versions_deleted: ${row.getLong(3)}")
+      println(s"   - checkpoints_deleted: ${row.getLong(4)}")
+
+      row.getString(1) shouldBe "SUCCESS"
+      row.getLong(3) should be >= 20L // Should delete versions 0-19 or 0-20
+      row.getLong(4) should be >= 1L // Should delete at least checkpoint at v10
+
+      // Verify transaction log state after truncation
+      val (versionsAfter, checkpointsAfter) = countTransactionLogFiles(tablePath)
+      println(s"📊 After truncation: $versionsAfter version files, $checkpointsAfter checkpoint files")
+      versionsAfter should be < versionsBefore
+      checkpointsAfter shouldBe 1 // Only latest checkpoint should remain
+
+      // CRITICAL: Verify ALL data is still readable after truncation
+      val dataAfter = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      val countAfter = dataAfter.count()
+      val sumAfter = dataAfter.agg(Map("amount" -> "sum")).collect().head.getDouble(0)
+      val idsAfter = dataAfter.select("id").collect().map(_.getInt(0)).sorted
+
+      println(s"📊 Data after truncation: count=$countAfter, sum(amount)=$sumAfter")
+
+      // Verify exact data integrity
+      countAfter shouldBe countBefore
+      sumAfter shouldBe sumBefore
+      idsAfter shouldBe idsBefore
+
+      // Verify each individual record is readable
+      for (expectedId <- 1 to 21) {
+        val record = dataAfter.filter(s"id = $expectedId").collect()
+        record.length shouldBe 1
+        record.head.getString(1) shouldBe s"value_$expectedId"
+        record.head.getDouble(2) shouldBe (expectedId * 100.0)
+      }
+
+      println(s"✅ All 21 records verified individually after truncation")
+      println(s"✅ Data integrity fully verified:")
+      println(s"   - Count: before=$countBefore, after=$countAfter")
+      println(s"   - Sum(amount): before=$sumBefore, after=$sumAfter")
+      println(s"   - All IDs match: ${idsBefore.mkString(",")}")
+
+    } finally {
+      // Restore checkpoint interval
+      spark.conf.set("spark.indextables.checkpoint.interval", "5")
+    }
+  }
+}

--- a/src/test/scala/io/indextables/spark/sql/TruncateTimeTravelParsingTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/TruncateTimeTravelParsingTest.scala
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sql
+
+import org.apache.spark.sql.SparkSession
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Tests for TRUNCATE INDEXTABLES TIME TRAVEL SQL parsing.
+ */
+class TruncateTimeTravelParsingTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
+
+  private var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    spark = SparkSession.builder()
+      .appName("TruncateTimeTravelParsingTest")
+      .master("local[2]")
+      .config("spark.sql.extensions", "io.indextables.spark.extensions.IndexTables4SparkExtensions")
+      .getOrCreate()
+  }
+
+  override def afterAll(): Unit = {
+    if (spark != null) {
+      spark.stop()
+    }
+    super.afterAll()
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should parse with path string") {
+    val sql = "TRUNCATE INDEXTABLES TIME TRAVEL '/tmp/test_table'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[TruncateTimeTravelCommand])
+
+    val cmd = plan.asInstanceOf[TruncateTimeTravelCommand]
+    assert(cmd.tablePath == "/tmp/test_table")
+    assert(cmd.dryRun == false)
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should parse with S3 path") {
+    val sql = "TRUNCATE INDEXTABLES TIME TRAVEL 's3://bucket/path/to/table'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[TruncateTimeTravelCommand])
+
+    val cmd = plan.asInstanceOf[TruncateTimeTravelCommand]
+    assert(cmd.tablePath == "s3://bucket/path/to/table")
+    assert(cmd.dryRun == false)
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should parse with Azure path") {
+    val sql = "TRUNCATE INDEXTABLES TIME TRAVEL 'abfss://container@account.dfs.core.windows.net/path'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[TruncateTimeTravelCommand])
+
+    val cmd = plan.asInstanceOf[TruncateTimeTravelCommand]
+    assert(cmd.tablePath == "abfss://container@account.dfs.core.windows.net/path")
+    assert(cmd.dryRun == false)
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should parse with DRY RUN flag") {
+    val sql = "TRUNCATE INDEXTABLES TIME TRAVEL '/tmp/test_table' DRY RUN"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[TruncateTimeTravelCommand])
+
+    val cmd = plan.asInstanceOf[TruncateTimeTravelCommand]
+    assert(cmd.tablePath == "/tmp/test_table")
+    assert(cmd.dryRun == true)
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should parse with table identifier") {
+    val sql = "TRUNCATE INDEXTABLES TIME TRAVEL my_table"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[TruncateTimeTravelCommand])
+
+    val cmd = plan.asInstanceOf[TruncateTimeTravelCommand]
+    assert(cmd.tablePath == "my_table")
+    assert(cmd.dryRun == false)
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should parse with qualified table identifier") {
+    val sql = "TRUNCATE INDEXTABLES TIME TRAVEL my_database.my_table"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[TruncateTimeTravelCommand])
+
+    val cmd = plan.asInstanceOf[TruncateTimeTravelCommand]
+    assert(cmd.tablePath == "my_database.my_table")
+    assert(cmd.dryRun == false)
+  }
+
+  test("TRUNCATE TANTIVY4SPARK TIME TRAVEL should parse (alternate keyword)") {
+    val sql = "TRUNCATE TANTIVY4SPARK TIME TRAVEL '/tmp/test_table'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[TruncateTimeTravelCommand])
+
+    val cmd = plan.asInstanceOf[TruncateTimeTravelCommand]
+    assert(cmd.tablePath == "/tmp/test_table")
+    assert(cmd.dryRun == false)
+  }
+
+  test("TRUNCATE TANTIVY4SPARK TIME TRAVEL with DRY RUN should parse") {
+    val sql = "TRUNCATE TANTIVY4SPARK TIME TRAVEL 's3://bucket/table' DRY RUN"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[TruncateTimeTravelCommand])
+
+    val cmd = plan.asInstanceOf[TruncateTimeTravelCommand]
+    assert(cmd.tablePath == "s3://bucket/table")
+    assert(cmd.dryRun == true)
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should be case-insensitive") {
+    val sql = "truncate indextables time travel '/tmp/test'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[TruncateTimeTravelCommand])
+
+    val cmd = plan.asInstanceOf[TruncateTimeTravelCommand]
+    assert(cmd.tablePath == "/tmp/test")
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL with mixed case DRY RUN") {
+    val sql = "TRUNCATE INDEXTABLES TIME TRAVEL '/tmp/test' Dry Run"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[TruncateTimeTravelCommand])
+
+    val cmd = plan.asInstanceOf[TruncateTimeTravelCommand]
+    assert(cmd.tablePath == "/tmp/test")
+    assert(cmd.dryRun == true)
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should parse with double-quoted path") {
+    val sql = """TRUNCATE INDEXTABLES TIME TRAVEL "/tmp/test_table""""
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[TruncateTimeTravelCommand])
+
+    val cmd = plan.asInstanceOf[TruncateTimeTravelCommand]
+    assert(cmd.tablePath == "/tmp/test_table")
+  }
+}

--- a/src/test/scala/io/indextables/spark/sql/TruncateTimeTravelTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/TruncateTimeTravelTest.scala
@@ -1,0 +1,451 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sql
+
+import java.io.File
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+
+import io.indextables.spark.TestBase
+
+/**
+ * Integration tests for TRUNCATE INDEXTABLES TIME TRAVEL command.
+ *
+ * Tests cover:
+ * - Basic truncation with multiple transactions
+ * - Checkpoint creation before truncation
+ * - DRY RUN mode
+ * - Data integrity after truncation
+ * - Edge cases (empty table, single version, etc.)
+ */
+class TruncateTimeTravelTest extends TestBase {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    // Set checkpoint interval low for testing
+    spark.conf.set("spark.indextables.checkpoint.interval", "5")
+  }
+
+  private def createTestTable(tablePath: String): Unit = {
+    val schema = StructType(
+      Seq(
+        StructField("id", IntegerType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      )
+    )
+    val data = Seq(Row(1, "one"), Row(2, "two"), Row(3, "three"))
+    val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+
+    df.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .mode("overwrite")
+      .save(tablePath)
+  }
+
+  /**
+   * Create a table with multiple transactions to generate version files.
+   */
+  private def createTableWithManyTransactions(tablePath: String, numTransactions: Int): Unit = {
+    val schema = StructType(
+      Seq(
+        StructField("id", IntegerType, nullable = false),
+        StructField("value", StringType, nullable = false)
+      )
+    )
+
+    for (i <- 1 to numTransactions) {
+      val data = Seq(Row(i, s"value_$i"))
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .mode(if (i == 1) "overwrite" else "append")
+        .save(tablePath)
+    }
+  }
+
+  /**
+   * Count transaction log files in a table directory.
+   * Returns (versionFileCount, checkpointFileCount)
+   */
+  private def countTransactionLogFiles(tablePath: String): (Int, Int) = {
+    val txLogDir = new File(tablePath, "_transaction_log")
+    if (!txLogDir.exists()) {
+      return (0, 0)
+    }
+
+    val files = txLogDir.listFiles()
+    if (files == null) {
+      return (0, 0)
+    }
+
+    val versionPattern = """^\d{20}\.json$""".r
+    val checkpointPattern = """^\d{20}\.checkpoint.*\.json$""".r
+
+    val versionCount = files.count(f => versionPattern.findFirstIn(f.getName).isDefined)
+    val checkpointCount = files.count(f => checkpointPattern.findFirstIn(f.getName).isDefined)
+
+    (versionCount, checkpointCount)
+  }
+
+  // ===== Basic Truncation Tests =====
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should truncate table with many transactions") {
+    val tablePath = new File(tempDir, "many_transactions_test").getAbsolutePath
+
+    // Create table with 15 transactions (should create 2-3 checkpoints with interval of 5)
+    createTableWithManyTransactions(tablePath, 15)
+
+    // Verify we have multiple version files before truncation
+    val (versionsBefore, _) = countTransactionLogFiles(tablePath)
+    versionsBefore should be >= 15
+
+    // Truncate time travel
+    val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'")
+    val rows = result.collect()
+
+    rows.length shouldBe 1
+    val row = rows.head
+
+    row.getString(1) shouldBe "SUCCESS" // status
+    row.getLong(2) should be >= 0L // checkpoint_version
+    row.getLong(3) should be >= 0L // versions_deleted
+
+    // Verify version files were deleted
+    val (versionsAfter, _) = countTransactionLogFiles(tablePath)
+    versionsAfter should be < versionsBefore
+
+    // Verify data integrity - all records should still be readable
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(tablePath)
+    df.count() shouldBe 15
+  }
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL should create checkpoint if none exists") {
+    val tablePath = new File(tempDir, "no_checkpoint_test").getAbsolutePath
+
+    // Create table with just 2 transactions (below checkpoint interval)
+    createTableWithManyTransactions(tablePath, 2)
+
+    // No checkpoint should exist yet
+    val (_, checkpointsBefore) = countTransactionLogFiles(tablePath)
+
+    // Truncate - should create checkpoint first
+    val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'")
+    val row = result.collect().head
+
+    row.getString(1) shouldBe "SUCCESS"
+    row.getLong(2) should be >= 0L // checkpoint_version created
+
+    // Checkpoint should now exist
+    val (_, checkpointsAfter) = countTransactionLogFiles(tablePath)
+    checkpointsAfter should be >= 1
+
+    // Data should still be readable
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(tablePath)
+    df.count() shouldBe 2
+  }
+
+  // ===== DRY RUN Tests =====
+
+  test("TRUNCATE INDEXTABLES TIME TRAVEL DRY RUN should preview without deleting") {
+    val tablePath = new File(tempDir, "dry_run_test").getAbsolutePath
+
+    // Create table with 12 transactions
+    createTableWithManyTransactions(tablePath, 12)
+
+    val (versionsBefore, _) = countTransactionLogFiles(tablePath)
+
+    // Run DRY RUN
+    val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath' DRY RUN")
+    val row = result.collect().head
+
+    row.getString(1) shouldBe "DRY_RUN"
+    row.getLong(3) should be >= 0L // versions_deleted (would be deleted)
+
+    // Verify NO files were actually deleted
+    val (versionsAfter, _) = countTransactionLogFiles(tablePath)
+    versionsAfter shouldBe versionsBefore
+  }
+
+  test("DRY RUN followed by actual truncate should produce consistent results") {
+    val tablePath = new File(tempDir, "dry_run_consistency_test").getAbsolutePath
+
+    // Create table with 10 transactions
+    createTableWithManyTransactions(tablePath, 10)
+
+    // First, DRY RUN
+    val dryRunResult = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath' DRY RUN")
+    val dryRunRow = dryRunResult.collect().head
+    val versionsToDelete = dryRunRow.getLong(3)
+
+    // Now actually truncate
+    val actualResult = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'")
+    val actualRow = actualResult.collect().head
+
+    actualRow.getString(1) shouldBe "SUCCESS"
+    actualRow.getLong(3) shouldBe versionsToDelete // Should match DRY RUN
+  }
+
+  // ===== Edge Cases =====
+
+  test("TRUNCATE should handle table with single version") {
+    val tablePath = new File(tempDir, "single_version_test").getAbsolutePath
+
+    // Create table with just 1 transaction
+    createTestTable(tablePath)
+
+    val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'")
+    val row = result.collect().head
+
+    // Should succeed (creates checkpoint, nothing old to delete)
+    row.getString(1) shouldBe "SUCCESS"
+
+    // Data should still be readable
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(tablePath)
+    df.count() shouldBe 3
+  }
+
+  test("TRUNCATE should handle table already at minimal state") {
+    val tablePath = new File(tempDir, "minimal_state_test").getAbsolutePath
+
+    // Create table and immediately truncate
+    createTestTable(tablePath)
+    spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'").collect()
+
+    // Try to truncate again
+    val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'")
+    val row = result.collect().head
+
+    row.getString(1) shouldBe "SUCCESS"
+    // Message should indicate nothing to delete
+    row.getString(6) should include("minimal state")
+  }
+
+  test("TRUNCATE should return ERROR for non-existent table") {
+    val nonExistentPath = new File(tempDir, "non_existent_table").getAbsolutePath
+
+    val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$nonExistentPath'")
+    val row = result.collect().head
+
+    row.getString(1) shouldBe "ERROR"
+  }
+
+  // ===== Data Integrity Tests =====
+
+  test("All data should be preserved after truncation") {
+    val tablePath = new File(tempDir, "data_integrity_test").getAbsolutePath
+
+    // Create table with 20 transactions, each adding one record
+    createTableWithManyTransactions(tablePath, 20)
+
+    // Get record count before truncation
+    val countBefore = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(tablePath)
+      .count()
+
+    // Truncate
+    spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'").collect()
+
+    // Verify record count is preserved
+    val countAfter = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(tablePath)
+      .count()
+
+    countAfter shouldBe countBefore
+    countAfter shouldBe 20
+  }
+
+  test("Queries should work correctly after truncation") {
+    val tablePath = new File(tempDir, "query_after_truncate_test").getAbsolutePath
+
+    // Create table with diverse data
+    val schema = StructType(
+      Seq(
+        StructField("id", IntegerType, nullable = false),
+        StructField("name", StringType, nullable = false),
+        StructField("score", DoubleType, nullable = false)
+      )
+    )
+
+    // Write initial data
+    val initialData = (1 to 10).map(i => Row(i, s"value_$i", i * 10.0))
+    val initialDf = spark.createDataFrame(spark.sparkContext.parallelize(initialData), schema)
+    initialDf.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .mode("overwrite")
+      .save(tablePath)
+
+    // Add more data in separate transactions
+    for (i <- 11 to 15) {
+      val data = Seq(Row(i, s"value_$i", i * 10.0))
+      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+      df.write
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .mode("append")
+        .save(tablePath)
+    }
+
+    // Truncate
+    spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'").collect()
+
+    // Test various queries
+    val result = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(tablePath)
+
+    // Count query
+    result.count() shouldBe 15
+
+    // Filter query
+    result.filter("id > 10").count() shouldBe 5
+
+    // Aggregation
+    result.agg(Map("score" -> "sum")).collect().head.getDouble(0) shouldBe 1200.0
+  }
+
+  // ===== Output Schema Tests =====
+
+  test("TRUNCATE should return correct output schema") {
+    val tablePath = new File(tempDir, "schema_test").getAbsolutePath
+    createTestTable(tablePath)
+
+    val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'")
+
+    val columns = result.columns.toSet
+    columns should contain("table_path")
+    columns should contain("status")
+    columns should contain("checkpoint_version")
+    columns should contain("versions_deleted")
+    columns should contain("checkpoints_deleted")
+    columns should contain("files_preserved")
+    columns should contain("message")
+
+    result.count() shouldBe 1
+  }
+
+  // ===== Syntax Variants Tests =====
+
+  test("TRUNCATE TANTIVY4SPARK TIME TRAVEL should work with alternate keyword") {
+    val tablePath = new File(tempDir, "tantivy4spark_keyword_test").getAbsolutePath
+    createTableWithManyTransactions(tablePath, 8)
+
+    val result = spark.sql(s"TRUNCATE TANTIVY4SPARK TIME TRAVEL '$tablePath'")
+    val row = result.collect().head
+
+    row.getString(1) shouldBe "SUCCESS"
+  }
+
+  // ===== Multiple Checkpoint Tests =====
+
+  test("TRUNCATE should handle multiple existing checkpoints with uncheckpointed version") {
+    val tablePath = new File(tempDir, "multi_checkpoint_test").getAbsolutePath
+
+    // Use checkpoint interval of 10 for this test
+    val originalInterval = spark.conf.getOption("spark.indextables.checkpoint.interval")
+    spark.conf.set("spark.indextables.checkpoint.interval", "10")
+
+    try {
+      val schema = StructType(
+        Seq(
+          StructField("id", IntegerType, nullable = false),
+          StructField("value", StringType, nullable = false),
+          StructField("amount", DoubleType, nullable = false)
+        )
+      )
+
+      // Write 21 transactions to create:
+      // - Checkpoint at version 10
+      // - Checkpoint at version 20
+      // - Version 21 (uncheckpointed - the "extra" version after checkpoint)
+      for (i <- 1 to 21) {
+        val data = Seq(Row(i, s"value_$i", i * 100.0))
+        val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+        df.write
+          .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+          .mode(if (i == 1) "overwrite" else "append")
+          .save(tablePath)
+      }
+
+      // Verify we have multiple checkpoints before truncation
+      val (versionsBefore, checkpointsBefore) = countTransactionLogFiles(tablePath)
+      versionsBefore should be >= 21
+      checkpointsBefore should be >= 2 // Should have checkpoints at v10 and v20
+
+      // Get data state before truncation
+      val dataBefore = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+      val countBefore = dataBefore.count()
+      val sumBefore = dataBefore.agg(Map("amount" -> "sum")).collect().head.getDouble(0)
+      val idsBefore = dataBefore.select("id").collect().map(_.getInt(0)).sorted
+
+      countBefore shouldBe 21
+      sumBefore shouldBe 23100.0 // sum of 100+200+...+2100 = 100*(1+2+...+21) = 100*231 = 23100
+
+      // Truncate time travel
+      val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$tablePath'")
+      val row = result.collect().head
+
+      row.getString(1) shouldBe "SUCCESS"
+      row.getLong(3) should be >= 20L // Should delete versions 0-19 or 0-20
+      row.getLong(4) should be >= 1L // Should delete at least checkpoint at v10
+
+      // Verify transaction log state after truncation
+      val (versionsAfter, checkpointsAfter) = countTransactionLogFiles(tablePath)
+      versionsAfter should be < versionsBefore
+      checkpointsAfter shouldBe 1 // Only latest checkpoint should remain
+
+      // CRITICAL: Verify ALL data is still readable after truncation
+      val dataAfter = spark.read
+        .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+        .load(tablePath)
+
+      val countAfter = dataAfter.count()
+      val sumAfter = dataAfter.agg(Map("amount" -> "sum")).collect().head.getDouble(0)
+      val idsAfter = dataAfter.select("id").collect().map(_.getInt(0)).sorted
+
+      // Verify exact data integrity
+      countAfter shouldBe countBefore
+      sumAfter shouldBe sumBefore
+      idsAfter shouldBe idsBefore
+
+      // Verify each individual record is readable
+      for (expectedId <- 1 to 21) {
+        val record = dataAfter.filter(s"id = $expectedId").collect()
+        record.length shouldBe 1
+        record.head.getString(1) shouldBe s"value_$expectedId"
+        record.head.getDouble(2) shouldBe (expectedId * 100.0)
+      }
+
+    } finally {
+      // Restore checkpoint interval
+      originalInterval match {
+        case Some(v) => spark.conf.set("spark.indextables.checkpoint.interval", v)
+        case None    => spark.conf.set("spark.indextables.checkpoint.interval", "5")
+      }
+    }
+  }
+}


### PR DESCRIPTION
# PR: Add TRUNCATE TIME TRAVEL SQL Command

## Summary

This PR adds a new SQL command `TRUNCATE INDEXTABLES TIME TRAVEL` that removes all historical transaction log versions from a table, keeping only the current state via the latest checkpoint. This enables users to:

- Reduce transaction log storage overhead after many write operations
- Clean up tables that no longer need time travel capability
- Prepare tables for archival by removing history

## Syntax

```sql
-- Truncate time travel data (remove historical versions)
TRUNCATE INDEXTABLES TIME TRAVEL '/path/to/table';
TRUNCATE INDEXTABLES TIME TRAVEL 's3://bucket/table';
TRUNCATE INDEXTABLES TIME TRAVEL my_database.my_table;

-- Preview what would be deleted without making changes
TRUNCATE INDEXTABLES TIME TRAVEL '/path/to/table' DRY RUN;

-- Alternate keyword also supported
TRUNCATE TANTIVY4SPARK TIME TRAVEL '/path/to/table';
```

## What This Command Does

1. **Creates checkpoint at current version** (if one doesn't exist at the latest version)
2. **Deletes all version files** older than the checkpoint
3. **Deletes all older checkpoint files** (preserves only the latest)
4. **Preserves all data files** (splits) - only transaction log metadata is affected

## Output Schema

| Column | Type | Description |
|--------|------|-------------|
| `table_path` | String | Resolved table path |
| `status` | String | "SUCCESS", "DRY_RUN", or "ERROR" |
| `checkpoint_version` | Long | Version at which checkpoint exists |
| `versions_deleted` | Long | Number of version files deleted |
| `checkpoints_deleted` | Long | Number of checkpoint files deleted |
| `files_preserved` | Long | Number of data files (splits) in table |
| `message` | String | Descriptive status message |

## Files Changed

### New Files
- `src/main/scala/io/indextables/spark/sql/TruncateTimeTravelCommand.scala` - Command implementation
- `src/test/scala/io/indextables/spark/sql/TruncateTimeTravelParsingTest.scala` - Parsing tests (11 tests)
- `src/test/scala/io/indextables/spark/sql/TruncateTimeTravelTest.scala` - Integration tests (11 tests)
- `src/test/scala/io/indextables/spark/sql/RealS3TruncateTimeTravelTest.scala` - Real S3 integration tests (3 tests)

### Modified Files
- `src/main/antlr4/io/indextables/spark/sql/parser/IndexTables4SparkSqlBase.g4` - Added grammar rule
- `src/main/scala/io/indextables/spark/sql/parser/IndexTables4SparkSqlAstBuilder.scala` - Added visitor method

## Key Implementation Details

### Credential Handling
Credentials are handled consistently with other commands (PURGE, DROP PARTITIONS, etc.):
- Uses `ConfigNormalization` to extract and merge Spark/Hadoop configs
- Uses `ConfigUtils.resolveCredentialsFromProviderOnDriver` to resolve credentials from custom providers
- Supports Unity Catalog credential provider and other custom providers

### Safety Features
- **DRY RUN mode** - Preview what would be deleted before making changes
- **Checkpoint preservation** - Always keeps the latest checkpoint
- **Current version preservation** - Never deletes version files >= checkpoint version
- **Concurrent write handling** - Creates checkpoint atomically with version tracking

### File Pattern Detection
Uses regex patterns consistent with other commands:
- Version files: `^(\d{20})\.json$`
- Checkpoint manifests: `^(\d{20})\.checkpoint\.json$`
- Multi-part checkpoint parts: `^(\d{20})\.checkpoint\.([a-f0-9]+)\.(\d{5})\.json$`

## Test Plan

- [x] Parsing tests for all syntax variants (11 tests)
- [x] Integration tests for local filesystem (11 tests)
- [x] Real S3 integration tests (3 tests)
- [x] DRY RUN mode verification
- [x] Data integrity after truncation
- [x] Checkpoint creation when none exists
- [x] Minimal state handling (nothing to delete)
- [x] Error handling for non-existent tables

## Example Usage

```scala
// Create table with many transactions
(1 to 20).foreach { i =>
  Seq((i, s"value_$i")).toDF("id", "value")
    .write.format("io.indextables.spark.core.IndexTables4SparkTableProvider")
    .mode(if (i == 1) "overwrite" else "append")
    .save("s3://bucket/table")
}

// Preview truncation
spark.sql("TRUNCATE INDEXTABLES TIME TRAVEL 's3://bucket/table' DRY RUN").show()
// +-------------------+-------+------------------+----------------+-------------------+---------------+------------------------+
// |table_path         |status |checkpoint_version|versions_deleted|checkpoints_deleted|files_preserved|message                 |
// +-------------------+-------+------------------+----------------+-------------------+---------------+------------------------+
// |s3://bucket/table  |DRY_RUN|               20 |             19 |                  2|             20|Would delete 19 vers...|
// +-------------------+-------+------------------+----------------+-------------------+---------------+------------------------+

// Execute truncation
spark.sql("TRUNCATE INDEXTABLES TIME TRAVEL 's3://bucket/table'").show()
// +-------------------+-------+------------------+----------------+-------------------+---------------+------------------------+
// |table_path         |status |checkpoint_version|versions_deleted|checkpoints_deleted|files_preserved|message                 |
// +-------------------+-------+------------------+----------------+-------------------+---------------+------------------------+
// |s3://bucket/table  |SUCCESS|               20 |             19 |                  2|             20|Successfully trunca...|
// +-------------------+-------+------------------+----------------+-------------------+---------------+------------------------+

// Data still readable
spark.read.format("...").load("s3://bucket/table").count()  // Returns 20
```