### PR TITLE
feature: Auto-Selection of read splitsPerTask

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,13 @@ spark.indextables.cache.disk.manifestSyncInterval: 30 (default: 30 seconds)
 // Read Limits (controls default result set size when no explicit LIMIT is specified)
 spark.indextables.read.defaultLimit: 250 (default: 250, maximum documents per partition when no LIMIT pushed down)
 
+// Splits Per Task (controls batching of splits into Spark tasks)
+// Auto-selection: 1 split/task for small tables (≤2×parallelism), batched for larger tables
+spark.indextables.read.splitsPerTask: "auto" (default: auto, or numeric value to override)
+spark.indextables.read.maxSplitsPerTask: 8 (default: 8, cap for auto-selection)
+spark.indextables.read.aggregate.splitsPerTask: (falls back to read.splitsPerTask)
+spark.indextables.read.aggregate.maxSplitsPerTask: (falls back to read.maxSplitsPerTask)
+
 // Partition Pruning Optimization (reduces complexity from O(n*f) to O(p*f) where n=files, p=partitions, f=filters)
 spark.indextables.partitionPruning.filterCacheEnabled: true (default: true, LRU cache for filter evaluations)
 spark.indextables.partitionPruning.indexEnabled: true (default: true, O(1) index lookup for equality/IN filters)

