### PR TITLE
fix:  IndexQuery Invalid Syntax Handling bugs

### DIFF
--- a/src/main/scala/io/indextables/spark/sql/DescribeComponentSizesCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/DescribeComponentSizesCommand.scala
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sql
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import org.apache.hadoop.fs.Path
+
+import io.indextables.spark.storage.GlobalSplitCacheManager
+import io.indextables.spark.transaction.{AddAction, PartitionPredicateUtils, TransactionLogFactory}
+import io.indextables.spark.util.{ConfigNormalization, ConfigUtils, ProtocolNormalizer, SplitMetadataFactory}
+import org.slf4j.LoggerFactory
+
+/**
+ * SQL command to describe sub-component sizes for all splits in a table.
+ *
+ * Syntax:
+ * {{{
+ * DESCRIBE INDEXTABLES COMPONENT SIZES '/path/to/table'
+ *   [WHERE partition_col = 'value']
+ *
+ * DESCRIBE TANTIVY4SPARK COMPONENT SIZES my_table
+ *   WHERE year = '2024'
+ * }}}
+ *
+ * This command outputs:
+ *   - split_path: Path to the split file
+ *   - partition_values: JSON map of partition key/values (null if unpartitioned)
+ *   - component_key: Component identifier (e.g., `score.fastfield`, `_term_total`)
+ *   - size_bytes: Size in bytes
+ *   - component_type: Category: `fastfield`, `fieldnorm`, `term`, `postings`, `positions`, `store`
+ *   - field_name: Field name (null for segment-level components)
+ *
+ * @param tablePath
+ *   Table path or identifier
+ * @param wherePredicates
+ *   Partition predicates for filtering splits
+ */
+case class DescribeComponentSizesCommand(
+  tablePath: String,
+  wherePredicates: Seq[String])
+    extends LeafRunnableCommand {
+
+  private val logger = LoggerFactory.getLogger(classOf[DescribeComponentSizesCommand])
+
+  override val output: Seq[Attribute] = Seq(
+    AttributeReference("split_path", StringType, nullable = false)(),
+    AttributeReference("partition_values", StringType, nullable = true)(),
+    AttributeReference("component_key", StringType, nullable = false)(),
+    AttributeReference("size_bytes", LongType, nullable = false)(),
+    AttributeReference("component_type", StringType, nullable = false)(),
+    AttributeReference("field_name", StringType, nullable = true)()
+  )
+
+  /**
+   * Resolve AWS credentials on the driver and return a modified config.
+   * This eliminates executor-side HTTP calls for credential providers like UnityCatalogAWSCredentialProvider.
+   */
+  private def resolveCredentialsOnDriver(config: Map[String, String], tablePath: String): Map[String, String] = {
+    val providerClass = config.get("spark.indextables.aws.credentialsProviderClass")
+      .orElse(config.get("spark.indextables.aws.credentialsproviderclass"))
+
+    providerClass match {
+      case Some(className) if className.nonEmpty =>
+        try {
+          val normalizedPath = io.indextables.spark.util.TablePathNormalizer.normalizeToTablePath(tablePath)
+          val credentials = io.indextables.spark.utils.CredentialProviderFactory.resolveAWSCredentialsFromConfig(
+            config, normalizedPath
+          )
+
+          credentials match {
+            case Some(creds) =>
+              logger.info(s"[DRIVER] Resolved AWS credentials from provider: $className")
+              var newConfig = config -
+                "spark.indextables.aws.credentialsProviderClass" -
+                "spark.indextables.aws.credentialsproviderclass" +
+                ("spark.indextables.aws.accessKey" -> creds.accessKey) +
+                ("spark.indextables.aws.secretKey" -> creds.secretKey)
+
+              creds.sessionToken.foreach(token => newConfig = newConfig + ("spark.indextables.aws.sessionToken" -> token))
+              newConfig
+
+            case None =>
+              logger.warn(s"[DRIVER] Failed to resolve credentials from provider $className, passing to executors")
+              config
+          }
+        } catch {
+          case ex: Exception =>
+            logger.warn(s"[DRIVER] Driver-side credential resolution failed: ${ex.getMessage}, passing to executors")
+            config
+        }
+
+      case None => config
+    }
+  }
+
+  override def run(sparkSession: SparkSession): Seq[Row] =
+    try {
+      val resolvedPath = resolveTablePath(tablePath, sparkSession)
+      logger.info(s"Describing component sizes for table: $resolvedPath")
+
+      val sc = sparkSession.sparkContext
+
+      // Get session config for credentials and cache settings
+      val sparkConfigs = ConfigNormalization.extractTantivyConfigsFromSpark(sparkSession)
+      val hadoopConfigs =
+        ConfigNormalization.extractTantivyConfigsFromHadoop(sparkSession.sparkContext.hadoopConfiguration)
+      val baseConfig = ConfigNormalization.mergeWithPrecedence(hadoopConfigs, sparkConfigs)
+
+      // PERFORMANCE OPTIMIZATION: Resolve credentials on driver to avoid executor-side HTTP calls
+      val mergedConfig = resolveCredentialsOnDriver(baseConfig, resolvedPath.toString)
+
+      // Create transaction log
+      val transactionLog = TransactionLogFactory.create(
+        resolvedPath,
+        sparkSession,
+        new CaseInsensitiveStringMap(mergedConfig.asJava)
+      )
+
+      try {
+        // Get partition schema for predicate validation
+        val metadata = transactionLog.getMetadata()
+        val partitionSchema = StructType(
+          metadata.partitionColumns.map(name => StructField(name, StringType, nullable = true))
+        )
+
+        // Parse predicates and convert to Spark Filters for Avro manifest pruning
+        val (parsedPredicates, partitionFilters) = if (wherePredicates.nonEmpty) {
+          val parsed = PartitionPredicateUtils.parseAndValidatePredicates(wherePredicates, partitionSchema, sparkSession)
+          val filters = PartitionPredicateUtils.expressionsToFilters(parsed)
+          logger.info(s"Converted ${filters.length} of ${parsed.length} predicates to Spark Filters for manifest pruning")
+          (parsed, filters)
+        } else {
+          (Seq.empty, Seq.empty)
+        }
+
+        // Get active splits with manifest-level pruning if filters are available
+        var addActions = if (partitionFilters.nonEmpty) {
+          val actions = transactionLog.listFilesWithPartitionFilters(partitionFilters)
+          logger.info(s"Found ${actions.length} splits using Avro manifest pruning")
+          actions
+        } else {
+          val actions = transactionLog.listFiles()
+          logger.info(s"Found ${actions.length} splits in transaction log")
+          actions
+        }
+
+        // Apply in-memory partition filtering for any predicates not converted to Spark Filters
+        if (parsedPredicates.nonEmpty) {
+          addActions = PartitionPredicateUtils.filterAddActionsByPredicates(addActions, partitionSchema, parsedPredicates)
+          logger.info(s"After in-memory partition filtering: ${addActions.length} splits")
+        }
+
+        if (addActions.isEmpty) {
+          logger.info("No splits found matching the criteria")
+          return Seq.empty
+        }
+
+        // Broadcast config for executor access
+        val broadcastConfig = sc.broadcast(mergedConfig)
+        val tablePathStr = resolvedPath.toString
+
+        // Create tasks with split metadata
+        val tasks = addActions.map { addAction =>
+          ComponentSizeTask(
+            addAction = addAction,
+            tablePath = tablePathStr
+          )
+        }
+
+        logger.info(s"Processing ${tasks.length} splits for component sizes")
+
+        // Execute tasks in parallel across executors
+        val results = sc.parallelize(tasks, math.min(tasks.length, sc.defaultParallelism))
+          .flatMap(task => executeComponentSizeTask(task, broadcastConfig.value))
+          .collect()
+          .toSeq
+
+        logger.info(s"Collected ${results.length} component size entries")
+
+        results
+
+      } finally
+        transactionLog.close()
+
+    } catch {
+      case e: Exception =>
+        logger.error(s"Failed to describe component sizes: ${e.getMessage}", e)
+        throw e
+    }
+
+  /** Execute component size task on an executor. */
+  private def executeComponentSizeTask(
+    task: ComponentSizeTask,
+    config: Map[String, String]
+  ): Seq[Row] = {
+    val taskLogger = LoggerFactory.getLogger(classOf[DescribeComponentSizesCommand])
+
+    try {
+      // Normalize path for tantivy4java compatibility
+      val fullPath =
+        if (ProtocolNormalizer.isS3Path(task.addAction.path) || ProtocolNormalizer.isAzurePath(task.addAction.path)) {
+          task.addAction.path
+        } else {
+          s"${task.tablePath}/${task.addAction.path}"
+        }
+      val actualPath = ProtocolNormalizer.normalizeAllProtocols(fullPath)
+
+      // Create cache config and manager
+      val cacheConfig = ConfigUtils.createSplitCacheConfig(config, Some(task.tablePath))
+      val cacheManager = GlobalSplitCacheManager.getInstance(cacheConfig)
+
+      // Create split metadata from AddAction
+      val splitMetadata = SplitMetadataFactory.fromAddAction(task.addAction, task.tablePath)
+
+      // Create split searcher
+      val splitSearcher = cacheManager.createSplitSearcher(actualPath, splitMetadata)
+
+      try {
+        // Get per-field component sizes from tantivy4java
+        val componentSizes: java.util.Map[String, java.lang.Long] = splitSearcher.getPerFieldComponentSizes()
+
+        // Convert partition values to JSON string
+        val partitionValuesJson = if (task.addAction.partitionValues.nonEmpty) {
+          val jsonPairs = task.addAction.partitionValues.map { case (k, v) => s""""$k":"$v"""" }.mkString(",")
+          s"{$jsonPairs}"
+        } else {
+          null
+        }
+
+        // Convert each component size entry to a Row
+        componentSizes.asScala.map { case (componentKey, sizeBytes) =>
+          val (componentType, fieldName) = parseComponentKey(componentKey)
+          Row(
+            task.addAction.path,
+            partitionValuesJson,
+            componentKey,
+            sizeBytes.toLong,
+            componentType,
+            fieldName
+          )
+        }.toSeq
+
+      } finally
+        try { splitSearcher.close() } catch { case _: Exception => }
+
+    } catch {
+      case e: Exception =>
+        taskLogger.warn(s"Failed to get component sizes for split ${task.addAction.path}: ${e.getMessage}")
+        Seq.empty
+    }
+  }
+
+  /**
+   * Parse component key to extract component type and field name.
+   *
+   * Key formats:
+   *   - Per-field: `{field}.fastfield`, `{field}.fieldnorm`
+   *   - Segment-level: `_term_total`, `_postings_total`, `_positions_total`, `_store`
+   */
+  private def parseComponentKey(componentKey: String): (String, String) =
+    if (componentKey.startsWith("_")) {
+      // Segment-level component
+      val componentType = componentKey match {
+        case "_term_total"      => "term"
+        case "_postings_total"  => "postings"
+        case "_positions_total" => "positions"
+        case "_store"           => "store"
+        case other              => other.stripPrefix("_").takeWhile(_ != '_')
+      }
+      (componentType, null)
+    } else if (componentKey.endsWith(".fastfield")) {
+      val fieldName = componentKey.stripSuffix(".fastfield")
+      ("fastfield", fieldName)
+    } else if (componentKey.endsWith(".fieldnorm")) {
+      val fieldName = componentKey.stripSuffix(".fieldnorm")
+      ("fieldnorm", fieldName)
+    } else if (componentKey.contains(".")) {
+      // Generic field.type format
+      val lastDot = componentKey.lastIndexOf('.')
+      val fieldName = componentKey.substring(0, lastDot)
+      val componentType = componentKey.substring(lastDot + 1)
+      (componentType, fieldName)
+    } else {
+      // Unknown format - use as-is
+      (componentKey, null)
+    }
+
+  private def resolveTablePath(pathOrTable: String, sparkSession: SparkSession): Path =
+    if (
+      pathOrTable.startsWith("/") || pathOrTable.startsWith("s3://") || pathOrTable.startsWith("s3a://") ||
+      pathOrTable.startsWith("hdfs://") || pathOrTable.startsWith("file://") ||
+      pathOrTable.startsWith("abfss://") || pathOrTable.startsWith("wasbs://")
+    ) {
+      new Path(pathOrTable)
+    } else {
+      try {
+        val tableIdentifier = sparkSession.sessionState.sqlParser.parseTableIdentifier(pathOrTable)
+        val catalog = sparkSession.sessionState.catalog
+        if (catalog.tableExists(tableIdentifier)) {
+          val tableMetadata = catalog.getTableMetadata(tableIdentifier)
+          new Path(tableMetadata.location)
+        } else {
+          throw new IllegalArgumentException(s"Table not found: $pathOrTable")
+        }
+      } catch {
+        case _: Exception =>
+          new Path(pathOrTable)
+      }
+    }
+}
+
+/** Internal task representation for component size retrieval. */
+private[sql] case class ComponentSizeTask(
+  addAction: AddAction,
+  tablePath: String)
+    extends Serializable

--- a/src/test/scala/io/indextables/spark/sql/DescribeComponentSizesIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/DescribeComponentSizesIntegrationTest.scala
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sql
+
+import java.nio.file.Files
+
+import org.apache.spark.sql.SparkSession
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * Integration tests for DESCRIBE INDEXTABLES COMPONENT SIZES command.
+ *
+ * Tests actual execution against real IndexTables tables.
+ */
+class DescribeComponentSizesIntegrationTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
+
+  private var spark: SparkSession = _
+  private var testDir: java.nio.file.Path = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    spark = SparkSession
+      .builder()
+      .appName("DescribeComponentSizesIntegrationTest")
+      .master("local[2]")
+      .config("spark.sql.extensions", "io.indextables.spark.extensions.IndexTables4SparkExtensions")
+      .config("spark.ui.enabled", "false")
+      .config("spark.driver.bindAddress", "127.0.0.1")
+      .getOrCreate()
+
+    testDir = Files.createTempDirectory("component_sizes_test_")
+  }
+
+  override def afterAll(): Unit = {
+    if (spark != null) {
+      spark.stop()
+      spark = null
+    }
+    if (testDir != null) {
+      deleteDirectory(testDir.toFile)
+    }
+    super.afterAll()
+  }
+
+  private def deleteDirectory(dir: java.io.File): Unit =
+    if (dir.exists()) {
+      dir.listFiles().foreach { file =>
+        if (file.isDirectory) deleteDirectory(file)
+        else file.delete()
+      }
+      dir.delete()
+    }
+
+  // ===== Schema Tests =====
+
+  test("DESCRIBE COMPONENT SIZES should have correct output schema") {
+    val tablePath = createTestTable("schema_test")
+
+    val result = spark.sql(s"DESCRIBE INDEXTABLES COMPONENT SIZES '$tablePath'")
+
+    // Verify schema
+    val columns = result.columns.toSet
+    columns should contain("split_path")
+    columns should contain("partition_values")
+    columns should contain("component_key")
+    columns should contain("size_bytes")
+    columns should contain("component_type")
+    columns should contain("field_name")
+
+    // Verify column types
+    val schema = result.schema
+    schema("split_path").dataType.typeName shouldBe "string"
+    schema("partition_values").dataType.typeName shouldBe "string"
+    schema("component_key").dataType.typeName shouldBe "string"
+    schema("size_bytes").dataType.typeName shouldBe "long"
+    schema("component_type").dataType.typeName shouldBe "string"
+    schema("field_name").dataType.typeName shouldBe "string"
+  }
+
+  // ===== Basic Execution Tests =====
+
+  test("DESCRIBE COMPONENT SIZES should return component sizes for single split") {
+    val tablePath = createTestTable("single_split")
+
+    val result = spark.sql(s"DESCRIBE INDEXTABLES COMPONENT SIZES '$tablePath'")
+    val rows = result.collect()
+
+    // Should return at least some component sizes
+    rows.length should be >= 1
+
+    // All rows should have valid split_path
+    rows.foreach { row =>
+      row.getString(0) should not be null // split_path
+      row.getString(2) should not be null // component_key
+      row.getLong(3) should be >= 0L      // size_bytes
+      row.getString(4) should not be null // component_type
+    }
+  }
+
+  test("DESCRIBE COMPONENT SIZES should return fastfield components") {
+    val tablePath = createTestTableWithFastField("fastfield_test")
+
+    val result = spark.sql(s"DESCRIBE INDEXTABLES COMPONENT SIZES '$tablePath'")
+    result.createOrReplaceTempView("components_fastfield")
+
+    val fastfieldComponents = spark.sql(
+      "SELECT * FROM components_fastfield WHERE component_type = 'fastfield'"
+    ).collect()
+
+    // Should have at least one fastfield component (for the configured fast field)
+    fastfieldComponents.length should be >= 1
+
+    // Fastfield components should have field_name set
+    fastfieldComponents.foreach { row =>
+      row.getString(5) should not be null // field_name
+    }
+  }
+
+  test("DESCRIBE COMPONENT SIZES should return segment-level components with null field_name") {
+    val tablePath = createTestTable("segment_level")
+
+    val result = spark.sql(s"DESCRIBE INDEXTABLES COMPONENT SIZES '$tablePath'")
+    result.createOrReplaceTempView("components_segment")
+
+    // Look for segment-level components (those starting with _)
+    val segmentComponents = spark.sql(
+      "SELECT * FROM components_segment WHERE component_key LIKE '\\_%'"
+    ).collect()
+
+    // Segment-level components should exist
+    segmentComponents.length should be >= 1
+
+    // Segment-level components should have null field_name
+    segmentComponents.foreach { row =>
+      row.isNullAt(5) shouldBe true // field_name should be null
+    }
+  }
+
+  // ===== Component Type Tests =====
+
+  test("DESCRIBE COMPONENT SIZES should return correct component types") {
+    val tablePath = createTestTableWithFastField("component_types")
+
+    val result = spark.sql(s"DESCRIBE INDEXTABLES COMPONENT SIZES '$tablePath'")
+    result.createOrReplaceTempView("components_types")
+
+    val componentTypes = spark.sql(
+      "SELECT DISTINCT component_type FROM components_types"
+    ).collect().map(_.getString(0)).toSet
+
+    // Should have at least some recognized component types
+    val knownTypes = Set("fastfield", "fieldnorm", "term", "postings", "positions", "store")
+    (componentTypes & knownTypes).size should be >= 1
+  }
+
+  // ===== Partition Filtering Tests =====
+
+  test("DESCRIBE COMPONENT SIZES with WHERE clause should filter by partition") {
+    val tablePath = createPartitionedTable("partitioned_filter")
+
+    // Get all components
+    val allResult = spark.sql(s"DESCRIBE INDEXTABLES COMPONENT SIZES '$tablePath'")
+    val allRows = allResult.collect()
+
+    // Get filtered components
+    val filteredResult = spark.sql(
+      s"DESCRIBE INDEXTABLES COMPONENT SIZES '$tablePath' WHERE year = '2024'"
+    )
+    val filteredRows = filteredResult.collect()
+
+    // Filtered should have fewer or equal rows
+    filteredRows.length should be <= allRows.length
+
+    // All filtered rows should have partition_values containing 2024
+    filteredRows.foreach { row =>
+      val partitionValues = row.getString(1)
+      if (partitionValues != null) {
+        partitionValues should include("2024")
+      }
+    }
+  }
+
+  test("DESCRIBE COMPONENT SIZES should return empty for non-matching WHERE predicate") {
+    val tablePath = createPartitionedTable("no_match")
+
+    val result = spark.sql(
+      s"DESCRIBE INDEXTABLES COMPONENT SIZES '$tablePath' WHERE year = '9999'"
+    )
+    val rows = result.collect()
+
+    rows.length shouldBe 0
+  }
+
+  // ===== Unpartitioned Table Tests =====
+
+  test("DESCRIBE COMPONENT SIZES should work with unpartitioned table") {
+    val tablePath = createTestTable("unpartitioned")
+
+    val result = spark.sql(s"DESCRIBE INDEXTABLES COMPONENT SIZES '$tablePath'")
+    val rows = result.collect()
+
+    rows.length should be >= 1
+
+    // Partition values should be null for unpartitioned table
+    rows.foreach { row =>
+      row.isNullAt(1) shouldBe true // partition_values should be null
+    }
+  }
+
+  // ===== Queryability Tests =====
+
+  test("DESCRIBE COMPONENT SIZES result should be queryable") {
+    val tablePath = createTestTable("queryable")
+
+    val result = spark.sql(s"DESCRIBE INDEXTABLES COMPONENT SIZES '$tablePath'")
+    result.createOrReplaceTempView("components_query")
+
+    // Should be able to aggregate
+    val totalSize = spark.sql("SELECT SUM(size_bytes) as total FROM components_query").head().getLong(0)
+    totalSize should be >= 0L
+
+    // Should be able to filter
+    val filteredCount = spark.sql(
+      "SELECT COUNT(*) FROM components_query WHERE size_bytes > 0"
+    ).head().getLong(0)
+    filteredCount should be >= 0L
+
+    // Should be able to group
+    val groupedResult = spark.sql(
+      "SELECT component_type, COUNT(*) as cnt FROM components_query GROUP BY component_type"
+    ).collect()
+    groupedResult.length should be >= 1
+  }
+
+  // ===== Error Handling Tests =====
+
+  test("DESCRIBE COMPONENT SIZES should handle non-existent table path gracefully") {
+    val nonExistentPath = s"${testDir.toString}/does_not_exist"
+
+    val ex = intercept[Exception] {
+      spark.sql(s"DESCRIBE INDEXTABLES COMPONENT SIZES '$nonExistentPath'").collect()
+    }
+    // Should throw an exception for non-existent table
+    ex should not be null
+  }
+
+  // ===== Helper Methods =====
+
+  private def createTestTable(name: String): String = {
+    val tablePath = s"${testDir.toString}/$name"
+
+    val data = Seq(
+      (1, "hello world", 10.5),
+      (2, "test data", 20.3),
+      (3, "sample text", 15.7)
+    )
+    val df = spark.createDataFrame(data).toDF("id", "content", "score")
+
+    df.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.content", "text")
+      .save(tablePath)
+
+    tablePath
+  }
+
+  private def createTestTableWithFastField(name: String): String = {
+    val tablePath = s"${testDir.toString}/$name"
+
+    val data = Seq(
+      (1, "hello world", 10.5),
+      (2, "test data", 20.3),
+      (3, "sample text", 15.7)
+    )
+    val df = spark.createDataFrame(data).toDF("id", "content", "score")
+
+    df.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.indexing.typemap.content", "text")
+      .option("spark.indextables.indexing.fastfields", "score")
+      .save(tablePath)
+
+    tablePath
+  }
+
+  private def createPartitionedTable(name: String): String = {
+    val tablePath = s"${testDir.toString}/$name"
+
+    val data = Seq(
+      (1, "hello", "2023", "us-east"),
+      (2, "world", "2024", "us-east"),
+      (3, "test", "2024", "us-west")
+    )
+    val df = spark.createDataFrame(data).toDF("id", "content", "year", "region")
+
+    df.write
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .partitionBy("year", "region")
+      .save(tablePath)
+
+    tablePath
+  }
+}

