### PR TITLE
fix: Fix IndexQuery with Non-Existent Field Silent Failure

### DIFF
--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkSimpleAggregateScan.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkSimpleAggregateScan.scala
@@ -344,6 +344,9 @@ class IndexTables4SparkSimpleAggregateReader(
         logger.debug(s"SIMPLE AGGREGATE READER INITIALIZE: First result contains ${results.head.numFields} fields")
       }
     } catch {
+      case e: IllegalArgumentException =>
+        // Rethrow field validation errors - these should propagate to the user
+        throw e
       case e: Exception =>
         logger.error(s"SIMPLE AGGREGATE READER INITIALIZE: Failed to execute simple aggregation", e)
         // Return empty results on failure
@@ -816,6 +819,13 @@ class IndexTables4SparkSimpleAggregateReader(
       }
 
     } catch {
+      case e: IllegalArgumentException =>
+        // Rethrow field validation errors - these should propagate to the user
+        logger.error(
+          s"SIMPLE AGGREGATE EXECUTION: Field validation error for split ${partition.split.path}",
+          e
+        )
+        throw e
       case e: Exception =>
         logger.error(
           s"SIMPLE AGGREGATE EXECUTION: Failed to execute simple aggregation for split ${partition.split.path}",

--- a/src/test/scala/io/indextables/spark/indexquery/IndexQueryNonExistentFieldTest.scala
+++ b/src/test/scala/io/indextables/spark/indexquery/IndexQueryNonExistentFieldTest.scala
@@ -1,0 +1,560 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.indexquery
+
+import io.indextables.spark.TestBase
+import org.apache.spark.SparkException
+
+/**
+ * Test that IndexQuery with non-existent field throws a descriptive error.
+ *
+ * Previously, the system would silently ignore the predicate and return all documents,
+ * which led to incorrect results without any indication of the problem.
+ */
+class IndexQueryNonExistentFieldTest extends TestBase {
+
+  test("IndexQuery with non-existent field should throw descriptive error") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_nonexistent_field_test"
+
+    // Create test data with known fields
+    val testData = Seq(
+      (1, "machine learning algorithms", "tech"),
+      (2, "data engineering pipeline", "tech"),
+      (3, "web development", "tech")
+    ).toDF("id", "title", "category")
+
+    // Write with text field for title
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.title", "text")
+      .option("spark.indextables.indexing.typemap.category", "string")
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("test_table")
+
+    // Test: IndexQuery with a field that doesn't exist should throw an error
+    val exception = intercept[SparkException] {
+      spark
+        .sql("""
+        SELECT id, title FROM test_table
+        WHERE fake_field indexquery 'something'
+      """)
+        .collect()
+    }
+
+    // Verify the error message is descriptive
+    val errorMessage = exception.getMessage + Option(exception.getCause).map(_.getMessage).getOrElse("")
+
+    assert(
+      errorMessage.contains("fake_field") || errorMessage.contains("does not exist") ||
+        errorMessage.contains("not found"),
+      s"Error message should mention the non-existent field. Actual message: $errorMessage"
+    )
+
+    // Verify available fields are listed in the error
+    assert(
+      errorMessage.contains("title") || errorMessage.contains("category") || errorMessage.contains("id"),
+      s"Error message should list available fields. Actual message: $errorMessage"
+    )
+  }
+
+  test("IndexQuery with existing field should work normally") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_existing_field_test"
+
+    val testData = Seq(
+      (1, "machine learning algorithms", "tech"),
+      (2, "data engineering pipeline", "tech"),
+      (3, "web development", "tech")
+    ).toDF("id", "title", "category")
+
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.title", "text")
+      .option("spark.indextables.indexing.typemap.category", "string")
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("test_table_existing")
+
+    // This should work fine - "title" is a valid field
+    val results = spark
+      .sql("""
+        SELECT id, title FROM test_table_existing
+        WHERE title indexquery 'machine'
+      """)
+      .collect()
+
+    assert(results.length == 1, s"Expected 1 result, got ${results.length}")
+    assert(results(0).getInt(0) == 1, s"Expected id=1, got ${results(0).getInt(0)}")
+  }
+
+  test("IndexQuery error message should include available fields") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_error_message_test"
+
+    val testData = Seq(
+      (1, "test content", "category1", 100.0)
+    ).toDF("id", "content", "category", "score")
+
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.content", "text")
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("test_table_error_msg")
+
+    val exception = intercept[SparkException] {
+      spark
+        .sql("""
+        SELECT * FROM test_table_error_msg
+        WHERE nonexistent_column indexquery 'test'
+      """)
+        .collect()
+    }
+
+    val fullErrorMessage = getFullErrorMessage(exception)
+
+    // The error should mention available fields to help the user
+    assert(
+      fullErrorMessage.contains("Available fields") || fullErrorMessage.contains("available fields"),
+      s"Error should mention available fields. Got: $fullErrorMessage"
+    )
+  }
+
+  test("Simple SELECT with IndexQuery on non-existent field should throw error") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_simple_select_test"
+
+    val testData = Seq(
+      (1, "machine learning", 100.0),
+      (2, "data science", 200.0),
+      (3, "deep learning", 150.0)
+    ).toDF("id", "title", "score")
+
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.title", "text")
+      .option("spark.indextables.indexing.fastfields", "score")
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("simple_select_test")
+
+    // Simple SELECT with non-existent field should fail
+    val exception = intercept[SparkException] {
+      spark
+        .sql("""
+        SELECT id, title FROM simple_select_test
+        WHERE bogus_field indexquery 'learning'
+      """)
+        .collect()
+    }
+
+    val fullErrorMessage = getFullErrorMessage(exception)
+    assert(
+      fullErrorMessage.contains("bogus_field") && fullErrorMessage.contains("non-existent"),
+      s"Error should mention the non-existent field 'bogus_field'. Got: $fullErrorMessage"
+    )
+  }
+
+  test("COUNT aggregation with IndexQuery on non-existent field should throw error") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_count_agg_test"
+
+    val testData = Seq(
+      (1, "machine learning", 100.0),
+      (2, "data science", 200.0),
+      (3, "deep learning", 150.0)
+    ).toDF("id", "title", "score")
+
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.title", "text")
+      .option("spark.indextables.indexing.fastfields", "score")
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("count_agg_test")
+
+    // COUNT with IndexQuery on non-existent field should fail
+    // Can throw either SparkException or IllegalArgumentException depending on execution path
+    val exception = intercept[Exception] {
+      spark
+        .sql("""
+        SELECT COUNT(*) FROM count_agg_test
+        WHERE invalid_column indexquery 'learning'
+      """)
+        .collect()
+    }
+
+    val fullErrorMessage = getFullErrorMessage(exception)
+    assert(
+      fullErrorMessage.contains("invalid_column") && fullErrorMessage.contains("non-existent"),
+      s"Error should mention the non-existent field 'invalid_column'. Got: $fullErrorMessage"
+    )
+  }
+
+  test("SUM aggregation with IndexQuery on non-existent field should throw error") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_sum_agg_test"
+
+    val testData = Seq(
+      (1, "machine learning", 100.0),
+      (2, "data science", 200.0),
+      (3, "deep learning", 150.0)
+    ).toDF("id", "title", "score")
+
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.title", "text")
+      .option("spark.indextables.indexing.fastfields", "score")
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("sum_agg_test")
+
+    // SUM with IndexQuery on non-existent field should fail
+    // Can throw either SparkException or IllegalArgumentException depending on execution path
+    val exception = intercept[Exception] {
+      spark
+        .sql("""
+        SELECT SUM(score) FROM sum_agg_test
+        WHERE does_not_exist indexquery 'machine'
+      """)
+        .collect()
+    }
+
+    val fullErrorMessage = getFullErrorMessage(exception)
+    assert(
+      fullErrorMessage.contains("does_not_exist") && fullErrorMessage.contains("non-existent"),
+      s"Error should mention the non-existent field 'does_not_exist'. Got: $fullErrorMessage"
+    )
+  }
+
+  test("COUNT aggregation with IndexQuery on existing field should work") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_count_existing_test"
+
+    val testData = Seq(
+      (1, "machine learning algorithms", 100.0),
+      (2, "data science pipeline", 200.0),
+      (3, "deep learning neural networks", 150.0)
+    ).toDF("id", "title", "score")
+
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.title", "text")
+      .option("spark.indextables.indexing.fastfields", "score")
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("count_existing_test")
+
+    // COUNT with IndexQuery on valid field should work
+    val results = spark
+      .sql("""
+        SELECT COUNT(*) FROM count_existing_test
+        WHERE title indexquery 'learning'
+      """)
+      .collect()
+
+    // "learning" appears in "machine learning algorithms" and "deep learning neural networks"
+    assert(results.length == 1, s"Expected 1 row, got ${results.length}")
+    assert(results(0).getLong(0) == 2, s"Expected count of 2, got ${results(0).getLong(0)}")
+  }
+
+  test("SUM aggregation with IndexQuery on existing field should work") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_sum_existing_test"
+
+    val testData = Seq(
+      (1, "machine learning algorithms", 100.0),
+      (2, "data science pipeline", 200.0),
+      (3, "deep learning neural networks", 150.0)
+    ).toDF("id", "title", "score")
+
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.title", "text")
+      .option("spark.indextables.indexing.fastfields", "score")
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("sum_existing_test")
+
+    // SUM with IndexQuery on valid field should work
+    val results = spark
+      .sql("""
+        SELECT SUM(score) FROM sum_existing_test
+        WHERE title indexquery 'learning'
+      """)
+      .collect()
+
+    // "learning" appears in rows with score 100.0 and 150.0
+    assert(results.length == 1, s"Expected 1 row, got ${results.length}")
+    assert(results(0).getDouble(0) == 250.0, s"Expected sum of 250.0, got ${results(0).getDouble(0)}")
+  }
+
+  test("GROUP BY with IndexQuery on non-existent field should throw error") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_groupby_nonexistent_test"
+
+    val testData = Seq(
+      (1, "machine learning", "tech", 100.0),
+      (2, "data science", "tech", 200.0),
+      (3, "deep learning", "ai", 150.0),
+      (4, "neural networks", "ai", 175.0)
+    ).toDF("id", "title", "category", "score")
+
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.title", "text")
+      .option("spark.indextables.indexing.typemap.category", "string")
+      .option("spark.indextables.indexing.fastfields", "score,category") // category needed for GROUP BY
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("groupby_nonexistent_test")
+
+    // GROUP BY with IndexQuery on non-existent field should fail
+    // Can throw either SparkException or IllegalArgumentException depending on execution path
+    val exception = intercept[Exception] {
+      spark
+        .sql("""
+        SELECT category, COUNT(*), SUM(score)
+        FROM groupby_nonexistent_test
+        WHERE nonexistent_field indexquery 'learning'
+        GROUP BY category
+      """)
+        .collect()
+    }
+
+    val fullErrorMessage = getFullErrorMessage(exception)
+    assert(
+      fullErrorMessage.contains("nonexistent_field") && fullErrorMessage.contains("non-existent"),
+      s"Error should mention the non-existent field 'nonexistent_field'. Got: $fullErrorMessage"
+    )
+  }
+
+  test("GROUP BY with IndexQuery on existing field should work") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_groupby_existing_test"
+
+    val testData = Seq(
+      (1, "machine learning algorithms", "tech", 100.0),
+      (2, "data science pipeline", "tech", 200.0),
+      (3, "deep learning neural networks", "ai", 150.0),
+      (4, "neural networks training", "ai", 175.0)
+    ).toDF("id", "title", "category", "score")
+
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.title", "text")
+      .option("spark.indextables.indexing.typemap.category", "string")
+      .option("spark.indextables.indexing.fastfields", "score,category") // category needed for GROUP BY
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("groupby_existing_test")
+
+    // GROUP BY with IndexQuery on valid field should work
+    // "learning" appears in "machine learning algorithms" (tech) and "deep learning neural networks" (ai)
+    val results = spark
+      .sql("""
+        SELECT category, COUNT(*) as cnt, SUM(score) as total
+        FROM groupby_existing_test
+        WHERE title indexquery 'learning'
+        GROUP BY category
+        ORDER BY category
+      """)
+      .collect()
+
+    assert(results.length == 2, s"Expected 2 categories, got ${results.length}")
+
+    // ai: 1 doc (deep learning neural networks), score 150.0
+    // tech: 1 doc (machine learning algorithms), score 100.0
+    val aiRow   = results.find(_.getString(0) == "ai").get
+    val techRow = results.find(_.getString(0) == "tech").get
+
+    assert(aiRow.getLong(1) == 1, s"Expected ai count 1, got ${aiRow.getLong(1)}")
+    assert(aiRow.getDouble(2) == 150.0, s"Expected ai sum 150.0, got ${aiRow.getDouble(2)}")
+    assert(techRow.getLong(1) == 1, s"Expected tech count 1, got ${techRow.getLong(1)}")
+    assert(techRow.getDouble(2) == 100.0, s"Expected tech sum 100.0, got ${techRow.getDouble(2)}")
+  }
+
+  test("Complex aggregation (AVG, MAX, MIN) with IndexQuery on non-existent field should throw error") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_complex_agg_nonexistent_test"
+
+    val testData = Seq(
+      (1, "machine learning", 100.0),
+      (2, "data science", 200.0),
+      (3, "deep learning", 150.0)
+    ).toDF("id", "title", "score")
+
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.title", "text")
+      .option("spark.indextables.indexing.fastfields", "score")
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("complex_agg_nonexistent_test")
+
+    // Complex aggregation with IndexQuery on non-existent field should fail
+    // Can throw either SparkException or IllegalArgumentException depending on execution path
+    val exception = intercept[Exception] {
+      spark
+        .sql("""
+        SELECT AVG(score), MAX(score), MIN(score)
+        FROM complex_agg_nonexistent_test
+        WHERE missing_column indexquery 'learning'
+      """)
+        .collect()
+    }
+
+    val fullErrorMessage = getFullErrorMessage(exception)
+    assert(
+      fullErrorMessage.contains("missing_column") && fullErrorMessage.contains("non-existent"),
+      s"Error should mention the non-existent field 'missing_column'. Got: $fullErrorMessage"
+    )
+  }
+
+  test("Complex aggregation with IndexQuery on existing field should work") {
+    val spark = this.spark
+    import spark.implicits._
+
+    val testPath = s"$tempDir/indexquery_complex_agg_existing_test"
+
+    val testData = Seq(
+      (1, "machine learning algorithms", 100.0),
+      (2, "data science pipeline", 200.0),
+      (3, "deep learning neural networks", 150.0)
+    ).toDF("id", "title", "score")
+
+    testData.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.title", "text")
+      .option("spark.indextables.indexing.fastfields", "score")
+      .mode("overwrite")
+      .save(testPath)
+
+    val df = spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .load(testPath)
+
+    df.createOrReplaceTempView("complex_agg_existing_test")
+
+    // Complex aggregation with IndexQuery on valid field should work
+    // "learning" matches rows with scores 100.0 and 150.0
+    val results = spark
+      .sql("""
+        SELECT AVG(score), MAX(score), MIN(score)
+        FROM complex_agg_existing_test
+        WHERE title indexquery 'learning'
+      """)
+      .collect()
+
+    assert(results.length == 1, s"Expected 1 row, got ${results.length}")
+    assert(results(0).getDouble(0) == 125.0, s"Expected avg 125.0, got ${results(0).getDouble(0)}")
+    assert(results(0).getDouble(1) == 150.0, s"Expected max 150.0, got ${results(0).getDouble(1)}")
+    assert(results(0).getDouble(2) == 100.0, s"Expected min 100.0, got ${results(0).getDouble(2)}")
+  }
+
+  private def getFullErrorMessage(e: Throwable): String = {
+    val messages = scala.collection.mutable.ArrayBuffer[String]()
+    var current: Throwable = e
+    while (current != null) {
+      if (current.getMessage != null) {
+        messages += current.getMessage
+      }
+      current = current.getCause
+    }
+    messages.mkString(" -> ")
+  }
+}