--- a/src/test/scala/io/indextables/spark/util/SplitsPerTaskCalculatorTest.scala
+++ b/src/test/scala/io/indextables/spark/util/SplitsPerTaskCalculatorTest.scala
@@ -1,0 +1,495 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.util
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Unit tests for SplitsPerTaskCalculator auto-selection algorithm.
+ *
+ * Algorithm summary:
+ * - If totalSplits <= defaultParallelism × 2: use 1 split per task (maximize parallelism)
+ * - Otherwise: ensure at least 4 × defaultParallelism groups, capped at maxSplitsPerTask
+ */
+class SplitsPerTaskCalculatorTest extends AnyFunSuite with Matchers {
+
+  // ============================================================================
+  // AUTO-SELECTION: SMALL TABLE TESTS
+  // ============================================================================
+
+  test("small table: 1 split with 4 cores returns 1 split per task") {
+    // 1 <= 4*2=8, so maximize parallelism
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 1,
+      defaultParallelism = 4,
+      configuredValue = None
+    )
+    result shouldBe 1
+  }
+
+  test("small table: splits at threshold returns 1 split per task") {
+    // 8 <= 4*2=8, so maximize parallelism (boundary case)
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 8,
+      defaultParallelism = 4,
+      configuredValue = None
+    )
+    result shouldBe 1
+  }
+
+  test("small table: splits just below threshold returns 1 split per task") {
+    // 7 <= 4*2=8, so maximize parallelism
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 7,
+      defaultParallelism = 4,
+      configuredValue = None
+    )
+    result shouldBe 1
+  }
+
+  test("small table: large cluster with few splits returns 1 split per task") {
+    // 100 <= 64*2=128, so maximize parallelism
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = 64,
+      configuredValue = None
+    )
+    result shouldBe 1
+  }
+
+  test("small table: splits exactly at threshold with large cluster returns 1") {
+    // 128 <= 64*2=128, boundary case
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 128,
+      defaultParallelism = 64,
+      configuredValue = None
+    )
+    result shouldBe 1
+  }
+
+  // ============================================================================
+  // AUTO-SELECTION: LARGE TABLE TESTS
+  // ============================================================================
+
+  test("large table: splits just above threshold triggers batching") {
+    // 9 > 4*2=8, target groups = 4*4=16
+    // splitsPerTask = ceil(9/16) = 1
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 9,
+      defaultParallelism = 4,
+      configuredValue = None
+    )
+    result shouldBe 1
+  }
+
+  test("large table: 32 splits with 4 cores returns 2 splits per task") {
+    // 32 > 4*2=8, target groups = 4*4=16
+    // splitsPerTask = ceil(32/16) = 2
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 32,
+      defaultParallelism = 4,
+      configuredValue = None
+    )
+    result shouldBe 2
+  }
+
+  test("large table: 64 splits with 4 cores returns 4 splits per task") {
+    // 64 > 4*2=8, target groups = 4*4=16
+    // splitsPerTask = ceil(64/16) = 4
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 64,
+      defaultParallelism = 4,
+      configuredValue = None
+    )
+    result shouldBe 4
+  }
+
+  test("large table: 128 splits with 4 cores returns 8 (capped at default max)") {
+    // 128 > 4*2=8, target groups = 4*4=16
+    // splitsPerTask = ceil(128/16) = 8, capped at default max 8
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 128,
+      defaultParallelism = 4,
+      configuredValue = None
+    )
+    result shouldBe 8
+  }
+
+  test("large table: 256 splits with 4 cores returns 8 (capped)") {
+    // 256 > 4*2=8, target groups = 4*4=16
+    // splitsPerTask = ceil(256/16) = 16, capped at default max 8
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 256,
+      defaultParallelism = 4,
+      configuredValue = None
+    )
+    result shouldBe 8
+  }
+
+  test("large table: 512 splits with 64 cores returns 2 splits per task") {
+    // 512 > 64*2=128, target groups = 64*4=256
+    // splitsPerTask = ceil(512/256) = 2
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 512,
+      defaultParallelism = 64,
+      configuredValue = None
+    )
+    result shouldBe 2
+  }
+
+  test("large table: 1024 splits with 64 cores returns 4 splits per task") {
+    // 1024 > 64*2=128, target groups = 64*4=256
+    // splitsPerTask = ceil(1024/256) = 4
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 1024,
+      defaultParallelism = 64,
+      configuredValue = None
+    )
+    result shouldBe 4
+  }
+
+  test("large table: 2048 splits with 64 cores returns 8 (capped)") {
+    // 2048 > 64*2=128, target groups = 64*4=256
+    // splitsPerTask = ceil(2048/256) = 8, at default max
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 2048,
+      defaultParallelism = 64,
+      configuredValue = None
+    )
+    result shouldBe 8
+  }
+
+  test("large table: 10000 splits with 64 cores returns 8 (capped)") {
+    // 10000 > 64*2=128, target groups = 64*4=256
+    // splitsPerTask = ceil(10000/256) = 40, capped at default max 8
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 10000,
+      defaultParallelism = 64,
+      configuredValue = None
+    )
+    result shouldBe 8
+  }
+
+  // ============================================================================
+  // CUSTOM MAX SPLITS PER TASK
+  // ============================================================================
+
+  test("custom max: higher cap allows more splits per task") {
+    // 256 > 4*2=8, target groups = 4*4=16
+    // splitsPerTask = ceil(256/16) = 16, with custom cap 16
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 256,
+      defaultParallelism = 4,
+      configuredValue = None,
+      maxSplitsPerTask = 16
+    )
+    result shouldBe 16
+  }
+
+  test("custom max: lower cap reduces splits per task") {
+    // 64 > 4*2=8, target groups = 4*4=16
+    // splitsPerTask = ceil(64/16) = 4, capped at custom max 2
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 64,
+      defaultParallelism = 4,
+      configuredValue = None,
+      maxSplitsPerTask = 2
+    )
+    result shouldBe 2
+  }
+
+  test("custom max: cap of 1 forces single-split tasks") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 1000,
+      defaultParallelism = 64,
+      configuredValue = None,
+      maxSplitsPerTask = 1
+    )
+    result shouldBe 1
+  }
+
+  // ============================================================================
+  // EXPLICIT NUMERIC CONFIGURATION
+  // ============================================================================
+
+  test("explicit config: numeric value overrides auto-selection") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = 64,
+      configuredValue = Some("4")
+    )
+    result shouldBe 4
+  }
+
+  test("explicit config: value 1 returns 1") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 1000,
+      defaultParallelism = 64,
+      configuredValue = Some("1")
+    )
+    result shouldBe 1
+  }
+
+  test("explicit config: large value is used as-is") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = 4,
+      configuredValue = Some("100")
+    )
+    result shouldBe 100
+  }
+
+  test("explicit config: zero is treated as 1 (minimum)") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = 4,
+      configuredValue = Some("0")
+    )
+    result shouldBe 1
+  }
+
+  test("explicit config: negative is treated as 1 (minimum)") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = 4,
+      configuredValue = Some("-5")
+    )
+    result shouldBe 1
+  }
+
+  // ============================================================================
+  // AUTO KEYWORD AND INVALID VALUES
+  // ============================================================================
+
+  test("auto keyword: 'auto' triggers auto-selection") {
+    // "auto" is not a valid integer, so auto-selection is used
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = 64,
+      configuredValue = Some("auto")
+    )
+    // 100 <= 64*2=128, so maximize parallelism
+    result shouldBe 1
+  }
+
+  test("auto keyword: empty string triggers auto-selection") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = 64,
+      configuredValue = Some("")
+    )
+    result shouldBe 1
+  }
+
+  test("auto keyword: invalid string triggers auto-selection") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = 64,
+      configuredValue = Some("invalid")
+    )
+    result shouldBe 1
+  }
+
+  test("auto keyword: None triggers auto-selection") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = 64,
+      configuredValue = None
+    )
+    result shouldBe 1
+  }
+
+  // ============================================================================
+  // EDGE CASES
+  // ============================================================================
+
+  test("edge case: zero splits returns 1") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 0,
+      defaultParallelism = 4,
+      configuredValue = None
+    )
+    result shouldBe 1
+  }
+
+  test("edge case: single split returns 1") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 1,
+      defaultParallelism = 64,
+      configuredValue = None
+    )
+    result shouldBe 1
+  }
+
+  test("edge case: zero parallelism is guarded to 1") {
+    // With parallelism=1, threshold=2, target groups=4
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = 0,
+      configuredValue = None
+    )
+    // 100 > 1*2=2, target groups = 1*4=4
+    // splitsPerTask = ceil(100/4) = 25, capped at 8
+    result shouldBe 8
+  }
+
+  test("edge case: negative parallelism is guarded to 1") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = -5,
+      configuredValue = None
+    )
+    result shouldBe 8
+  }
+
+  test("edge case: very large split count") {
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 1000000,
+      defaultParallelism = 64,
+      configuredValue = None
+    )
+    // Always capped at maxSplitsPerTask
+    result shouldBe 8
+  }
+
+  test("edge case: single core cluster with many splits") {
+    // 100 > 1*2=2, target groups = 1*4=4
+    // splitsPerTask = ceil(100/4) = 25, capped at 8
+    val result = SplitsPerTaskCalculator.calculate(
+      totalSplits = 100,
+      defaultParallelism = 1,
+      configuredValue = None
+    )
+    result shouldBe 8
+  }
+
+  // ============================================================================
+  // RESULTING GROUP COUNT VERIFICATION
+  // ============================================================================
+
+  test("group count: small table achieves maximum parallelism") {
+    val totalSplits = 8
+    val parallelism = 4
+    val splitsPerTask = SplitsPerTaskCalculator.calculate(
+      totalSplits = totalSplits,
+      defaultParallelism = parallelism,
+      configuredValue = None
+    )
+    val groups = math.ceil(totalSplits.toDouble / splitsPerTask).toInt
+    groups shouldBe 8 // Full parallelism
+  }
+
+  test("group count: large table achieves approximately 4x parallelism groups") {
+    val totalSplits = 1024  // Use power of 2 for exact division
+    val parallelism = 64
+    val splitsPerTask = SplitsPerTaskCalculator.calculate(
+      totalSplits = totalSplits,
+      defaultParallelism = parallelism,
+      configuredValue = None
+    )
+    val groups       = math.ceil(totalSplits.toDouble / splitsPerTask).toInt
+    val targetGroups = parallelism * 4  // 256
+    // Algorithm: splitsPerTask = ceil(1024/256) = 4, groups = 1024/4 = 256
+    groups shouldBe targetGroups
+  }
+
+  test("group count: large table with non-exact division achieves close to target") {
+    val totalSplits = 1000
+    val parallelism = 64
+    val splitsPerTask = SplitsPerTaskCalculator.calculate(
+      totalSplits = totalSplits,
+      defaultParallelism = parallelism,
+      configuredValue = None
+    )
+    val groups       = math.ceil(totalSplits.toDouble / splitsPerTask).toInt
+    val targetGroups = parallelism * 4  // 256
+    // Algorithm: splitsPerTask = ceil(1000/256) = 4, groups = ceil(1000/4) = 250
+    // We get close to target (within 10%), but not exactly due to ceiling
+    splitsPerTask shouldBe 4
+    groups shouldBe 250
+    groups.toDouble / targetGroups should be >= 0.9  // Within 10% of target
+  }
+
+  test("group count: very large table still respects max splits cap") {
+    val totalSplits = 100000
+    val parallelism = 64
+    val splitsPerTask = SplitsPerTaskCalculator.calculate(
+      totalSplits = totalSplits,
+      defaultParallelism = parallelism,
+      configuredValue = None
+    )
+    splitsPerTask shouldBe 8 // Default max
+    val groups = math.ceil(totalSplits.toDouble / splitsPerTask).toInt
+    groups shouldBe 12500 // 100000/8
+  }
+
+  // ============================================================================
+  // DEFAULT CONSTANT
+  // ============================================================================
+
+  test("DefaultMaxSplitsPerTask constant should be 8") {
+    SplitsPerTaskCalculator.DefaultMaxSplitsPerTask shouldBe 8
+  }
+
+  // ============================================================================
+  // COMPREHENSIVE EXAMPLES FROM DESIGN DOC
+  // ============================================================================
+
+  test("design doc example: small cluster (4 cores) table progression") {
+    val parallelism = 4
+    // threshold = 4*2 = 8
+    // target groups = 4*4 = 16
+
+    // 8 splits: at threshold, returns 1
+    SplitsPerTaskCalculator.calculate(8, parallelism, None) shouldBe 1
+
+    // 16 splits: above threshold, ceil(16/16)=1
+    SplitsPerTaskCalculator.calculate(16, parallelism, None) shouldBe 1
+
+    // 32 splits: ceil(32/16)=2
+    SplitsPerTaskCalculator.calculate(32, parallelism, None) shouldBe 2
+
+    // 64 splits: ceil(64/16)=4
+    SplitsPerTaskCalculator.calculate(64, parallelism, None) shouldBe 4
+
+    // 256 splits: ceil(256/16)=16, capped at 8
+    SplitsPerTaskCalculator.calculate(256, parallelism, None) shouldBe 8
+  }
+
+  test("design doc example: large cluster (64 cores) table progression") {
+    val parallelism = 64
+    // threshold = 64*2 = 128
+    // target groups = 64*4 = 256
+
+    // 128 splits: at threshold, returns 1
+    SplitsPerTaskCalculator.calculate(128, parallelism, None) shouldBe 1
+
+    // 256 splits: above threshold, ceil(256/256)=1
+    SplitsPerTaskCalculator.calculate(256, parallelism, None) shouldBe 1
+
+    // 512 splits: ceil(512/256)=2
+    SplitsPerTaskCalculator.calculate(512, parallelism, None) shouldBe 2
+
+    // 1024 splits: ceil(1024/256)=4
+    SplitsPerTaskCalculator.calculate(1024, parallelism, None) shouldBe 4
+
+    // 4096 splits: ceil(4096/256)=16, capped at 8
+    SplitsPerTaskCalculator.calculate(4096, parallelism, None) shouldBe 8
+  }
+}