--- a/src/test/scala/io/indextables/spark/sql/DescribeComponentSizesParsingTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/DescribeComponentSizesParsingTest.scala
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sql
+
+import org.apache.spark.sql.SparkSession
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.BeforeAndAfterEach
+
+/**
+ * Parsing tests for DESCRIBE INDEXTABLES COMPONENT SIZES command.
+ *
+ * Tests SQL syntax variations and parameter extraction.
+ */
+class DescribeComponentSizesParsingTest extends AnyFunSuite with BeforeAndAfterEach {
+
+  var spark: SparkSession = _
+
+  override def beforeEach(): Unit =
+    spark = SparkSession
+      .builder()
+      .master("local[2]")
+      .appName("DescribeComponentSizesParsingTest")
+      .config("spark.ui.enabled", "false")
+      .config("spark.sql.extensions", "io.indextables.spark.extensions.IndexTables4SparkExtensions")
+      .getOrCreate()
+
+  override def afterEach(): Unit =
+    if (spark != null) {
+      spark.stop()
+      spark = null
+    }
+
+  // === Basic Syntax Tests ===
+
+  test("DESCRIBE INDEXTABLES COMPONENT SIZES should parse with path only") {
+    val sql = "DESCRIBE INDEXTABLES COMPONENT SIZES '/tmp/test_table'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.tablePath == "/tmp/test_table")
+    assert(cmd.wherePredicates.isEmpty)
+  }
+
+  test("DESCRIBE INDEXTABLES COMPONENT SIZES should parse with S3 path") {
+    val sql = "DESCRIBE INDEXTABLES COMPONENT SIZES 's3://bucket/table'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.tablePath == "s3://bucket/table")
+  }
+
+  test("DESCRIBE INDEXTABLES COMPONENT SIZES should parse with Azure path") {
+    val sql = "DESCRIBE INDEXTABLES COMPONENT SIZES 'abfss://container@account.dfs.core.windows.net/path'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.tablePath == "abfss://container@account.dfs.core.windows.net/path")
+  }
+
+  test("DESCRIBE TANTIVY4SPARK COMPONENT SIZES should also work") {
+    val sql = "DESCRIBE TANTIVY4SPARK COMPONENT SIZES '/tmp/test_table'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+  }
+
+  test("DESCRIBE COMPONENT SIZES should parse case-insensitive keywords") {
+    val sql = "describe indextables component sizes '/tmp/test_table'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+  }
+
+  test("DESCRIBE INDEXTABLES COMPONENT SIZES should parse with table identifier") {
+    val sql = "DESCRIBE INDEXTABLES COMPONENT SIZES my_table"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.tablePath == "my_table")
+  }
+
+  test("DESCRIBE INDEXTABLES COMPONENT SIZES should parse with qualified table identifier") {
+    val sql = "DESCRIBE INDEXTABLES COMPONENT SIZES my_db.my_table"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.tablePath == "my_db.my_table")
+  }
+
+  // === WHERE Clause Tests ===
+
+  test("DESCRIBE COMPONENT SIZES should parse with simple WHERE clause") {
+    val sql = "DESCRIBE INDEXTABLES COMPONENT SIZES '/tmp/test' WHERE year = '2024'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.wherePredicates.nonEmpty)
+    assert(cmd.wherePredicates.head.contains("year"))
+    assert(cmd.wherePredicates.head.contains("2024"))
+  }
+
+  test("DESCRIBE COMPONENT SIZES should parse with compound WHERE clause (AND)") {
+    val sql = "DESCRIBE INDEXTABLES COMPONENT SIZES '/tmp/test' WHERE year = '2024' AND region = 'us-east'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.wherePredicates.nonEmpty)
+    assert(cmd.wherePredicates.head.contains("year"))
+    assert(cmd.wherePredicates.head.contains("region"))
+  }
+
+  test("DESCRIBE COMPONENT SIZES should parse with compound WHERE clause (OR)") {
+    val sql = "DESCRIBE INDEXTABLES COMPONENT SIZES '/tmp/test' WHERE year = '2023' OR year = '2024'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.wherePredicates.nonEmpty)
+    assert(cmd.wherePredicates.head.contains("OR") || cmd.wherePredicates.head.contains("or"))
+  }
+
+  test("DESCRIBE COMPONENT SIZES should parse with IN clause") {
+    val sql = "DESCRIBE INDEXTABLES COMPONENT SIZES '/tmp/test' WHERE region IN ('us-east', 'us-west')"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.wherePredicates.nonEmpty)
+    assert(cmd.wherePredicates.head.contains("IN") || cmd.wherePredicates.head.contains("in"))
+  }
+
+  test("DESCRIBE COMPONENT SIZES should parse with BETWEEN clause") {
+    val sql = "DESCRIBE INDEXTABLES COMPONENT SIZES '/tmp/test' WHERE month BETWEEN 1 AND 6"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.wherePredicates.nonEmpty)
+    assert(cmd.wherePredicates.head.contains("BETWEEN") || cmd.wherePredicates.head.contains("between"))
+  }
+
+  test("DESCRIBE COMPONENT SIZES should parse with comparison operators") {
+    val sql = "DESCRIBE INDEXTABLES COMPONENT SIZES '/tmp/test' WHERE year >= '2020' AND year < '2025'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.wherePredicates.nonEmpty)
+    assert(cmd.wherePredicates.head.contains(">="))
+    assert(cmd.wherePredicates.head.contains("<"))
+  }
+
+  // === Mixed Case and Whitespace Tests ===
+
+  test("DESCRIBE COMPONENT SIZES should handle mixed case in WHERE clause") {
+    val sql = "DESCRIBE IndExtables COMPONENT Sizes '/tmp/test' Where year = '2024'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.tablePath == "/tmp/test")
+    assert(cmd.wherePredicates.nonEmpty)
+  }
+
+  test("DESCRIBE COMPONENT SIZES should handle extra whitespace") {
+    val sql = "DESCRIBE   INDEXTABLES   COMPONENT   SIZES   '/tmp/test'   WHERE   year = '2024'"
+    val plan = spark.sessionState.sqlParser.parsePlan(sql)
+    assert(plan.isInstanceOf[DescribeComponentSizesCommand])
+
+    val cmd = plan.asInstanceOf[DescribeComponentSizesCommand]
+    assert(cmd.tablePath == "/tmp/test")
+    assert(cmd.wherePredicates.nonEmpty)
+  }
+}


