### PR TITLE
fix: Preserve Credential Refresh Logic for Custom AWS Credential Providers

### DIFF
--- a/src/main/scala/io/indextables/spark/auth/V1ToV2CredentialsProviderAdapter.scala
+++ b/src/main/scala/io/indextables/spark/auth/V1ToV2CredentialsProviderAdapter.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.auth
+
+import io.indextables.spark.utils.CredentialProviderFactory
+import org.slf4j.LoggerFactory
+import software.amazon.awssdk.auth.credentials.{
+  AwsBasicCredentials,
+  AwsCredentials,
+  AwsCredentialsProvider,
+  AwsSessionCredentials
+}
+
+/**
+ * AWS SDK v2 AwsCredentialsProvider that wraps a v1 AWSCredentialsProvider.
+ *
+ * This adapter allows v1 credential providers (like UnityCatalogAWSCredentialProvider)
+ * to be used with the AWS SDK v2 S3Client while preserving the v1 provider's refresh
+ * and caching logic.
+ *
+ * The key insight is that the AWS SDK v2 calls `resolveCredentials()` each time
+ * credentials are needed, not just once at client creation. This adapter delegates
+ * each call to the v1 provider's `getCredentials()` method, which allows the v1
+ * provider to:
+ *   - Return cached credentials if still valid
+ *   - Refresh credentials if they are near expiration
+ *   - Fetch new credentials from the source (e.g., Unity Catalog API)
+ *
+ * Without this adapter, credentials would be extracted once at S3Client creation
+ * and wrapped in a StaticCredentialsProvider, which cannot refresh. This causes
+ * "token expired" errors for long-running Spark jobs that exceed the credential
+ * TTL (typically 1 hour for Unity Catalog temporary credentials).
+ *
+ * Usage:
+ * {{{
+ * val v1Provider = new UnityCatalogAWSCredentialProvider(uri, hadoopConf)
+ * val v2Provider = new V1ToV2CredentialsProviderAdapter(v1Provider)
+ * val s3Client = S3Client.builder()
+ *   .credentialsProvider(v2Provider)
+ *   .build()
+ * }}}
+ *
+ * @param v1Provider The AWS SDK v1 AWSCredentialsProvider to wrap. Must implement
+ *                   com.amazonaws.auth.AWSCredentialsProvider interface.
+ */
+class V1ToV2CredentialsProviderAdapter(v1Provider: AnyRef) extends AwsCredentialsProvider {
+
+  private val logger = LoggerFactory.getLogger(classOf[V1ToV2CredentialsProviderAdapter])
+
+  // Validate that the provider is actually a v1 provider
+  require(v1Provider != null, "v1Provider cannot be null")
+  require(
+    CredentialProviderFactory.isV1Provider(v1Provider),
+    s"Provider must implement com.amazonaws.auth.AWSCredentialsProvider, got: ${v1Provider.getClass.getName}"
+  )
+
+  logger.info(s"Created V1ToV2CredentialsProviderAdapter wrapping: ${v1Provider.getClass.getName}")
+
+  /**
+   * Resolve credentials by delegating to the v1 provider's getCredentials() method.
+   *
+   * This method is called by the AWS SDK v2 each time credentials are needed for
+   * a request. By delegating to the v1 provider, we preserve its refresh logic:
+   *   - The v1 provider checks if cached credentials are near expiration
+   *   - If near expiration, it fetches fresh credentials from the source
+   *   - Fresh credentials are cached and returned
+   *
+   * @return AWS credentials (either basic or session credentials)
+   */
+  override def resolveCredentials(): AwsCredentials = {
+    logger.debug(s"resolveCredentials() called, delegating to v1 provider: ${v1Provider.getClass.getName}")
+
+    // Extract credentials from the v1 provider using reflection
+    // This calls the v1 provider's getCredentials() method, which may refresh
+    // credentials if they are near expiration
+    val creds = CredentialProviderFactory.extractCredentialsViaReflection(v1Provider)
+
+    logger.debug(s"Resolved credentials: accessKey=${creds.accessKey.take(4)}..., " +
+      s"hasSessionToken=${creds.hasSessionToken}")
+
+    // Convert to AWS SDK v2 credentials
+    if (creds.hasSessionToken) {
+      AwsSessionCredentials.create(creds.accessKey, creds.secretKey, creds.sessionToken.get)
+    } else {
+      AwsBasicCredentials.create(creds.accessKey, creds.secretKey)
+    }
+  }
+
+  /**
+   * Get the wrapped v1 provider for debugging/testing purposes.
+   */
+  def getWrappedProvider: AnyRef = v1Provider
+}

