### PR TITLE
fix: ClassNotFoundException for Azure TokenCredential on AWS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -517,6 +517,7 @@
                                 <includes>
                                     <include>io.indextables:tantivy4java</include>
                                     <include>software.amazon.awssdk:*</include>
+                                    <include>com.azure:azure-core</include>
                                     <!-- <include>com.fasterxml.jackson.core:*</include>
                                     <include>com.fasterxml.jackson.module:*</include> -->
                                     <include>com.thoughtworks.paranamer:paranamer</include>


### PR DESCRIPTION
## Fix ClassNotFoundException for Azure TokenCredential on AWS

### Summary
- Add `com.azure:azure-core` to shaded JAR includes to fix `ClassNotFoundException: com.azure.identity.TokenCredential` when running merge operations on AWS

### Problem
After PR #80 (fix for Azure merge uploads), running `MERGE SPLITS` on AWS fails with:
```
java.lang.NoClassDefFoundError: com/azure/identity/TokenCredential
```

This occurs because `MergeUploader.scala` imports Azure SDK classes at the top level, and those classes weren't being bundled into the shaded JAR.

### Root Cause
The maven-shade-plugin's `artifactSet/includes` only bundled AWS SDK and a few other dependencies. Azure SDK dependencies (`azure-storage-blob`, `azure-identity`) were declared in pom.xml but not included in the shaded JAR.

### Fix
Add `com.azure:azure-core` to the shade plugin includes. This is the minimal dependency needed since `TokenCredential` interface is defined in `azure-core`, not `azure-identity`.

### Test plan
- [x] Build shaded JAR: `mvn clean package -DskipTests`
- [x] Verify azure-core is included in build output
- [x] Run `MERGE SPLITS` on AWS S3 table
- [ ] Run `MERGE SPLITS` on Azure table (if available)