### PR DESCRIPTION
# Fix: IndexQuery Invalid Syntax Validation Bugs

## Summary

This PR fixes two bugs in the IndexQuery invalid syntax validation introduced in PR #122:

1. **Error persistence across queries**: Invalid syntax errors persisted to subsequent queries even when the SQL changed
2. **Missing validation for mixed predicates**: Invalid syntax was not caught when IndexQuery was combined with Spark filters via AND/OR

## Bug Details

### Bug #1: Error Persistence Across Queries

**Symptom**: After running a query with invalid IndexQuery syntax, all subsequent queries on the same table failed with the same error, even if the new query had valid syntax.

**Root Cause**: The `storeIndexQueries()` method in `IndexTables4SparkScanBuilder` appends to existing cache entries. When validation throws an exception, the `build()` method (which clears the cache) never runs. The invalid query remains cached and gets included in subsequent validations.

**Fix**: Clear the relation's cache in a catch block when validation fails, before re-throwing the exception. This prevents stale errors from persisting to future queries.

```scala
try {
  validateIndexQueryFilters(result)
} catch {
  case e: Exception =>
    IndexTables4SparkScanBuilder.clearIndexQueries(relation)
    throw e
}
```

### Bug #2: Missing Validation for Mixed Predicates

**Symptom**: Queries like `WHERE id = 'id' AND text_field indexquery '((badquery'` did not trigger validation errors - the invalid syntax was silently ignored.