### PR DESCRIPTION
# PR: Fix IndexQuery with Non-Existent Field Silent Failure

## Summary

This PR fixes a bug where using `indexquery` with a non-existent field would silently ignore the predicate and return all documents, rather than failing with a descriptive error message.

**Before:** `WHERE fake_field indexquery 'something'` would return all documents without any warning
**After:** Throws `IllegalArgumentException` with message: `IndexQuery references non-existent field 'fake_field'. Available fields are: [id, title, category, ...]`

## Problem

When a user specified an IndexQuery filter on a field that doesn't exist in the schema, the system would:
1. Log a warning message (not visible to users)
2. Return a "match-all" query that matches every document
3. Complete successfully, returning incorrect results

This "graceful degradation" pattern made debugging very difficult because queries would appear to work but return unexpected results.

## Solution

The fix validates IndexQuery field names at multiple points in the query execution pipeline:

### 1. Filter Validation (`FiltersToQueryConverter.scala`)
Modified `isMixedFilterValidForSchema()` to throw an exception when an IndexQuery references a non-existent field, instead of silently filtering it out.

```scala
// For IndexQuery filters, throw an exception with a descriptive error message
filter match {
  case indexQuery: IndexQueryFilter =>
    throw new IllegalArgumentException(
      s"IndexQuery references non-existent field '${indexQuery.columnName}'. " +
        s"Available fields are: [$availableFields]"
    )
  // ... also handles IndexQueryV2Filter
}
```

