### PR TITLE
enhancement: move indexquery field validation to driver

### DIFF
--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkScanBuilder.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkScanBuilder.scala
@@ -191,6 +191,12 @@ class IndexTables4SparkScanBuilder(
         )
         extractedIndexQueryFilters.foreach(filter => logger.debug(s"  - Extracted IndexQuery: $filter"))
 
+        // CRITICAL: Validate IndexQuery field existence on driver before creating scan
+        // This prevents task failures on executors when fields don't exist
+        // Same pattern as PR #122's syntax validation - fail fast on driver
+        validateIndexQueryFieldsExist()
+        logger.debug(s"BUILD: IndexQuery field validation passed for regular scan")
+
         logger.debug(s"BUILD: Creating IndexTables4SparkScan on instance ${System.identityHashCode(this)} with ${effectiveFilters.length} pushed filters")
         effectiveFilters.foreach(filter => logger.debug(s"BUILD:   - Creating scan with filter: $filter"))
         new IndexTables4SparkScan(


### PR DESCRIPTION
# PR: Move IndexQuery Field Validation to Driver

## Summary
- Moves IndexQuery field validation from executors to driver, aligning with PR #122's syntax validation pattern
- Prevents task failures when IndexQuery references non-existent fields
- Provides immediate, descriptive error messages before tasks are dispatched

## Problem
IndexQuery field validation from PR #114 was happening on executors inside `FiltersToQueryConverter.isMixedFilterValidForSchema()`. This caused:
- Task failures and retries when queries referenced non-existent fields
- Delayed error reporting (errors only surfaced after task execution began)
- Inconsistent behavior between aggregate queries (validated on driver) and regular queries (validated on executor)

## Solution
Aligned the field validation architecture with PR #122's syntax validation pattern:

1. **Added driver-side validation** in `IndexTables4SparkScanBuilder.build()` for regular (non-aggregate) scans
2. **Removed executor-side throwing** in `FiltersToQueryConverter.isMixedFilterValidForSchema()` - now returns `false` with warning log as a safety net

### Before
```
Driver: validateIndexQueryFieldsExist() - aggregate queries only
Executor: isMixedFilterValidForSchema() - throws IllegalArgumentException
```

### After
```
Driver: validateIndexQueryFieldsExist() - ALL queries (aggregate + regular)
Executor: isMixedFilterValidForSchema() - returns false, logs warning (safety net only)
```

## Changes

### `IndexTables4SparkScanBuilder.scala`
- Added `validateIndexQueryFieldsExist()` call before creating `IndexTables4SparkScan` in regular scan path

### `FiltersToQueryConverter.scala`
- Removed `throw IllegalArgumentException` for IndexQuery filters with invalid fields
- Changed to return `false` with warning log for graceful degradation
- Updated docstring to reflect new role as safety net

### `IndexQueryNonExistentFieldTest.scala`
- Updated 3 tests to expect `IllegalArgumentException` instead of `SparkException`
- Removed unused `SparkException` import

## Test plan
- [x] `IndexQueryNonExistentFieldTest` - 12/12 tests pass
- [x] `IndexQueryInvalidSyntaxTest` - 15/15 tests pass
- [x] `IndexQueryAggregateInvalidSyntaxTest` - 5/5 tests pass
- [x] All 32 IndexQuery validation tests pass

## Behavior Change
Users will now see `IllegalArgumentException` thrown directly from driver planning instead of `SparkException` wrapping executor task failures. Error messages remain the same:

```
IndexQuery references non-existent field 'fake_field'. Available fields are: [id, title, category]
```