**Root Cause**: When IndexQuery is combined with Spark filters via AND/OR, the `V2IndexQueryExpressionRule` creates a `MixedBooleanFilter` tree structure (e.g., `MixedAndFilter`, `MixedOrFilter`). The validation code only handled leaf node types (`IndexQueryFilter`, `MixedIndexQuery`, etc.) but not the tree container types. Tree nodes fell into the `case other =>` branch and were skipped with just a debug log.

**Fix**: Added recursive tree traversal to validate all IndexQuery filters within `MixedBooleanFilter` trees:

```scala
private def validateMixedBooleanTree(
  tree: MixedBooleanFilter,
  tantivySchema: Schema
): Unit = {
  tree match {
    case MixedIndexQuery(filter) => validateSingleQuery(...)
    case MixedIndexQueryAll(filter) => validateSingleQuery(...)
    case MixedAndFilter(left, right) =>
      validateMixedBooleanTree(left, tantivySchema)
      validateMixedBooleanTree(right, tantivySchema)
    case MixedOrFilter(left, right) =>
      validateMixedBooleanTree(left, tantivySchema)
      validateMixedBooleanTree(right, tantivySchema)
    case MixedNotFilter(child) =>
      validateMixedBooleanTree(child, tantivySchema)
    case _: MixedSparkFilter => () // Spark filters don't need validation
  }
}
```

## Changes

### Modified Files

- `src/main/scala/io/indextables/spark/core/IndexTables4SparkScanBuilder.scala`
  - Added imports for `MixedAndFilter`, `MixedOrFilter`, `MixedNotFilter`, `MixedSparkFilter`, `MixedBooleanFilter`
  - Added case branches in `validateIndexQueryFilters()` to handle tree structures
  - Added `validateMixedBooleanTree()` method for recursive tree traversal
  - Added try/catch in `extractIndexQueriesFromCurrentPlan()` to clear cache on validation failure

- `src/test/scala/io/indextables/spark/indexquery/IndexQueryInvalidSyntaxTest.scala`
  - Added test: "invalid syntax error should not persist to subsequent queries"
  - Added test: "invalid syntax should be caught when combined with Spark filters via AND"
  - Added test: "invalid syntax should be caught when combined with Spark filters via OR"
  - Added test: "valid IndexQuery combined with Spark filters should work correctly"

## Test Plan

- [x] All 15 invalid syntax tests pass (11 existing + 4 new)
- [x] New test verifies error doesn't persist across queries
- [x] New tests verify validation works with mixed AND/OR predicates
- [x] New test verifies valid mixed predicates still work correctly