### PR DESCRIPTION
# Auto-Selection of splitsPerTask

## Summary

Implements automatic `splitsPerTask` selection based on cluster size and split count. This enhancement to PR #117 intelligently adjusts the number of splits per Spark task to optimize parallelism for small tables while reducing scheduler overhead for large tables.

## Motivation

The previous implementation used a fixed default of 2 splits per task, which:
- Under-utilizes cluster parallelism for small tables (could run more tasks in parallel)
- May create excessive tasks for very large tables (scheduler overhead)

Auto-selection dynamically adjusts based on the actual workload and cluster size.

## Algorithm

```
totalSplits = number of splits after data skipping
defaultParallelism = spark.sparkContext.defaultParallelism
maxSplitsPerTask = spark.indextables.read.maxSplitsPerTask (default: 8)
minTargetGroups = 4 × defaultParallelism

if (totalSplits <= defaultParallelism × 2) {
    // Small table: maximize parallelism
    splitsPerTask = 1
} else {
    // Large table: batch splits while ensuring at least minTargetGroups
    splitsPerTask = ceil(totalSplits / minTargetGroups)
    splitsPerTask = min(maxSplitsPerTask, splitsPerTask)
    splitsPerTask = max(1, splitsPerTask)
}
```

### Key Design Decisions

