### PR TITLE
fix: Fix Azure Blob Storage Upload Gap from PR74 Support for Merge Operations

### DIFF
--- a/src/main/scala/io/indextables/spark/io/merge/MergeUploader.scala
+++ b/src/main/scala/io/indextables/spark/io/merge/MergeUploader.scala
@@ -21,6 +21,7 @@ import java.io.File
 import java.net.URI
 import java.nio.file.{Files, Paths}
 
+import io.indextables.spark.util.ProtocolNormalizer
 import io.indextables.spark.utils.CredentialProviderFactory
 
 import software.amazon.awssdk.auth.credentials._
@@ -29,32 +30,41 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 
+import com.azure.identity.ClientSecretCredentialBuilder
+import com.azure.storage.blob.{BlobClient, BlobServiceClient, BlobServiceClientBuilder}
+import com.azure.storage.common.StorageSharedKeyCredential
+
 import org.slf4j.LoggerFactory
 
 /**
- * Helper for uploading merged splits to cloud storage.
+ * Helper for uploading merged splits to cloud storage (S3 and Azure).
  *
- * Uses the same credential resolution as S3AsyncDownloader for consistency:
- * CredentialProviderFactory.resolveAWSCredentialsFromConfig(configs, tablePath)
+ * Supports:
+ *   - S3: s3://, s3a:// paths with AWS credentials or custom credential providers
+ *   - Azure: azure://, wasb://, wasbs://, abfs://, abfss:// paths with account key or OAuth
+ *   - Local: file paths copied directly
+ *
+ * Uses the same credential resolution patterns as S3AsyncDownloader and AzureAsyncDownloader
+ * for consistency across download and upload operations.
  */
 object MergeUploader {
 
   private val logger = LoggerFactory.getLogger(getClass)
 
   /**
-   * Upload a local file to S3.
+   * Upload a local file to cloud storage (S3, Azure, or local).
    *
-   * Uses the same credential resolution pattern as S3AsyncDownloader.fromConfig()
+   * Uses the same credential resolution patterns as S3AsyncDownloader and AzureAsyncDownloader
    * to ensure Unity Catalog and other custom credential providers work consistently.
    *
    * @param localPath
    *   Path to the local file to upload
    * @param destPath
-   *   Destination S3 path (s3:// or s3a://)
+   *   Destination path: S3 (s3://, s3a://), Azure (azure://, wasb://, wasbs://, abfs://, abfss://), or local
    * @param configs
    *   Configuration map with cloud provider settings
    * @param tablePath
-   *   Table path for credential provider resolution
+   *   Table path for credential provider resolution (used for S3 custom providers)
    * @return
    *   The number of bytes uploaded
    */
@@ -69,10 +79,12 @@ object MergeUploader {
 
     logger.info(s"Uploading merged split: $localPath -> $destPath ($fileSize bytes)")
 
-    // Determine if this is a cloud path
-    val isS3Path = destPath.startsWith("s3://") || destPath.startsWith("s3a://")
+    // Route to appropriate upload method based on cloud provider
+    if (ProtocolNormalizer.isAzurePath(destPath)) {
+      return uploadToAzure(localFile, destPath, configs)
+    }
 
-    if (!isS3Path) {
+    if (!ProtocolNormalizer.isS3Path(destPath)) {
       // Local path - just copy the file
       val destFile = new File(destPath)
       destFile.getParentFile.mkdirs()
@@ -81,7 +93,7 @@ object MergeUploader {
       return fileSize
     }
 
-    // Use the SAME credential resolution as S3AsyncDownloader
+    // S3 upload - Use the SAME credential resolution as S3AsyncDownloader
     val s3Client = createS3Client(configs, tablePath)
 
     try {
@@ -176,6 +188,133 @@ object MergeUploader {
     val bucket = uri.getHost
     val key    = uri.getPath.stripPrefix("/")
     (bucket, key)
+  }
+
+  /**
+   * Upload a local file to Azure Blob Storage.
+   *
+   * Uses the same credential resolution pattern as AzureAsyncDownloader.fromConfig()
+   * to ensure consistent authentication.
+   *
+   * @param localFile
+   *   The local file to upload
+   * @param destPath
+   *   Destination Azure path (azure://, wasb://, wasbs://, abfs://, abfss://)
+   * @param configs
+   *   Configuration map with Azure credentials
+   * @return
+   *   The number of bytes uploaded
+   */
+  private def uploadToAzure(
+    localFile: File,
+    destPath: String,
+    configs: Map[String, String]
+  ): Long = {
+    val fileSize = localFile.length()
+
+    // Create Azure client using same pattern as AzureAsyncDownloader
+    val blobClient = createAzureBlobClient(destPath, configs)
+
+    try {
+      logger.info(s"Uploading to Azure: ${localFile.getAbsolutePath} -> $destPath")
+
+      // Upload file (overwrite if exists)
+      blobClient.uploadFromFile(localFile.getAbsolutePath, true)
+
+      logger.info(s"Azure upload completed: $destPath ($fileSize bytes)")
+      fileSize
+    } catch {
+      case ex: Exception =>
+        logger.error(s"Azure upload failed: $destPath", ex)
+        throw ex
+    }
+  }
+
+  /**
+   * Create an Azure BlobClient for the specified path.
+   *
+   * Uses the same credential resolution as AzureAsyncDownloader.fromConfig().
+   */
+  private def createAzureBlobClient(destPath: String, configs: Map[String, String]): BlobClient = {
+    def get(key: String): Option[String] =
+      configs.get(key).orElse(configs.get(key.toLowerCase)).filter(_.nonEmpty)
+
+    val accountName = get("spark.indextables.azure.accountName")
+      .getOrElse(throw new RuntimeException("Azure account name not configured (spark.indextables.azure.accountName)"))
+
+    val accountKey   = get("spark.indextables.azure.accountKey")
+    val tenantId     = get("spark.indextables.azure.tenantId")
+    val clientId     = get("spark.indextables.azure.clientId")
+    val clientSecret = get("spark.indextables.azure.clientSecret")
+
+    // Build service client with appropriate credentials
+    val serviceClient: BlobServiceClient = accountKey match {
+      case Some(key) =>
+        // Account key authentication
+        logger.debug(s"Creating Azure client with account key for account: $accountName")
+        val credential = new StorageSharedKeyCredential(accountName, key)
+        new BlobServiceClientBuilder()
+          .endpoint(s"https://$accountName.blob.core.windows.net")
+          .credential(credential)
+          .buildClient()
+
+      case None =>
+        // Try OAuth (Service Principal) authentication
+        (tenantId, clientId, clientSecret) match {
+          case (Some(tenant), Some(client), Some(secret)) =>
+            logger.debug(s"Creating Azure client with OAuth for account: $accountName")
+            val credential = new ClientSecretCredentialBuilder()
+              .tenantId(tenant)
+              .clientId(client)
+              .clientSecret(secret)
+              .build()
+            new BlobServiceClientBuilder()
+              .endpoint(s"https://$accountName.blob.core.windows.net")
+              .credential(credential)
+              .buildClient()
+
+          case _ =>
+            throw new RuntimeException(
+              "Azure credentials not configured. Provide either spark.indextables.azure.accountKey " +
+                "or OAuth credentials (tenantId, clientId, clientSecret)"
+            )
+        }
+    }
+
+    // Parse Azure path to get container and blob
+    val (container, blobPath) = parseAzurePath(destPath)
+    logger.debug(s"Azure upload target: container=$container, blob=$blobPath")
+
+    // Get blob client for upload
+    serviceClient.getBlobContainerClient(container).getBlobClient(blobPath)
+  }
+
+  /**
+   * Parse an Azure path into container and blob path.
+   *
+   * Handles various Azure URL schemes: azure://, wasb://, wasbs://, abfs://, abfss://
+   */
+  private def parseAzurePath(path: String): (String, String) = {
+    // Normalize to azure:// scheme for parsing
+    val normalizedPath = path
+      .replaceFirst("^wasbs?://", "azure://")
+      .replaceFirst("^abfss?://", "azure://")
+
+    val uri = new URI(normalizedPath)
+
+    // Container is the host or first path component depending on URL format
+    // azure://container/path or azure://container@account/path
+    val hostPart = uri.getHost
+    val pathPart = uri.getPath.stripPrefix("/")
+
+    // If host contains @, it's in format container@account
+    if (hostPart.contains("@")) {
+      val container = hostPart.split("@")(0)
+      (container, pathPart)
+    } else {
+      // Host is the container
+      (hostPart, pathPart)
+    }
   }
 
   /**


### PR DESCRIPTION
# PR: Add Azure Blob Storage Upload Support for Merge Operations

## Summary

This PR adds Azure Blob Storage upload support to `MergeUploader`, fixing merge-on-write operations for Azure-backed tables.

## Problem

After PR #77 rewrote the merge I/O logic to use Scala-side uploads, the `MergeUploader` only supported S3 uploads. Azure paths (`azure://`, `wasb://`, `wasbs://`, `abfs://`, `abfss://`) were incorrectly treated as local paths, causing merge operations to fail with file copy errors.

| Component | S3 Support | Azure Support |
|-----------|------------|---------------|
| Download (`AsyncDownloader`) | S3AsyncDownloader | AzureAsyncDownloader |
| Upload (`MergeUploader`) | S3Client | **Missing** |

## Solution

Added Azure Blob Storage upload support to `MergeUploader.scala`:

1. **Path detection**: Use `ProtocolNormalizer.isAzurePath()` utility to detect Azure paths
2. **Credential handling**: Support both account key and OAuth (Service Principal) authentication, using the same pattern as `AzureAsyncDownloader.fromConfig()`
3. **Upload implementation**: Use Azure SDK `BlobClient.uploadFromFile()` for efficient file uploads

## Changes

### `MergeUploader.scala`
- Added imports for Azure SDK classes and `ProtocolNormalizer`
- Updated `upload()` method to route Azure paths to new `uploadToAzure()` method
- Added `uploadToAzure()` method for Azure Blob Storage uploads
- Added `createAzureBlobClient()` method with account key and OAuth support
- Added `parseAzurePath()` method to extract container and blob path from various Azure URL schemes
- Updated class documentation to reflect multi-cloud support

## Testing

All Azure tests pass (20/20):

**RealAzurePostCommitMergeOnWriteTest** (6 tests):
- Post-commit merge-on-write threshold triggering
- No-merge when below threshold
- Write options propagation
- Partitioned data support
- Multiple appends handling
- OAuth credentials support

**RealAzureEndToEndTest** (14 tests):
- Basic read/write operations
- Partitioned datasets
- MERGE SPLITS operations
- OAuth authentication
- Various URL schemes (azure://, abfss://)

## Configuration

No new configuration required. Uses existing Azure credentials:

```scala
// Account key authentication
spark.indextables.azure.accountName: <account>
spark.indextables.azure.accountKey: <key>

// OAuth Service Principal authentication
spark.indextables.azure.accountName: <account>
spark.indextables.azure.tenantId: <tenant>
spark.indextables.azure.clientId: <client>
spark.indextables.azure.clientSecret: <secret>
```

## Supported URL Schemes

- `azure://container/path`
- `wasb://container@account.blob.core.windows.net/path`
- `wasbs://container@account.blob.core.windows.net/path`
- `abfs://container@account.dfs.core.windows.net/path`
- `abfss://container@account.dfs.core.windows.net/path`