### 2. Aggregate Pushdown Validation (`IndexTables4SparkScanBuilder.scala`)
Added `validateIndexQueryFieldsExist()` method that runs during aggregate pushdown to catch non-existent fields early. Modified the exception handling to rethrow IndexQuery validation errors instead of silently rejecting pushdown.

```scala
case e: IllegalArgumentException if e.getMessage.contains("IndexQuery references non-existent") =>
  // Rethrow IndexQuery field validation errors - these should fail the query
  throw e
```

### 3. Aggregate Execution (`IndexTables4SparkSimpleAggregateScan.scala`)
Modified exception handling in `initialize()` and `executeSimpleAggregation()` to rethrow `IllegalArgumentException` for field validation errors instead of returning empty results.

## Files Changed

- `src/main/scala/io/indextables/spark/core/FiltersToQueryConverter.scala`
  - Modified `isMixedFilterValidForSchema()` to throw exception for IndexQuery on non-existent fields
  - Added handling for `IndexQueryV2Filter` and `IndexQueryAllV2Filter`
  - Cleaned up redundant validation code in conversion methods

- `src/main/scala/io/indextables/spark/core/IndexTables4SparkScanBuilder.scala`
  - Added `validateIndexQueryFieldsExist()` method for early field validation
  - Added `getSchemaFieldNames()` helper method
  - Modified `pushAggregation()` to rethrow IndexQuery validation errors