--- a/src/test/scala/io/indextables/spark/auth/V1ToV2CredentialsProviderAdapterTest.scala
+++ b/src/test/scala/io/indextables/spark/auth/V1ToV2CredentialsProviderAdapterTest.scala
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.auth
+
+import java.net.URI
+import java.util.concurrent.atomic.AtomicInteger
+
+import org.apache.hadoop.conf.Configuration
+
+import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider, BasicAWSCredentials, BasicSessionCredentials}
+import io.indextables.spark.TestBase
+import io.indextables.spark.testutils.TestV1CredentialProvider
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials
+
+/**
+ * Unit tests for V1ToV2CredentialsProviderAdapter.
+ *
+ * These tests verify that the adapter properly:
+ * 1. Wraps v1 credential providers
+ * 2. Delegates resolveCredentials() to the v1 provider's getCredentials()
+ * 3. Preserves refresh logic by calling getCredentials() on each resolveCredentials() call
+ * 4. Handles both session credentials and basic credentials
+ */
+class V1ToV2CredentialsProviderAdapterTest extends TestBase {
+
+  private var hadoopConf: Configuration = _
+  private var testUri: URI              = _
+
+  override def beforeEach(): Unit = {
+    hadoopConf = new Configuration()
+    testUri = new URI("s3://test-bucket")
+  }
+
+  test("wraps v1 provider and delegates resolveCredentials") {
+    hadoopConf.set("test.aws.accessKey", "TEST_ACCESS_KEY")
+    hadoopConf.set("test.aws.secretKey", "TEST_SECRET_KEY")
+    hadoopConf.set("test.aws.sessionToken", "TEST_SESSION_TOKEN")
+
+    val v1Provider = new TestV1CredentialProvider(testUri, hadoopConf)
+    val adapter = new V1ToV2CredentialsProviderAdapter(v1Provider)
+
+    val creds = adapter.resolveCredentials()
+
+    assert(creds != null)
+    assert(creds.isInstanceOf[AwsSessionCredentials])
+    val sessionCreds = creds.asInstanceOf[AwsSessionCredentials]
+    assert(sessionCreds.accessKeyId() == "TEST_ACCESS_KEY")
+    assert(sessionCreds.secretAccessKey() == "TEST_SECRET_KEY")
+    assert(sessionCreds.sessionToken() == "TEST_SESSION_TOKEN")
+  }
+
+  test("handles basic credentials without session token") {
+    hadoopConf.set("test.aws.accessKey", "BASIC_ACCESS_KEY")
+    hadoopConf.set("test.aws.secretKey", "BASIC_SECRET_KEY")
+    // No session token
+
+    val v1Provider = new TestV1CredentialProvider(testUri, hadoopConf)
+    val adapter = new V1ToV2CredentialsProviderAdapter(v1Provider)
+
+    val creds = adapter.resolveCredentials()
+
+    assert(creds != null)
+    assert(!creds.isInstanceOf[AwsSessionCredentials])
+    assert(creds.accessKeyId() == "BASIC_ACCESS_KEY")
+    assert(creds.secretAccessKey() == "BASIC_SECRET_KEY")
+  }
+
+  test("calls v1 provider on each resolveCredentials call (preserves refresh)") {
+    // Use a counting provider to verify getCredentials() is called each time
+    val callCount = new AtomicInteger(0)
+
+    val countingProvider = new AWSCredentialsProvider {
+      override def getCredentials(): AWSCredentials = {
+        val count = callCount.incrementAndGet()
+        new BasicAWSCredentials(s"ACCESS_KEY_$count", s"SECRET_KEY_$count")
+      }
+      override def refresh(): Unit = {}
+    }
+
+    val adapter = new V1ToV2CredentialsProviderAdapter(countingProvider)
+
+    // First call
+    val creds1 = adapter.resolveCredentials()
+    assert(creds1.accessKeyId() == "ACCESS_KEY_1")
+    assert(callCount.get() == 1)
+
+    // Second call - should call getCredentials() again
+    val creds2 = adapter.resolveCredentials()
+    assert(creds2.accessKeyId() == "ACCESS_KEY_2")
+    assert(callCount.get() == 2)
+
+    // Third call
+    val creds3 = adapter.resolveCredentials()
+    assert(creds3.accessKeyId() == "ACCESS_KEY_3")
+    assert(callCount.get() == 3)
+  }
+
+  test("simulates credential refresh scenario") {
+    // Simulates a v1 provider that returns different credentials after "refresh"
+    var credentialVersion = 1
+
+    val refreshableProvider = new AWSCredentialsProvider {
+      override def getCredentials(): AWSCredentials = {
+        // Simulate: check expiration and refresh if needed (real providers do this internally)
+        new BasicSessionCredentials(
+          s"ACCESS_V$credentialVersion",
+          s"SECRET_V$credentialVersion",
+          s"TOKEN_V$credentialVersion"
+        )
+      }
+      override def refresh(): Unit = {
+        credentialVersion += 1
+      }
+    }
+
+    val adapter = new V1ToV2CredentialsProviderAdapter(refreshableProvider)
+
+    // Initial credentials
+    val creds1 = adapter.resolveCredentials().asInstanceOf[AwsSessionCredentials]
+    assert(creds1.accessKeyId() == "ACCESS_V1")
+    assert(creds1.sessionToken() == "TOKEN_V1")
+
+    // Simulate refresh (in real scenario, this happens when credentials are near expiration)
+    refreshableProvider.refresh()
+
+    // Next call gets refreshed credentials
+    val creds2 = adapter.resolveCredentials().asInstanceOf[AwsSessionCredentials]
+    assert(creds2.accessKeyId() == "ACCESS_V2")
+    assert(creds2.sessionToken() == "TOKEN_V2")
+  }
+
+  test("getWrappedProvider returns original v1 provider") {
+    hadoopConf.set("test.aws.accessKey", "TEST_ACCESS")
+    hadoopConf.set("test.aws.secretKey", "TEST_SECRET")
+
+    val v1Provider = new TestV1CredentialProvider(testUri, hadoopConf)
+    val adapter = new V1ToV2CredentialsProviderAdapter(v1Provider)
+
+    assert(adapter.getWrappedProvider eq v1Provider)
+  }
+
+  test("rejects null provider") {
+    val exception = intercept[IllegalArgumentException] {
+      new V1ToV2CredentialsProviderAdapter(null)
+    }
+    assert(exception.getMessage.contains("cannot be null"))
+  }
+
+  test("rejects non-v1 provider") {
+    // Create an object that doesn't implement AWSCredentialsProvider
+    val notAProvider = new Object()
+
+    val exception = intercept[IllegalArgumentException] {
+      new V1ToV2CredentialsProviderAdapter(notAProvider)
+    }
+    assert(exception.getMessage.contains("AWSCredentialsProvider"))
+  }
+
+  test("multiple adapters can wrap same provider") {
+    hadoopConf.set("test.aws.accessKey", "SHARED_ACCESS")
+    hadoopConf.set("test.aws.secretKey", "SHARED_SECRET")
+
+    val v1Provider = new TestV1CredentialProvider(testUri, hadoopConf)
+    val adapter1 = new V1ToV2CredentialsProviderAdapter(v1Provider)
+    val adapter2 = new V1ToV2CredentialsProviderAdapter(v1Provider)
+
+    val creds1 = adapter1.resolveCredentials()
+    val creds2 = adapter2.resolveCredentials()
+
+    assert(creds1.accessKeyId() == creds2.accessKeyId())
+    assert(creds1.secretAccessKey() == creds2.secretAccessKey())
+  }
+
+  test("is thread-safe for concurrent access") {
+    val callCount = new AtomicInteger(0)
+
+    val threadSafeProvider = new AWSCredentialsProvider {
+      override def getCredentials(): AWSCredentials = {
+        callCount.incrementAndGet()
+        // Small delay to increase chance of race conditions
+        Thread.sleep(1)
+        new BasicAWSCredentials("ACCESS", "SECRET")
+      }
+      override def refresh(): Unit = {}
+    }
+
+    val adapter = new V1ToV2CredentialsProviderAdapter(threadSafeProvider)
+
+    // Run 10 concurrent threads, each calling resolveCredentials 10 times
+    val threads = (1 to 10).map { _ =>
+      new Thread(() => {
+        (1 to 10).foreach { _ =>
+          adapter.resolveCredentials()
+        }
+      })
+    }
+
+    threads.foreach(_.start())
+    threads.foreach(_.join())
+
+    // All 100 calls should have completed successfully
+    assert(callCount.get() == 100)
+  }
+}