1. **Threshold at 2× parallelism**: Below this, the cluster can easily handle all splits as separate tasks with minimal scheduler overhead.

2. **Target 4× parallelism groups**: Maintains sufficient over-subscription for good load balancing even with stragglers.

3. **Cap at 8 splits per task**: Prevents any single task from becoming a bottleneck, even with millions of splits.

## Configuration

| Property | Default | Description |
|----------|---------|-------------|
| `spark.indextables.read.splitsPerTask` | `auto` | "auto" for auto-selection, or numeric value to override |
| `spark.indextables.read.maxSplitsPerTask` | `8` | Maximum splits per task (cap for auto-selection) |
| `spark.indextables.read.aggregate.splitsPerTask` | (falls back) | Aggregate-specific override |
| `spark.indextables.read.aggregate.maxSplitsPerTask` | (falls back) | Aggregate-specific max cap |

## Examples

### Small Cluster (4 cores, defaultParallelism=4)

| Splits | Threshold (8) | Auto Result | Task Groups |
|--------|---------------|-------------|-------------|
| 6 | ≤8 | 1 | 6 |
| 8 | ≤8 | 1 | 8 |
| 16 | >8, target≥16 | 1 | 16 |
| 32 | >8, target≥16 | 2 | 16 |
| 64 | >8, target≥16 | 4 | 16 |
| 128 | >8, target≥16 | 8 (capped) | 16 |
| 256 | >8, target≥16 | 8 (capped) | 32 |