- `src/main/scala/io/indextables/spark/core/IndexTables4SparkSimpleAggregateScan.scala`
  - Modified exception handling to rethrow `IllegalArgumentException` in `initialize()` and `executeSimpleAggregation()`

- `src/test/scala/io/indextables/spark/indexquery/IndexQueryNonExistentFieldTest.scala` (new)
  - 12 comprehensive tests covering simple queries, COUNT, SUM, AVG/MAX/MIN, and GROUP BY aggregations

## Test Coverage

The new test suite covers:

| Test Case | Description |
|-----------|-------------|
| Simple SELECT with non-existent field | Throws error with field name and available fields |
| Simple SELECT with existing field | Works correctly, returns matching documents |
| COUNT aggregation with non-existent field | Throws error |
| COUNT aggregation with existing field | Returns correct count |
| SUM aggregation with non-existent field | Throws error |
| SUM aggregation with existing field | Returns correct sum |
| GROUP BY with non-existent field | Throws error |
| GROUP BY with existing field | Returns correct grouped results |
| Complex aggregation (AVG/MAX/MIN) with non-existent field | Throws error |
| Complex aggregation with existing field | Returns correct values |
| Error message includes available fields | Validates error message format |

## Error Message Format

The error message is designed to help users quickly identify and fix the issue:

```
IndexQuery references non-existent field 'fake_field'. Available fields are: [category, id, score, title]
```

## Design Notes

The fix implements **layered validation** at multiple points:

1. **Planning-time validation** (`validateIndexQueryFieldsExist()` in ScanBuilder)
   - Validates against Spark schema
   - Provides early error detection before execution starts

2. **Execution-time validation** (`isMixedFilterValidForSchema()` in FiltersToQueryConverter)
   - Validates against Tantivy schema (actual indexed fields)
   - Authoritative check for all code paths

This dual validation is intentional because:
- Spark schema may include partition columns not in the tantivy index
- Early validation provides better user experience (fails during planning)
- Tantivy schema validation ensures indexed fields are validated

## Breaking Changes

None. The behavior change only affects queries that were previously returning incorrect results due to the silent failure. Users whose queries were silently ignoring IndexQuery predicates will now get clear error messages.

## Testing Instructions

```bash
# Run the new tests
mvn test-compile scalatest:test -DwildcardSuites='io.indextables.spark.indexquery.IndexQueryNonExistentFieldTest'

# Manually test with a non-existent field
spark.sql("SELECT * FROM my_table WHERE nonexistent indexquery 'test'").show()
# Should throw: IllegalArgumentException: IndexQuery references non-existent field 'nonexistent'...
```

## Related Issues

- Fixes silent failure behavior for IndexQuery with non-existent fields
- Improves user experience by providing actionable error messages