### PR DESCRIPTION
# Fix: Preserve Credential Refresh Logic for Custom AWS Credential Providers

## Summary

- Fix expired AWS token errors during commit operations when using Unity Catalog custom credential provider
- Add `V1ToV2CredentialsProviderAdapter` to wrap v1 credential providers and preserve their refresh logic
- Modify `S3CloudStorageProvider` to use the adapter instead of extracting credentials statically

## Problem

When using Unity Catalog's custom credential provider (`UnityCatalogAWSCredentialProvider`), AWS session tokens expire during long-running Spark jobs, causing authentication failures at commit time:

```
The security token included in the request is expired
```

### Root Cause

The issue was that credentials were being resolved **once** at `S3CloudStorageProvider` construction time and wrapped in a `StaticCredentialsProvider`. This happened when:

1. `IndexTables4SparkTable` is created (at DataFrame operation time)
2. `TransactionLogFactory.create()` creates an `OptimizedTransactionLog`
3. `S3CloudStorageProvider` is constructed with credentials resolved at that moment
4. `CredentialProviderFactory.resolveAWSCredentials()` extracts credentials via reflection
5. Credentials are wrapped in `StaticCredentialsProvider.create()`

For long-running jobs (e.g., 60+ minutes), by the time `commit()` is called, the original token had expired. The `UnityCatalogAWSCredentialProvider` has proper refresh logic, but it was completely bypassed because credentials were extracted once and stored statically.