### Large Cluster (64 cores, defaultParallelism=64)

| Splits | Threshold (128) | Auto Result | Task Groups |
|--------|-----------------|-------------|-------------|
| 100 | ≤128 | 1 | 100 |
| 128 | ≤128 | 1 | 128 |
| 256 | >128, target≥256 | 1 | 256 |
| 512 | >128, target≥256 | 2 | 256 |
| 1024 | >128, target≥256 | 4 | 256 |
| 2048 | >128, target≥256 | 8 (capped) | 256 |
| 10000 | >128, target≥256 | 8 (capped) | 1250 |

## Usage

### Default Behavior (Auto-Selection)
```scala
// No configuration needed - system adapts automatically
val df = spark.read
  .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
  .load("s3://bucket/path")

df.count()  // Auto-selects optimal splitsPerTask
```

### Customize Auto-Selection Limits
```scala
// Allow larger batches for scan-heavy workloads
spark.conf.set("spark.indextables.read.maxSplitsPerTask", "16")

// Use different max for aggregates
spark.conf.set("spark.indextables.read.aggregate.maxSplitsPerTask", "4")
```

### Fixed Configuration (Override Auto)
```scala
// Disable auto-selection, always use exactly 4 splits per task
spark.conf.set("spark.indextables.read.splitsPerTask", "4")
```

### Maximum Parallelism
```scala
// Revert to 1:1 split-to-task mapping
spark.conf.set("spark.indextables.read.splitsPerTask", "1")
```

## Files Changed

| File | Changes |
|------|---------|
| `PartitionUtils.scala` | Added `SplitsPerTaskCalculator` object with auto-selection algorithm |
| `IndexTables4SparkScan.scala` | Use calculator in `planInputPartitions()` |
| `IndexTables4SparkSimpleAggregateScan.scala` | Use calculator with aggregate fallback chain |
| `IndexTables4SparkGroupByAggregateScan.scala` | Use calculator with aggregate fallback chain |

## Backward Compatibility

- **Breaking change**: Default behavior changes from fixed 2 to auto-selection
  - Generally results in better performance, but could affect some workloads
- Setting `splitsPerTask` to a numeric value disables auto-selection
- Setting `splitsPerTask` to "1" reverts to original 1:1 behavior
- Setting `splitsPerTask` to "auto" or omitting it enables auto-selection

## Performance Impact

**With Auto-Selection (64-core cluster, defaultParallelism=64):**

| Total Splits | Tasks Before (fixed=2) | Tasks After (auto) | Improvement |
|--------------|------------------------|-------------------|-------------|
| 100 | 50 | 100 | +100% parallelism (small table) |
| 500 | 250 | 250 | Same |
| 2000 | 1000 | 250 | 75% fewer tasks |
| 10000 | 5000 | 1250 | 75% fewer tasks |

**Key Benefits:**
- Small tables: Maximum parallelism (1 split per task)
- Large tables: Reduced scheduler overhead (up to 75% fewer tasks)
- Load balancing: 4× over-subscription ensures even work distribution
- Bounded task size: Max 8 splits/task prevents stragglers
- Cache locality: Preserved (splits grouped by assigned host)

## Test Plan

- [x] Compilation passes
- [ ] Unit tests for `SplitsPerTaskCalculator.calculate()`
- [ ] Integration tests verifying auto-selection behavior
- [ ] Existing aggregate tests still pass