### Timeline Example

```
T+0:    DataFrame.write() triggers table creation
        → TransactionLogFactory.create()
        → S3CloudStorageProvider created
        → Credentials resolved from Unity Catalog (valid for 1 hour)
        → StaticCredentialsProvider created with current credentials

T+30m:  Spark job processes data across executors
        (credentials still valid)

T+75m:  commit() called on transaction log
        → S3CloudStorageProvider.writeFileIfNotExists()
        → Uses original StaticCredentialsProvider
        → TOKEN EXPIRED! ❌
```

## Solution

### New: V1ToV2CredentialsProviderAdapter

Created a new adapter class that wraps AWS SDK v1 credential providers (`AWSCredentialsProvider`) and implements the AWS SDK v2 interface (`AwsCredentialsProvider`).

The key insight is that `resolveCredentials()` is called by the AWS SDK v2 **each time credentials are needed**, not just once. By delegating each call to the v1 provider's `getCredentials()` method, we preserve the provider's refresh logic:

```scala
class V1ToV2CredentialsProviderAdapter(v1Provider: AnyRef) extends AwsCredentialsProvider {
  override def resolveCredentials(): AwsCredentials = {
    // Delegates to v1 provider's getCredentials() - triggers refresh if needed
    val creds = CredentialProviderFactory.extractCredentialsViaReflection(v1Provider)
    // Convert to v2 credentials...
  }
}
```

### Modified: S3CloudStorageProvider.createAwsCredentialsProvider()

Updated the credential provider creation with new priority logic:

1. **Explicit credentials** (accessKey/secretKey) → `StaticCredentialsProvider` (fine, they don't expire)
2. **Custom provider class** → Wrap in `V1ToV2CredentialsProviderAdapter` (preserves refresh)
3. **v2 provider** → Use directly (already supports refresh)
4. **Default chain** → `DefaultCredentialsProvider`

### Corrected Timeline

```
T+0:    DataFrame.write() triggers table creation
        → S3CloudStorageProvider created
        → UnityCatalogAWSCredentialProvider wrapped in V1ToV2CredentialsProviderAdapter

T+30m:  Spark job processes data
        → S3 requests call resolveCredentials()
        → Adapter delegates to v1 provider
        → Provider returns cached credentials (still valid)

T+55m:  Credentials approaching expiration
        → S3 request calls resolveCredentials()
        → Adapter delegates to v1 provider
        → Provider detects near-expiration, refreshes from Unity Catalog
        → Fresh credentials returned ✅

T+75m:  commit() called
        → Uses fresh credentials
        → SUCCESS! ✅
```

## Files Changed

| File | Change |
|------|--------|
| `src/main/scala/io/indextables/spark/auth/V1ToV2CredentialsProviderAdapter.scala` | **NEW** - Adapter that wraps v1 providers to preserve refresh logic |
| `src/main/scala/io/indextables/spark/io/S3CloudStorageProvider.scala` | **MODIFIED** - Use adapter for custom provider classes |
| `src/test/scala/io/indextables/spark/auth/V1ToV2CredentialsProviderAdapterTest.scala` | **NEW** - Unit tests for the adapter |

## Test Plan

- [x] New unit tests for `V1ToV2CredentialsProviderAdapter` (9 tests)
  - Wraps v1 provider and delegates `resolveCredentials`
  - Handles basic credentials without session token
  - Calls v1 provider on each `resolveCredentials` call (preserves refresh)
  - Simulates credential refresh scenario
  - Returns wrapped provider via `getWrappedProvider`
  - Rejects null provider
  - Rejects non-v1 provider
  - Multiple adapters can wrap same provider
  - Thread-safe for concurrent access

- [x] Existing `CredentialProviderFactoryTest` tests pass (17 tests)
- [x] Existing `UnityCatalogAWSCredentialProviderTest` tests pass (15 tests)
- [x] Existing `S3CloudStorageProviderMultipartTest` tests pass (4 tests)

## Backward Compatibility

This change is fully backward compatible:

- **Explicit credentials**: Continue to use `StaticCredentialsProvider` (no change needed - they don't expire)
- **Custom v1 providers**: Now wrapped to preserve refresh logic (bug fix)
- **Custom v2 providers**: Used directly (no change)
- **Default credentials**: Continue to use `DefaultCredentialsProvider` (no change)

## Configuration

No configuration changes required. The fix applies automatically when using a custom credential provider class via:

```scala
spark.conf.set("spark.indextables.aws.credentialsProviderClass",
  "io.indextables.spark.auth.unity.UnityCatalogAWSCredentialProvider")
```