### PR TITLE
feature: Optimized Writes via RequiresDistributionAndOrdering

### DIFF
--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkOptimizedWrite.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkOptimizedWrite.scala
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.core
+
+import io.indextables.spark.transaction.TransactionLog
+import io.indextables.spark.write.{OptimizedWriteConfig, WriteSizeEstimator}
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.connector.distributions.{Distribution, Distributions}
+import org.apache.spark.sql.connector.expressions.{Expression, Expressions, SortOrder}
+import org.apache.spark.sql.connector.write.{LogicalWriteInfo, RequiresDistributionAndOrdering}
+import org.slf4j.LoggerFactory
+
+/**
+ * Optimized write implementation that mixes in RequiresDistributionAndOrdering to request
+ * a shuffle before writing. This produces well-sized splits by clustering data by partition
+ * columns and using an advisory partition size based on transaction log history or a sampling ratio.
+ *
+ * All commit, writer factory, data writer, merge-on-write, and purge-on-write logic is
+ * inherited unchanged from IndexTables4SparkStandardWrite.
+ */
+class IndexTables4SparkOptimizedWrite(
+  @transient transactionLog: TransactionLog,
+  tablePath: Path,
+  @transient writeInfo: LogicalWriteInfo,
+  serializedOptions: Map[String, String],
+  @transient hadoopConf: org.apache.hadoop.conf.Configuration,
+  isOverwrite: Boolean,
+  config: OptimizedWriteConfig
+) extends IndexTables4SparkStandardWrite(
+      transactionLog, tablePath, writeInfo, serializedOptions, hadoopConf, isOverwrite
+    )
+    with RequiresDistributionAndOrdering {
+
+  @transient private val optLogger = LoggerFactory.getLogger(classOf[IndexTables4SparkOptimizedWrite])
+
+  // Capture first schema field name eagerly (writeInfo is @transient, unavailable after serialization)
+  private val firstSchemaField: String = writeInfo.schema().fieldNames.head
+
+  private lazy val advisorySize: Long = {
+    val estimator = new WriteSizeEstimator(transactionLog, config)
+    estimator.calculateAdvisoryPartitionSize()
+  }
+
+  override def requiredDistribution(): Distribution =
+    if (config.distributionMode == "hash") {
+      if (partitionColumns.nonEmpty) {
+        // Partitioned: cluster by partition columns so each writer gets one partition's data.
+        val exprs = partitionColumns.map(col => Expressions.column(col).asInstanceOf[Expression]).toArray
+        optLogger.info(s"Requesting clustered distribution on columns: ${partitionColumns.mkString(", ")}")
+        Distributions.clustered(exprs)
+      } else {
+        // Unpartitioned: cluster by a single column just to trigger a shuffle so AQE can
+        // coalesce using the advisory size. Spark 3.5 rejects empty clustering + advisory > 0
+        // (DistributionAndOrderingUtils treats empty clustering as "no distribution"), so we
+        // need at least one expression. A single column keeps hash cost O(1) per row
+        // regardless of schema width.
+        val expr = Array(Expressions.column(firstSchemaField).asInstanceOf[Expression])
+        optLogger.info(s"Requesting clustered distribution on column: $firstSchemaField (unpartitioned table)")
+        Distributions.clustered(expr)
+      }
+    } else {
+      optLogger.info("Using unspecified distribution (mode=none)")
+      Distributions.unspecified()
+    }
+
+  override def distributionStrictlyRequired(): Boolean = false
+
+  override def requiredOrdering(): Array[SortOrder] = Array.empty
+
+  override def advisoryPartitionSizeInBytes(): Long =
+    if (config.distributionMode == "hash") {
+      optLogger.info(s"Advisory partition size: ${config.targetSplitSizeString} ($advisorySize bytes)")
+      advisorySize
+    } else {
+      // Spark doesn't support advisory size with UnspecifiedDistribution
+      0L
+    }
+}

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkStandardWrite.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkStandardWrite.scala
@@ -66,7 +66,7 @@ class IndexTables4SparkStandardWrite(
   private val serializedHadoopConf =
     // Serialize only the tantivy4spark config properties from hadoopConf (includes credentials from enrichedHadoopConf)
     io.indextables.spark.util.ConfigNormalization.extractTantivyConfigsFromHadoop(hadoopConf)
-  private val partitionColumns =
+  protected val partitionColumns =
     // Extract partition columns from write options (set by .partitionBy())
     // Spark sets this as a JSON array string like ["col1","col2"]
     serializedOptions.get("__partition_columns") match {

--- a/src/main/scala/io/indextables/spark/write/OptimizedWriteConfig.scala
+++ b/src/main/scala/io/indextables/spark/write/OptimizedWriteConfig.scala
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.write
+
+import io.indextables.spark.util.SizeParser
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.slf4j.LoggerFactory
+
+/**
+ * Configuration for optimized writes using Spark's RequiresDistributionAndOrdering interface.
+ *
+ * When enabled, this feature requests a shuffle before writing to produce well-sized splits
+ * (~1GB by default). For partitioned tables, data is clustered by partition columns so each
+ * writer task handles a single partition, producing fewer, larger splits.
+ *
+ * @param enabled
+ *   Whether optimized write is enabled (default: false)
+ * @param targetSplitSizeBytes
+ *   Target on-disk split size in bytes (default: 1GB)
+ * @param samplingRatio
+ *   Ratio of split-size to shuffle-data, used when no history is available (default: 1.1)
+ * @param minRowsForEstimation
+ *   Minimum rows per split to qualify for history-based size estimation (default: 10000)
+ * @param distributionMode
+ *   Distribution mode: "hash" clusters by partition columns, "none" uses unspecified (default: "hash")
+ */
+case class OptimizedWriteConfig(
+  enabled: Boolean = OptimizedWriteConfig.DEFAULT_ENABLED,
+  targetSplitSizeBytes: Long = OptimizedWriteConfig.DEFAULT_TARGET_SPLIT_SIZE_BYTES,
+  samplingRatio: Double = OptimizedWriteConfig.DEFAULT_SAMPLING_RATIO,
+  minRowsForEstimation: Long = OptimizedWriteConfig.DEFAULT_MIN_ROWS_FOR_ESTIMATION,
+  distributionMode: String = OptimizedWriteConfig.DEFAULT_DISTRIBUTION_MODE) {
+
+  def validate(): OptimizedWriteConfig = {
+    require(
+      targetSplitSizeBytes > 0,
+      s"targetSplitSizeBytes must be > 0, got: $targetSplitSizeBytes"
+    )
+    require(
+      samplingRatio > 0.0,
+      s"samplingRatio must be > 0.0, got: $samplingRatio"
+    )
+    require(
+      minRowsForEstimation > 0,
+      s"minRowsForEstimation must be > 0, got: $minRowsForEstimation"
+    )
+    require(
+      OptimizedWriteConfig.VALID_DISTRIBUTION_MODES.contains(distributionMode),
+      s"distributionMode must be one of ${OptimizedWriteConfig.VALID_DISTRIBUTION_MODES.mkString(", ")}, got: $distributionMode"
+    )
+    this
+  }
+
+  def targetSplitSizeString: String = SizeParser.formatBytes(targetSplitSizeBytes)
+}
+
+object OptimizedWriteConfig {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  // Configuration key constants
+  val KEY_ENABLED              = "spark.indextables.write.optimizeWrite.enabled"
+  val KEY_TARGET_SPLIT_SIZE    = "spark.indextables.write.optimizeWrite.targetSplitSize"
+  val KEY_SAMPLING_RATIO       = "spark.indextables.write.optimizeWrite.samplingRatio"
+  val KEY_MIN_ROWS_FOR_EST     = "spark.indextables.write.optimizeWrite.minRowsForEstimation"
+  val KEY_DISTRIBUTION_MODE    = "spark.indextables.write.optimizeWrite.distributionMode"
+
+  // Default values
+  val DEFAULT_ENABLED: Boolean                = false
+  val DEFAULT_TARGET_SPLIT_SIZE_BYTES: Long   = 1L * 1024 * 1024 * 1024 // 1GB
+  val DEFAULT_SAMPLING_RATIO: Double          = 1.1
+  val DEFAULT_MIN_ROWS_FOR_ESTIMATION: Long   = 10000L
+  val DEFAULT_DISTRIBUTION_MODE: String       = "hash"
+
+  val VALID_DISTRIBUTION_MODES: Set[String] = Set("hash", "none")
+
+  def default: OptimizedWriteConfig = OptimizedWriteConfig()
+
+  def fromOptions(options: CaseInsensitiveStringMap): OptimizedWriteConfig = {
+    val enabled = getBooleanOption(options, KEY_ENABLED, DEFAULT_ENABLED)
+    val targetSplitSizeBytes = parseSizeOption(
+      options, KEY_TARGET_SPLIT_SIZE, DEFAULT_TARGET_SPLIT_SIZE_BYTES
+    )
+    val samplingRatio = getDoubleOption(
+      options, KEY_SAMPLING_RATIO, DEFAULT_SAMPLING_RATIO, minExclusive = Some(0.0)
+    )
+    val minRowsForEstimation = getLongOption(
+      options, KEY_MIN_ROWS_FOR_EST, DEFAULT_MIN_ROWS_FOR_ESTIMATION, mustBePositive = true
+    )
+    val distributionMode = getStringOption(
+      options, KEY_DISTRIBUTION_MODE, DEFAULT_DISTRIBUTION_MODE, VALID_DISTRIBUTION_MODES
+    )
+
+    val config = OptimizedWriteConfig(
+      enabled = enabled,
+      targetSplitSizeBytes = targetSplitSizeBytes,
+      samplingRatio = samplingRatio,
+      minRowsForEstimation = minRowsForEstimation,
+      distributionMode = distributionMode
+    )
+
+    logger.debug(
+      s"OptimizedWriteConfig: enabled=$enabled, targetSplitSize=${config.targetSplitSizeString}, " +
+        s"samplingRatio=$samplingRatio, minRowsForEstimation=$minRowsForEstimation, " +
+        s"distributionMode=$distributionMode"
+    )
+
+    config
+  }
+
+  def fromMap(configs: Map[String, String]): OptimizedWriteConfig = {
+    val lowerCaseConfigs                 = configs.map { case (k, v) => k.toLowerCase -> v }
+    def get(key: String): Option[String] = lowerCaseConfigs.get(key.toLowerCase)
+
+    OptimizedWriteConfig(
+      enabled = get(KEY_ENABLED).map(_.toBoolean).getOrElse(DEFAULT_ENABLED),
+      targetSplitSizeBytes = get(KEY_TARGET_SPLIT_SIZE)
+        .map(SizeParser.parseSize).getOrElse(DEFAULT_TARGET_SPLIT_SIZE_BYTES),
+      samplingRatio = get(KEY_SAMPLING_RATIO).map(_.toDouble).getOrElse(DEFAULT_SAMPLING_RATIO),
+      minRowsForEstimation = get(KEY_MIN_ROWS_FOR_EST).map(_.toLong).getOrElse(DEFAULT_MIN_ROWS_FOR_ESTIMATION),
+      distributionMode = get(KEY_DISTRIBUTION_MODE).getOrElse(DEFAULT_DISTRIBUTION_MODE)
+    ).validate()
+  }
+
+  private def getBooleanOption(
+    options: CaseInsensitiveStringMap,
+    key: String,
+    default: Boolean
+  ): Boolean = {
+    val value = options.get(key)
+    if (value == null || value.isEmpty) default
+    else {
+      try
+        value.toBoolean
+      catch {
+        case _: IllegalArgumentException =>
+          logger.warn(s"Invalid boolean value for $key: '$value', using default: $default")
+          default
+      }
+    }
+  }
+
+  private def getDoubleOption(
+    options: CaseInsensitiveStringMap,
+    key: String,
+    default: Double,
+    minExclusive: Option[Double] = None
+  ): Double = {
+    val value = options.get(key)
+    if (value == null || value.isEmpty) default
+    else {
+      try {
+        val parsed = value.toDouble
+        if (minExclusive.exists(min => parsed <= min)) {
+          logger.warn(s"Invalid value for $key: '$value' (must be > ${minExclusive.get}), using default: $default")
+          default
+        } else {
+          parsed
+        }
+      } catch {
+        case _: NumberFormatException =>
+          logger.warn(s"Invalid double value for $key: '$value', using default: $default")
+          default
+      }
+    }
+  }
+
+  private def getLongOption(
+    options: CaseInsensitiveStringMap,
+    key: String,
+    default: Long,
+    mustBePositive: Boolean = false
+  ): Long = {
+    val value = options.get(key)
+    if (value == null || value.isEmpty) default
+    else {
+      try {
+        val parsed = value.toLong
+        if (mustBePositive && parsed <= 0) {
+          logger.warn(s"Invalid value for $key: '$value' (must be > 0), using default: $default")
+          default
+        } else {
+          parsed
+        }
+      } catch {
+        case _: NumberFormatException =>
+          logger.warn(s"Invalid long value for $key: '$value', using default: $default")
+          default
+      }
+    }
+  }
+
+  private def parseSizeOption(
+    options: CaseInsensitiveStringMap,
+    key: String,
+    default: Long
+  ): Long = {
+    val value = options.get(key)
+    if (value == null || value.isEmpty) default
+    else {
+      try
+        SizeParser.parseSize(value)
+      catch {
+        case _: IllegalArgumentException =>
+          logger.warn(s"Invalid size value for $key: '$value', using default: ${SizeParser.formatBytes(default)}")
+          default
+      }
+    }
+  }
+
+  private def getStringOption(
+    options: CaseInsensitiveStringMap,
+    key: String,
+    default: String,
+    validValues: Set[String]
+  ): String = {
+    val value = options.get(key)
+    if (value == null || value.isEmpty) default
+    else {
+      val lower = value.toLowerCase
+      if (validValues.contains(lower)) lower
+      else {
+        logger.warn(
+          s"Invalid value for $key: '$value' (must be one of ${validValues.mkString(", ")}), using default: $default"
+        )
+        default
+      }
+    }
+  }
+}

--- a/src/main/scala/io/indextables/spark/write/WriteSizeEstimator.scala
+++ b/src/main/scala/io/indextables/spark/write/WriteSizeEstimator.scala
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.write
+
+import io.indextables.spark.transaction.TransactionLogInterface
+import io.indextables.spark.util.SizeParser
+import org.slf4j.LoggerFactory
+
+/**
+ * Calculates the advisory partition size for Spark's AQE to produce well-sized splits.
+ *
+ * Two estimation modes:
+ *
+ *   - '''Sampling mode''' (no qualifying history): Uses a configurable ratio to estimate the
+ *     relationship between shuffle data and on-disk split size. Advisory = targetSplitSize / samplingRatio.
+ *
+ *   - '''History mode''' (qualifying splits in transaction log): Uses real bytes-per-row from
+ *     existing splits. Advisory = targetSplitSize (we know the actual compression ratio).
+ *
+ * @param transactionLog
+ *   Transaction log to read existing split metadata from
+ * @param config
+ *   Optimized write configuration
+ */
+class WriteSizeEstimator(
+  transactionLog: TransactionLogInterface,
+  config: OptimizedWriteConfig) {
+
+  private val logger = LoggerFactory.getLogger(classOf[WriteSizeEstimator])
+
+  def calculateAdvisoryPartitionSize(): Long =
+    try {
+      val addActions = transactionLog.listFiles()
+      val qualifying = addActions.filter(_.numRecords.exists(_ >= config.minRowsForEstimation))
+
+      if (qualifying.nonEmpty) {
+        // HISTORY MODE: use real bytesPerRow from transaction log
+        val totalBytes = qualifying.map(_.size).sum
+        val totalRows = qualifying.flatMap(_.numRecords).sum
+        val bytesPerRow = totalBytes.toDouble / totalRows
+        val advisory = config.targetSplitSizeBytes
+        logger.info(
+          s"History mode: ${qualifying.length} qualifying splits, " +
+            s"bytesPerRow=${f"$bytesPerRow%.1f"}, advisory=${SizeParser.formatBytes(advisory)}"
+        )
+        advisory
+      } else {
+        // SAMPLING MODE: use configured ratio as fallback
+        val advisory = (config.targetSplitSizeBytes / config.samplingRatio).toLong
+        logger.info(
+          s"Sampling mode: advisory=${SizeParser.formatBytes(advisory)} " +
+            s"(target=${SizeParser.formatBytes(config.targetSplitSizeBytes)} / ratio=${config.samplingRatio})"
+        )
+        advisory
+      }
+    } catch {
+      case e: Exception =>
+        logger.warn(s"Size estimation failed, falling back to sampling: ${e.getMessage}")
+        (config.targetSplitSizeBytes / config.samplingRatio).toLong
+    }
+}

--- a/src/test/scala/io/indextables/spark/write/OptimizedWriteConfigTest.scala
+++ b/src/test/scala/io/indextables/spark/write/OptimizedWriteConfigTest.scala
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.write
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class OptimizedWriteConfigTest extends AnyFunSuite with Matchers {
+
+  private def makeOptions(entries: (String, String)*): CaseInsensitiveStringMap =
+    new CaseInsensitiveStringMap(entries.toMap.asJava)
+
+  test("default values") {
+    val config = OptimizedWriteConfig.default
+    config.enabled shouldBe false
+    config.targetSplitSizeBytes shouldBe (1L * 1024 * 1024 * 1024)
+    config.samplingRatio shouldBe 1.1
+    config.minRowsForEstimation shouldBe 10000L
+    config.distributionMode shouldBe "hash"
+  }
+
+  test("fromOptions with all defaults") {
+    val config = OptimizedWriteConfig.fromOptions(makeOptions())
+    config.enabled shouldBe false
+    config.targetSplitSizeBytes shouldBe (1L * 1024 * 1024 * 1024)
+    config.samplingRatio shouldBe 1.1
+    config.minRowsForEstimation shouldBe 10000L
+    config.distributionMode shouldBe "hash"
+  }
+
+  test("fromOptions with all values specified") {
+    val config = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_ENABLED -> "true",
+      OptimizedWriteConfig.KEY_TARGET_SPLIT_SIZE -> "512M",
+      OptimizedWriteConfig.KEY_SAMPLING_RATIO -> "1.5",
+      OptimizedWriteConfig.KEY_MIN_ROWS_FOR_EST -> "5000",
+      OptimizedWriteConfig.KEY_DISTRIBUTION_MODE -> "none"
+    ))
+    config.enabled shouldBe true
+    config.targetSplitSizeBytes shouldBe (512L * 1024 * 1024)
+    config.samplingRatio shouldBe 1.5
+    config.minRowsForEstimation shouldBe 5000L
+    config.distributionMode shouldBe "none"
+  }
+
+  test("fromOptions parses size strings correctly") {
+    val config1G = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_TARGET_SPLIT_SIZE -> "1G"
+    ))
+    config1G.targetSplitSizeBytes shouldBe (1L * 1024 * 1024 * 1024)
+
+    val config2G = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_TARGET_SPLIT_SIZE -> "2G"
+    ))
+    config2G.targetSplitSizeBytes shouldBe (2L * 1024 * 1024 * 1024)
+
+    val config256M = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_TARGET_SPLIT_SIZE -> "256M"
+    ))
+    config256M.targetSplitSizeBytes shouldBe (256L * 1024 * 1024)
+  }
+
+  test("fromOptions falls back to defaults for invalid boolean") {
+    val config = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_ENABLED -> "notabool"
+    ))
+    config.enabled shouldBe false
+  }
+
+  test("fromOptions falls back to defaults for invalid sampling ratio") {
+    // Zero ratio
+    val config1 = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_SAMPLING_RATIO -> "0"
+    ))
+    config1.samplingRatio shouldBe 1.1
+
+    // Negative ratio
+    val config2 = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_SAMPLING_RATIO -> "-1.0"
+    ))
+    config2.samplingRatio shouldBe 1.1
+
+    // Non-numeric
+    val config3 = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_SAMPLING_RATIO -> "abc"
+    ))
+    config3.samplingRatio shouldBe 1.1
+  }
+
+  test("fromOptions falls back to defaults for invalid minRows") {
+    val config = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_MIN_ROWS_FOR_EST -> "-100"
+    ))
+    config.minRowsForEstimation shouldBe 10000L
+  }
+
+  test("fromOptions falls back to defaults for invalid distribution mode") {
+    val config = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_DISTRIBUTION_MODE -> "invalid"
+    ))
+    config.distributionMode shouldBe "hash"
+  }
+
+  test("fromOptions distribution mode is case-insensitive") {
+    val config = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_DISTRIBUTION_MODE -> "HASH"
+    ))
+    config.distributionMode shouldBe "hash"
+
+    val config2 = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_DISTRIBUTION_MODE -> "None"
+    ))
+    config2.distributionMode shouldBe "none"
+  }
+
+  test("fromOptions falls back to defaults for invalid size string") {
+    val config = OptimizedWriteConfig.fromOptions(makeOptions(
+      OptimizedWriteConfig.KEY_TARGET_SPLIT_SIZE -> "notasize"
+    ))
+    config.targetSplitSizeBytes shouldBe (1L * 1024 * 1024 * 1024)
+  }
+
+  test("fromMap with valid values") {
+    val config = OptimizedWriteConfig.fromMap(Map(
+      OptimizedWriteConfig.KEY_ENABLED -> "true",
+      OptimizedWriteConfig.KEY_TARGET_SPLIT_SIZE -> "2G",
+      OptimizedWriteConfig.KEY_SAMPLING_RATIO -> "1.3",
+      OptimizedWriteConfig.KEY_MIN_ROWS_FOR_EST -> "20000",
+      OptimizedWriteConfig.KEY_DISTRIBUTION_MODE -> "none"
+    ))
+    config.enabled shouldBe true
+    config.targetSplitSizeBytes shouldBe (2L * 1024 * 1024 * 1024)
+    config.samplingRatio shouldBe 1.3
+    config.minRowsForEstimation shouldBe 20000L
+    config.distributionMode shouldBe "none"
+  }
+
+  test("fromMap is case-insensitive on keys") {
+    val config = OptimizedWriteConfig.fromMap(Map(
+      "SPARK.INDEXTABLES.WRITE.OPTIMIZEWRITE.ENABLED" -> "true"
+    ))
+    config.enabled shouldBe true
+  }
+
+  test("validate rejects negative target size") {
+    an[IllegalArgumentException] should be thrownBy {
+      OptimizedWriteConfig(targetSplitSizeBytes = -1).validate()
+    }
+  }
+
+  test("validate rejects zero sampling ratio") {
+    an[IllegalArgumentException] should be thrownBy {
+      OptimizedWriteConfig(samplingRatio = 0.0).validate()
+    }
+  }
+
+  test("validate rejects negative minRows") {
+    an[IllegalArgumentException] should be thrownBy {
+      OptimizedWriteConfig(minRowsForEstimation = -1).validate()
+    }
+  }
+
+  test("validate rejects invalid distribution mode") {
+    an[IllegalArgumentException] should be thrownBy {
+      OptimizedWriteConfig(distributionMode = "random").validate()
+    }
+  }
+
+  test("targetSplitSizeString formats correctly") {
+    OptimizedWriteConfig(targetSplitSizeBytes = 1L * 1024 * 1024 * 1024).targetSplitSizeString shouldBe "1G"
+    OptimizedWriteConfig(targetSplitSizeBytes = 512L * 1024 * 1024).targetSplitSizeString shouldBe "512M"
+  }
+}

--- a/src/test/scala/io/indextables/spark/write/OptimizedWriteIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/write/OptimizedWriteIntegrationTest.scala
@@ -1,0 +1,500 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.write
+
+import io.indextables.spark.TestBase
+import io.indextables.spark.transaction.TransactionLog
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.connector.distributions.{ClusteredDistribution, UnspecifiedDistribution}
+import org.apache.spark.sql.connector.expressions.NamedReference
+import org.apache.spark.sql.connector.write.RequiresDistributionAndOrdering
+
+class OptimizedWriteIntegrationTest extends TestBase {
+
+  private val FORMAT = "io.indextables.spark.core.IndexTables4SparkTableProvider"
+  private val GB = 1024L * 1024 * 1024
+
+  // Helper to create a TransactionLog for direct API testing
+  private def createTxLog(tablePath: Path): TransactionLog = {
+    import scala.jdk.CollectionConverters._
+    new TransactionLog(tablePath, spark, new org.apache.spark.sql.util.CaseInsensitiveStringMap(
+      Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava
+    ))
+  }
+
+  // Helper to create a WriteBuilder for API testing
+  private def createWriteBuilder(
+    tablePath: Path,
+    txLog: TransactionLog,
+    extraOptions: Map[String, String] = Map.empty,
+    schemaFields: Seq[(String, String)] = Seq("id" -> "long", "text" -> "string")
+  ): io.indextables.spark.core.IndexTables4SparkWriteBuilder = {
+    import scala.jdk.CollectionConverters._
+    val baseOptions = Map(
+      "spark.indextables.aws.accessKey" -> "test",
+      "spark.indextables.aws.secretKey" -> "test",
+      "spark.indextables.s3.pathStyleAccess" -> "true",
+      "spark.indextables.aws.region" -> "us-east-1",
+      "spark.indextables.s3.endpoint" -> "http://localhost:10101"
+    )
+    val writeOptions = new org.apache.spark.sql.util.CaseInsensitiveStringMap(
+      (baseOptions ++ extraOptions).asJava
+    )
+    var writeSchema = new org.apache.spark.sql.types.StructType()
+    schemaFields.foreach { case (name, typ) => writeSchema = writeSchema.add(name, typ) }
+
+    val writeInfo = new org.apache.spark.sql.connector.write.LogicalWriteInfo {
+      override def queryId(): String = "test-query"
+      override def schema(): org.apache.spark.sql.types.StructType = writeSchema
+      override def options(): org.apache.spark.sql.util.CaseInsensitiveStringMap = writeOptions
+    }
+
+    new io.indextables.spark.core.IndexTables4SparkWriteBuilder(
+      txLog, tablePath, writeInfo, writeOptions, spark.sparkContext.hadoopConfiguration
+    )
+  }
+
+  // ===== E2E Write/Read Tests =====
+
+  test("disabled by default - standard write behavior") {
+    withTempPath { path =>
+      val tablePath = s"file://$path/test_disabled"
+      val df = spark.range(0, 100).selectExpr("id", "CAST(id AS STRING) as text")
+
+      df.write
+        .mode("overwrite")
+        .format(FORMAT)
+        .save(tablePath)
+
+      val result = spark.read.format(FORMAT).load(tablePath)
+      result.count() shouldBe 100
+    }
+  }
+
+  test("enabled write produces correct data with all values intact") {
+    withTempPath { path =>
+      val tablePath = s"file://$path/test_enabled"
+      val df = spark.range(0, 200).selectExpr("id", "CAST(id AS STRING) as text")
+
+      df.write
+        .mode("overwrite")
+        .format(FORMAT)
+        .option(OptimizedWriteConfig.KEY_ENABLED, "true")
+        .option(OptimizedWriteConfig.KEY_TARGET_SPLIT_SIZE, "1G")
+        .save(tablePath)
+
+      val result = spark.read.format(FORMAT).load(tablePath)
+      result.count() shouldBe 200
+
+      // Verify actual data values survive the optimized write path
+      val ids = result.select("id").collect().map(_.getLong(0)).sorted
+      ids shouldBe (0L until 200L).toArray
+    }
+  }
+
+  test("enabled write with distribution mode none") {
+    withTempPath { path =>
+      val tablePath = s"file://$path/test_none_mode"
+      val df = spark.range(0, 100).selectExpr("id", "CAST(id AS STRING) as text")
+
+      df.write
+        .mode("overwrite")
+        .format(FORMAT)
+        .option(OptimizedWriteConfig.KEY_ENABLED, "true")
+        .option(OptimizedWriteConfig.KEY_DISTRIBUTION_MODE, "none")
+        .save(tablePath)
+
+      val result = spark.read.format(FORMAT).load(tablePath)
+      result.count() shouldBe 100
+    }
+  }
+
+  test("partitioned table with optimized write - data integrity per partition") {
+    withTempPath { path =>
+      val tablePath = s"file://$path/test_partitioned"
+      val df = spark.range(0, 300)
+        .selectExpr("id", "CAST(id AS STRING) as text", "CAST(id % 3 AS STRING) as category")
+
+      df.write
+        .mode("overwrite")
+        .format(FORMAT)
+        .partitionBy("category")
+        .option(OptimizedWriteConfig.KEY_ENABLED, "true")
+        .option(OptimizedWriteConfig.KEY_TARGET_SPLIT_SIZE, "1G")
+        .save(tablePath)
+
+      val result = spark.read.format(FORMAT).load(tablePath)
+      result.count() shouldBe 300
+
+      // Verify each partition has the correct count
+      result.filter("category = '0'").count() shouldBe 100
+      result.filter("category = '1'").count() shouldBe 100
+      result.filter("category = '2'").count() shouldBe 100
+
+      // Verify data values within a partition
+      val cat0Ids = result.filter("category = '0'").select("id").collect().map(_.getLong(0)).sorted
+      cat0Ids shouldBe (0L until 300L).filter(_ % 3 == 0).toArray
+    }
+  }
+
+  test("append after initial write preserves all data") {
+    withTempPath { path =>
+      val tablePath = s"file://$path/test_append"
+
+      // Initial write
+      val df1 = spark.range(0, 100).selectExpr("id", "CAST(id AS STRING) as text")
+      df1.write
+        .mode("overwrite")
+        .format(FORMAT)
+        .option(OptimizedWriteConfig.KEY_ENABLED, "true")
+        .save(tablePath)
+
+      // Append write
+      val df2 = spark.range(100, 200).selectExpr("id", "CAST(id AS STRING) as text")
+      df2.write
+        .mode("append")
+        .format(FORMAT)
+        .option(OptimizedWriteConfig.KEY_ENABLED, "true")
+        .save(tablePath)
+
+      val result = spark.read.format(FORMAT).load(tablePath)
+      result.count() shouldBe 200
+
+      // Verify both batches present
+      val ids = result.select("id").collect().map(_.getLong(0)).sorted
+      ids shouldBe (0L until 200L).toArray
+    }
+  }
+
+  // ===== WriteBuilder Type Selection Tests =====
+
+  test("WriteBuilder creates StandardWrite when disabled - not RequiresDistributionAndOrdering") {
+    withTempPath { path =>
+      val tablePath = new Path(s"file://$path/test_builder")
+      val txLog = createTxLog(tablePath)
+
+      val builder = createWriteBuilder(tablePath, txLog, Map(
+        OptimizedWriteConfig.KEY_ENABLED -> "false"
+      ))
+      val write = builder.build()
+
+      write.getClass.getSimpleName shouldBe "IndexTables4SparkStandardWrite"
+      write shouldNot be(a[RequiresDistributionAndOrdering])
+
+      txLog.close()
+    }
+  }
+
+  test("WriteBuilder creates OptimizedWrite when enabled - is RequiresDistributionAndOrdering") {
+    withTempPath { path =>
+      val tablePath = new Path(s"file://$path/test_builder_opt")
+      val txLog = createTxLog(tablePath)
+
+      val builder = createWriteBuilder(tablePath, txLog, Map(
+        OptimizedWriteConfig.KEY_ENABLED -> "true"
+      ))
+      val write = builder.build()
+
+      write.getClass.getSimpleName shouldBe "IndexTables4SparkOptimizedWrite"
+      write shouldBe a[RequiresDistributionAndOrdering]
+
+      txLog.close()
+    }
+  }
+
+  // ===== RequiresDistributionAndOrdering API Behavior Tests =====
+
+  test("partitioned + hash: clustered distribution with correct partition column expressions") {
+    withTempPath { path =>
+      val tablePath = new Path(s"file://$path/test_dist_partitioned")
+      val txLog = createTxLog(tablePath)
+
+      val builder = createWriteBuilder(tablePath, txLog,
+        extraOptions = Map(
+          OptimizedWriteConfig.KEY_ENABLED -> "true",
+          "__partition_columns" -> """["category"]"""
+        ),
+        schemaFields = Seq("id" -> "long", "text" -> "string", "category" -> "string")
+      )
+      val write = builder.build().asInstanceOf[RequiresDistributionAndOrdering]
+
+      // Distribution should be ClusteredDistribution
+      val dist = write.requiredDistribution()
+      dist shouldBe a[ClusteredDistribution]
+
+      // Clustering expressions should contain exactly the partition column
+      val clustered = dist.asInstanceOf[ClusteredDistribution]
+      val clusteringExprs = clustered.clustering()
+      clusteringExprs should have length 1
+      clusteringExprs(0) shouldBe a[NamedReference]
+      clusteringExprs(0).asInstanceOf[NamedReference].fieldNames() shouldBe Array("category")
+
+      // Ordering should be empty
+      write.requiredOrdering() shouldBe empty
+
+      // Distribution should not be strictly required
+      write.distributionStrictlyRequired() shouldBe false
+
+      // Advisory size should be sampling-mode value (no history): targetSize / ratio
+      val expectedAdvisory = (GB / 1.1).toLong
+      write.advisoryPartitionSizeInBytes() shouldBe expectedAdvisory
+
+      txLog.close()
+    }
+  }
+
+  test("partitioned + hash + multiple partition columns: all columns in clustering") {
+    withTempPath { path =>
+      val tablePath = new Path(s"file://$path/test_dist_multi_part")
+      val txLog = createTxLog(tablePath)
+
+      val builder = createWriteBuilder(tablePath, txLog,
+        extraOptions = Map(
+          OptimizedWriteConfig.KEY_ENABLED -> "true",
+          "__partition_columns" -> """["region","date"]"""
+        ),
+        schemaFields = Seq("id" -> "long", "text" -> "string", "region" -> "string", "date" -> "string")
+      )
+      val write = builder.build().asInstanceOf[RequiresDistributionAndOrdering]
+
+      val dist = write.requiredDistribution()
+      dist shouldBe a[ClusteredDistribution]
+
+      val clustered = dist.asInstanceOf[ClusteredDistribution]
+      val clusteringExprs = clustered.clustering()
+      clusteringExprs should have length 2
+      clusteringExprs(0).asInstanceOf[NamedReference].fieldNames() shouldBe Array("region")
+      clusteringExprs(1).asInstanceOf[NamedReference].fieldNames() shouldBe Array("date")
+
+      // Advisory should be set (> 0) since we have partition columns + hash mode
+      write.advisoryPartitionSizeInBytes() should be > 0L
+
+      txLog.close()
+    }
+  }
+
+  test("partitioned + mode=none: unspecified distribution and advisory=0") {
+    withTempPath { path =>
+      val tablePath = new Path(s"file://$path/test_dist_none_mode")
+      val txLog = createTxLog(tablePath)
+
+      val builder = createWriteBuilder(tablePath, txLog,
+        extraOptions = Map(
+          OptimizedWriteConfig.KEY_ENABLED -> "true",
+          OptimizedWriteConfig.KEY_DISTRIBUTION_MODE -> "none",
+          "__partition_columns" -> """["category"]"""
+        ),
+        schemaFields = Seq("id" -> "long", "text" -> "string", "category" -> "string")
+      )
+      val write = builder.build().asInstanceOf[RequiresDistributionAndOrdering]
+
+      // Even with partition columns, mode=none should give unspecified
+      val dist = write.requiredDistribution()
+      dist shouldBe a[UnspecifiedDistribution]
+
+      // Advisory must be 0 with UnspecifiedDistribution (Spark constraint)
+      write.advisoryPartitionSizeInBytes() shouldBe 0L
+
+      write.distributionStrictlyRequired() shouldBe false
+      write.requiredOrdering() shouldBe empty
+
+      txLog.close()
+    }
+  }
+
+  test("unpartitioned + hash: clustered distribution on first schema column with advisory size") {
+    withTempPath { path =>
+      val tablePath = new Path(s"file://$path/test_dist_unpartitioned")
+      val txLog = createTxLog(tablePath)
+
+      val builder = createWriteBuilder(tablePath, txLog, Map(
+        OptimizedWriteConfig.KEY_ENABLED -> "true"
+      ))
+      val write = builder.build().asInstanceOf[RequiresDistributionAndOrdering]
+
+      // Unpartitioned tables cluster by a single column to trigger a shuffle.
+      // Spark 3.5 rejects empty clustering + advisory > 0, so we use the first schema
+      // column — just enough to enter the shuffle branch while keeping hash cost O(1).
+      val dist = write.requiredDistribution()
+      dist shouldBe a[ClusteredDistribution]
+
+      val clustered = dist.asInstanceOf[ClusteredDistribution]
+      val clusteringExprs = clustered.clustering()
+      // Default schema is (id: long, text: string) - should cluster by first column only
+      clusteringExprs should have length 1
+      clusteringExprs(0).asInstanceOf[NamedReference].fieldNames() shouldBe Array("id")
+
+      // Advisory size should be set (not 0) since we have a clustered distribution
+      val expectedAdvisory = (GB / 1.1).toLong
+      write.advisoryPartitionSizeInBytes() shouldBe expectedAdvisory
+
+      write.distributionStrictlyRequired() shouldBe false
+      write.requiredOrdering() shouldBe empty
+
+      txLog.close()
+    }
+  }
+
+  test("advisory size uses configured targetSplitSize and samplingRatio") {
+    withTempPath { path =>
+      val tablePath = new Path(s"file://$path/test_advisory_custom")
+      val txLog = createTxLog(tablePath)
+
+      val targetSize = 2L * GB
+      val ratio = 2.0
+
+      val builder = createWriteBuilder(tablePath, txLog,
+        extraOptions = Map(
+          OptimizedWriteConfig.KEY_ENABLED -> "true",
+          OptimizedWriteConfig.KEY_TARGET_SPLIT_SIZE -> "2G",
+          OptimizedWriteConfig.KEY_SAMPLING_RATIO -> "2.0",
+          "__partition_columns" -> """["category"]"""
+        ),
+        schemaFields = Seq("id" -> "long", "text" -> "string", "category" -> "string")
+      )
+      val write = builder.build().asInstanceOf[RequiresDistributionAndOrdering]
+
+      // Sampling mode (empty tx log): advisory = targetSize / ratio = 2GB / 2.0 = 1GB
+      val expectedAdvisory = (targetSize / ratio).toLong
+      write.advisoryPartitionSizeInBytes() shouldBe expectedAdvisory
+      expectedAdvisory shouldBe GB // sanity check
+
+      txLog.close()
+    }
+  }
+
+  // ===== Consolidation Tests =====
+
+  test("consolidation: optimized write produces fewer splits than non-optimized with many input partitions") {
+    withTempPath { path =>
+      val nonOptPath = s"file://$path/non_optimized"
+      val optPath = s"file://$path/optimized"
+
+      // Create small data repartitioned to many partitions - simulates
+      // data arriving in many small chunks from a wide shuffle
+      val df = spark.range(0, 300)
+        .repartition(50)
+        .selectExpr("id", "CAST(id AS STRING) as text", "CAST(id % 3 AS STRING) as category")
+
+      // Non-optimized write: 50 input partitions, each writing per-partition-value splits
+      df.write
+        .mode("overwrite")
+        .format(FORMAT)
+        .partitionBy("category")
+        .save(nonOptPath)
+
+      // Optimized write: AQE should coalesce 200 shuffle partitions down
+      // to ~3 (one per partition value) since data is tiny vs 1G target
+      df.write
+        .mode("overwrite")
+        .format(FORMAT)
+        .partitionBy("category")
+        .option(OptimizedWriteConfig.KEY_ENABLED, "true")
+        .option(OptimizedWriteConfig.KEY_TARGET_SPLIT_SIZE, "1G")
+        .save(optPath)
+
+      // Verify data integrity in both cases
+      spark.read.format(FORMAT).load(nonOptPath).count() shouldBe 300
+      spark.read.format(FORMAT).load(optPath).count() shouldBe 300
+
+      // Count splits in each table
+      val nonOptTxLog = createTxLog(new Path(nonOptPath))
+      val optTxLog = createTxLog(new Path(optPath))
+
+      val nonOptSplitCount = nonOptTxLog.listFiles().length
+      val optSplitCount = optTxLog.listFiles().length
+
+      // Non-optimized: 50 input tasks × up to 3 partition values = many splits
+      // Optimized: AQE coalesces tiny data → ~3 splits (one per partition value)
+      withClue(s"non-optimized=$nonOptSplitCount splits, optimized=$optSplitCount splits: ") {
+        optSplitCount should be < nonOptSplitCount
+        optSplitCount should be <= 6 // At most a few (3 partitions, maybe some AQE variance)
+      }
+
+      nonOptTxLog.close()
+      optTxLog.close()
+    }
+  }
+
+  test("consolidation: unpartitioned small data consolidates to few splits with optimized write") {
+    withTempPath { path =>
+      val nonOptPath = s"file://$path/non_optimized"
+      val optPath = s"file://$path/optimized"
+
+      // Small data repartitioned to many partitions
+      val df = spark.range(0, 100)
+        .repartition(50)
+        .selectExpr("id", "CAST(id AS STRING) as text")
+
+      // Non-optimized: 50 input partitions → ~50 splits
+      df.write
+        .mode("overwrite")
+        .format(FORMAT)
+        .save(nonOptPath)
+
+      // Optimized: ClusteredDistribution(all columns) triggers AQE rebalance,
+      // AQE coalesces based on 1G advisory → should produce very few splits
+      df.write
+        .mode("overwrite")
+        .format(FORMAT)
+        .option(OptimizedWriteConfig.KEY_ENABLED, "true")
+        .option(OptimizedWriteConfig.KEY_TARGET_SPLIT_SIZE, "1G")
+        .save(optPath)
+
+      // Verify data integrity
+      spark.read.format(FORMAT).load(nonOptPath).count() shouldBe 100
+      spark.read.format(FORMAT).load(optPath).count() shouldBe 100
+
+      val nonOptTxLog = createTxLog(new Path(nonOptPath))
+      val optTxLog = createTxLog(new Path(optPath))
+
+      val nonOptSplitCount = nonOptTxLog.listFiles().length
+      val optSplitCount = optTxLog.listFiles().length
+
+      // Non-optimized: 50 input partitions → many splits
+      // Optimized: AQE coalesces tiny data with 1G advisory → very few splits
+      withClue(s"non-optimized=$nonOptSplitCount splits, optimized=$optSplitCount splits: ") {
+        optSplitCount should be < nonOptSplitCount
+        optSplitCount should be <= 5 // 100 tiny rows with 1G target → ~1 split
+      }
+
+      nonOptTxLog.close()
+      optTxLog.close()
+    }
+  }
+
+  // ===== WriteBuilder / API Tests =====
+
+  test("toBatch returns self for OptimizedWrite") {
+    withTempPath { path =>
+      val tablePath = new Path(s"file://$path/test_tobatch")
+      val txLog = createTxLog(tablePath)
+
+      val builder = createWriteBuilder(tablePath, txLog, Map(
+        OptimizedWriteConfig.KEY_ENABLED -> "true"
+      ))
+      val write = builder.build()
+      val batch = write.toBatch
+
+      // toBatch should return the same instance (inherited from StandardWrite)
+      batch shouldBe theSameInstanceAs(write)
+
+      txLog.close()
+    }
+  }
+}

--- a/src/test/scala/io/indextables/spark/write/WriteSizeEstimatorTest.scala
+++ b/src/test/scala/io/indextables/spark/write/WriteSizeEstimatorTest.scala
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.write
+
+import io.indextables.spark.transaction._
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.sources.Filter
+import org.apache.spark.sql.types.StructType
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class WriteSizeEstimatorTest extends AnyFunSuite with Matchers {
+
+  private val GB = 1024L * 1024 * 1024
+  private val MB = 1024L * 1024
+
+  private def makeAddAction(
+    size: Long,
+    numRecords: Option[Long] = None
+  ): AddAction =
+    AddAction(
+      path = s"test-${System.nanoTime()}.split",
+      partitionValues = Map.empty,
+      size = size,
+      modificationTime = System.currentTimeMillis(),
+      dataChange = true,
+      numRecords = numRecords
+    )
+
+  /** Minimal stub of TransactionLogInterface that returns canned AddActions. */
+  private class StubTransactionLog(files: Seq[AddAction] = Seq.empty, throwOnList: Boolean = false)
+      extends TransactionLogInterface {
+
+    override def getTablePath(): Path = new Path("file:///tmp/stub")
+    override def initialize(schema: StructType): Unit = ()
+    override def initialize(schema: StructType, partitionColumns: Seq[String]): Unit = ()
+    override def addFiles(addActions: Seq[AddAction]): Long = 0L
+    override def overwriteFiles(addActions: Seq[AddAction]): Long = 0L
+    override def removeFile(path: String, deletionTimestamp: Long): Long = 0L
+    override def listFiles(): Seq[AddAction] =
+      if (throwOnList) throw new RuntimeException("Simulated failure") else files
+    override def getTotalRowCount(): Long = files.flatMap(_.numRecords).sum
+    override def getSchema(): Option[StructType] = None
+    override def getPartitionColumns(): Seq[String] = Seq.empty
+    override def isPartitioned(): Boolean = false
+    override def getMetadata(): MetadataAction =
+      MetadataAction("stub", None, None, FileFormat("tantivy", Map.empty), "", Seq.empty, Map.empty, None)
+    override def getProtocol(): ProtocolAction = ProtocolAction(1, 1)
+    override def assertTableReadable(): Unit = ()
+    override def assertTableWritable(): Unit = ()
+    override def upgradeProtocol(newMinReaderVersion: Int, newMinWriterVersion: Int): Unit = ()
+    override def close(): Unit = ()
+  }
+
+  test("sampling mode: empty transaction log") {
+    val config = OptimizedWriteConfig(targetSplitSizeBytes = GB, samplingRatio = 1.1)
+    val estimator = new WriteSizeEstimator(new StubTransactionLog(), config)
+
+    val advisory = estimator.calculateAdvisoryPartitionSize()
+    advisory shouldBe (GB / 1.1).toLong
+  }
+
+  test("sampling mode: splits with too few rows") {
+    val files = Seq(
+      makeAddAction(size = 100 * MB, numRecords = Some(500)),   // Below minRowsForEstimation
+      makeAddAction(size = 50 * MB, numRecords = Some(1000))    // Below minRowsForEstimation
+    )
+    val config = OptimizedWriteConfig(
+      targetSplitSizeBytes = GB,
+      samplingRatio = 1.1,
+      minRowsForEstimation = 10000
+    )
+    val estimator = new WriteSizeEstimator(new StubTransactionLog(files), config)
+
+    val advisory = estimator.calculateAdvisoryPartitionSize()
+    advisory shouldBe (GB / 1.1).toLong
+  }
+
+  test("sampling mode: splits with no numRecords") {
+    val files = Seq(
+      makeAddAction(size = 500 * MB, numRecords = None),
+      makeAddAction(size = 300 * MB, numRecords = None)
+    )
+    val config = OptimizedWriteConfig(targetSplitSizeBytes = GB, samplingRatio = 1.1)
+    val estimator = new WriteSizeEstimator(new StubTransactionLog(files), config)
+
+    val advisory = estimator.calculateAdvisoryPartitionSize()
+    advisory shouldBe (GB / 1.1).toLong
+  }
+
+  test("history mode: qualifying splits exist") {
+    val files = Seq(
+      makeAddAction(size = 500 * MB, numRecords = Some(50000)),
+      makeAddAction(size = 700 * MB, numRecords = Some(70000))
+    )
+    val config = OptimizedWriteConfig(
+      targetSplitSizeBytes = GB,
+      samplingRatio = 1.1,
+      minRowsForEstimation = 10000
+    )
+    val estimator = new WriteSizeEstimator(new StubTransactionLog(files), config)
+
+    val advisory = estimator.calculateAdvisoryPartitionSize()
+    // History mode returns targetSplitSize directly
+    advisory shouldBe GB
+  }
+
+  test("history mode: mixed qualifying and non-qualifying splits") {
+    val files = Seq(
+      makeAddAction(size = 500 * MB, numRecords = Some(50000)),   // Qualifying
+      makeAddAction(size = 10 * MB, numRecords = Some(500)),       // Too few rows
+      makeAddAction(size = 800 * MB, numRecords = Some(80000))    // Qualifying
+    )
+    val config = OptimizedWriteConfig(
+      targetSplitSizeBytes = 2 * GB,
+      samplingRatio = 1.1,
+      minRowsForEstimation = 10000
+    )
+    val estimator = new WriteSizeEstimator(new StubTransactionLog(files), config)
+
+    val advisory = estimator.calculateAdvisoryPartitionSize()
+    // Only qualifying splits used, returns targetSplitSize
+    advisory shouldBe (2 * GB)
+  }
+
+  test("sampling mode with custom ratio") {
+    val config = OptimizedWriteConfig(
+      targetSplitSizeBytes = 2 * GB,
+      samplingRatio = 2.0
+    )
+    val estimator = new WriteSizeEstimator(new StubTransactionLog(), config)
+
+    val advisory = estimator.calculateAdvisoryPartitionSize()
+    advisory shouldBe GB // 2GB / 2.0 = 1GB
+  }
+
+  test("falls back to sampling on listFiles exception") {
+    val config = OptimizedWriteConfig(targetSplitSizeBytes = GB, samplingRatio = 1.1)
+    val estimator = new WriteSizeEstimator(new StubTransactionLog(throwOnList = true), config)
+
+    val advisory = estimator.calculateAdvisoryPartitionSize()
+    advisory shouldBe (GB / 1.1).toLong
+  }
+
+  test("history mode with single qualifying split") {
+    val files = Seq(
+      makeAddAction(size = 200 * MB, numRecords = Some(20000))
+    )
+    val config = OptimizedWriteConfig(
+      targetSplitSizeBytes = GB,
+      minRowsForEstimation = 10000
+    )
+    val estimator = new WriteSizeEstimator(new StubTransactionLog(files), config)
+
+    val advisory = estimator.calculateAdvisoryPartitionSize()
+    advisory shouldBe GB
+  }
+
+  test("minRowsForEstimation boundary: exactly at threshold qualifies for history mode") {
+    val files = Seq(
+      makeAddAction(size = 500 * MB, numRecords = Some(10000)) // Exactly at threshold
+    )
+    val config = OptimizedWriteConfig(
+      targetSplitSizeBytes = GB,
+      samplingRatio = 1.1,
+      minRowsForEstimation = 10000
+    )
+    val estimator = new WriteSizeEstimator(new StubTransactionLog(files), config)
+
+    // Should use history mode (returns targetSplitSize)
+    estimator.calculateAdvisoryPartitionSize() shouldBe GB
+  }
+
+  test("minRowsForEstimation boundary: one below threshold falls back to sampling mode") {
+    val files = Seq(
+      makeAddAction(size = 500 * MB, numRecords = Some(9999)) // Just below threshold
+    )
+    val config = OptimizedWriteConfig(
+      targetSplitSizeBytes = GB,
+      samplingRatio = 1.1,
+      minRowsForEstimation = 10000
+    )
+    val estimator = new WriteSizeEstimator(new StubTransactionLog(files), config)
+
+    // Should use sampling mode (returns targetSplitSize / samplingRatio)
+    estimator.calculateAdvisoryPartitionSize() shouldBe (GB / 1.1).toLong
+  }
+
+  test("history mode vs sampling mode produce different values") {
+    val files = Seq(
+      makeAddAction(size = 500 * MB, numRecords = Some(50000))
+    )
+    val config = OptimizedWriteConfig(
+      targetSplitSizeBytes = GB,
+      samplingRatio = 1.1,
+      minRowsForEstimation = 10000
+    )
+
+    // History mode (with qualifying splits)
+    val historyAdvisory = new WriteSizeEstimator(new StubTransactionLog(files), config)
+      .calculateAdvisoryPartitionSize()
+
+    // Sampling mode (empty tx log)
+    val samplingAdvisory = new WriteSizeEstimator(new StubTransactionLog(), config)
+      .calculateAdvisoryPartitionSize()
+
+    // History mode = targetSplitSize = 1GB
+    historyAdvisory shouldBe GB
+    // Sampling mode = targetSplitSize / ratio ≈ 930MB
+    samplingAdvisory shouldBe (GB / 1.1).toLong
+
+    // They should differ
+    historyAdvisory should not equal samplingAdvisory
+    // History mode should be larger (since ratio > 1.0)
+    historyAdvisory should be > samplingAdvisory
+  }
+
+  test("different targetSplitSizeBytes produce proportionally different advisories") {
+    // Use ratio=2.0 to avoid integer division rounding differences
+    val config1G = OptimizedWriteConfig(targetSplitSizeBytes = GB, samplingRatio = 2.0)
+    val config2G = OptimizedWriteConfig(targetSplitSizeBytes = 2 * GB, samplingRatio = 2.0)
+
+    val advisory1G = new WriteSizeEstimator(new StubTransactionLog(), config1G)
+      .calculateAdvisoryPartitionSize()
+    val advisory2G = new WriteSizeEstimator(new StubTransactionLog(), config2G)
+      .calculateAdvisoryPartitionSize()
+
+    // 1G/2.0 = 512M, 2G/2.0 = 1G — exactly 2x
+    advisory1G shouldBe (GB / 2)
+    advisory2G shouldBe GB
+    advisory2G shouldBe (2 * advisory1G)
+  }
+}


### PR DESCRIPTION
# PR: Optimized Writes via RequiresDistributionAndOrdering

## Summary

- Add configurable shuffle-based write optimization using Spark's DSv2 `RequiresDistributionAndOrdering` interface
- Produces well-sized splits (~1GB default) by requesting a clustered distribution + advisory partition size, letting AQE coalesce shuffle partitions
- Disabled by default; when off, zero code path changes

## Motivation

Without this feature, each Spark write task produces its own splits independently. With many tasks writing small amounts of data (common after joins, filters, or wide shuffles), this produces many undersized splits — increasing read latency, S3 request counts, and merge overhead.

Delta Lake ("Optimize Write") and Iceberg ("write distribution mode") solve this using the same Spark DSv2 interface. This PR brings equivalent functionality to IndexTables4Spark.

## Design

### Thin subclass — zero duplication

`IndexTables4SparkOptimizedWrite` extends `IndexTables4SparkStandardWrite` and mixes in `RequiresDistributionAndOrdering`. It overrides only 4 methods. All commit, writer factory, data writer, merge-on-write, and purge-on-write logic (747 lines) is inherited unchanged.

`WriteBuilder.build()` checks config and returns either `StandardWrite` or `OptimizedWrite`.

### Distribution strategy

| Table type | Distribution | Advisory size | Behavior |
|---|---|---|---|
| **Partitioned, mode=hash** | `ClusteredDistribution(partitionColumns)` | From estimator | Each writer gets one partition's data; AQE sizes partitions to ~1GB |
| **Unpartitioned, mode=hash** | `ClusteredDistribution(firstSchemaColumn)` | From estimator | Single-column hash triggers shuffle; AQE coalesces to ~1GB |
| **Any table, mode=none** | `UnspecifiedDistribution` | 0 | No shuffle (same as disabled) |

Key decisions:
- **`distributionStrictlyRequired = false`** — Spark uses `RebalancePartitions` (AQE-aware) instead of `RepartitionByExpression`. This means AQE can split skewed partitions: 3B rows with the same partition key on 16 executors will still be distributed across all executors, not stuck on one.
- **Single column for unpartitioned** — Spark 3.5 rejects `ClusteredDistribution(empty) + advisory > 0` (the empty clustering falls into the "no distribution" branch in `DistributionAndOrderingUtils.prepareQuery` and throws `PARTITION_SIZE_WITH_UNSPECIFIED_DISTRIBUTION`). Iceberg avoids this by forcing `mode=NONE` for unpartitioned tables. We instead use a single-column hash — O(1) per row regardless of schema width — just enough to enter Spark's shuffle branch so AQE can coalesce using the advisory size.
- **No ordering required** — tantivy splits don't benefit from row ordering.

### Advisory size estimation

`WriteSizeEstimator` calculates the advisory partition size using two modes:

- **History mode** (qualifying splits in transaction log): Sets advisory to `targetSplitSize` directly — we know the actual bytes-per-row from existing splits.
- **Sampling mode** (no qualifying history): Sets advisory to `targetSplitSize / samplingRatio` — conservative estimate assuming splits are ~1.1x the raw shuffle data.

Falls back to sampling mode on any exception.

## Configuration

| Key | Default | Description |
|-----|---------|-------------|
| `spark.indextables.write.optimizeWrite.enabled` | `false` | Enable shuffle-based write optimization |
| `spark.indextables.write.optimizeWrite.targetSplitSize` | `1G` | Target on-disk split size (supports size strings) |
| `spark.indextables.write.optimizeWrite.samplingRatio` | `1.1` | Split-to-shuffle-data ratio (sampling mode only) |
| `spark.indextables.write.optimizeWrite.minRowsForEstimation` | `10000` | Min rows per split to qualify for history mode |
| `spark.indextables.write.optimizeWrite.distributionMode` | `hash` | `hash` (cluster + advisory) or `none` (no shuffle) |

## Usage

```scala
// Basic: enable optimized writes
df.write
  .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
  .option("spark.indextables.write.optimizeWrite.enabled", "true")
  .save("s3://bucket/path")

// With partitions and custom target size
df.write
  .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
  .partitionBy("date", "region")
  .option("spark.indextables.write.optimizeWrite.enabled", "true")
  .option("spark.indextables.write.optimizeWrite.targetSplitSize", "512M")
  .save("s3://bucket/path")

// Session-level
spark.conf.set("spark.indextables.write.optimizeWrite.enabled", "true")
spark.conf.set("spark.indextables.write.optimizeWrite.targetSplitSize", "2G")
```

## Files changed

### New files (413 lines production, 939 lines test)

| File | Lines | Description |
|------|-------|-------------|
| `src/main/scala/.../core/IndexTables4SparkOptimizedWrite.scala` | 93 | Subclass with `RequiresDistributionAndOrdering` |
| `src/main/scala/.../write/OptimizedWriteConfig.scala` | 244 | Configuration parsing with validation and defaults |
| `src/main/scala/.../write/WriteSizeEstimator.scala` | 76 | Advisory size calculation (history + sampling modes) |
| `src/test/scala/.../write/OptimizedWriteConfigTest.scala` | 191 | 17 tests: defaults, parsing, validation, edge cases |
| `src/test/scala/.../write/WriteSizeEstimatorTest.scala` | 248 | 12 tests: both modes, boundaries, fallback |
| `src/test/scala/.../write/OptimizedWriteIntegrationTest.scala` | 500 | 15 tests: E2E writes, API behavior, consolidation |

### Modified files (2 files, ~20 lines changed)

| File | Change |
|------|--------|
| `src/main/scala/.../core/IndexTables4SparkStandardWrite.scala` | `private val partitionColumns` → `protected val partitionColumns` (1 word) |
| `src/main/scala/.../core/IndexTables4SparkWriteBuilder.scala` | `build()` dispatches to `OptimizedWrite` or `StandardWrite` based on config (~15 lines) |

## Test plan

44/44 tests passing:

- [ ] **OptimizedWriteConfigTest** (17 tests) — default values, all config keys parsed, size string parsing, validation of invalid values, case insensitivity, `fromMap` and `fromOptions` paths
- [ ] **WriteSizeEstimatorTest** (12 tests) — sampling mode (empty log, too-few-rows, no numRecords), history mode (qualifying splits, mixed, single split), boundary at `minRowsForEstimation`, exception fallback, proportional advisory values
- [ ] **OptimizedWriteIntegrationTest** (15 tests):
  - E2E (5): disabled default, enabled data integrity, mode=none, partitioned per-partition counts, append preserves data
  - API (8): StandardWrite/OptimizedWrite type selection, clustered distribution with correct columns, multi-partition columns, mode=none → UnspecifiedDistribution, unpartitioned → single-column ClusteredDistribution, advisory size from config, toBatch returns self
  - Consolidation (2): partitioned table with 50 input partitions consolidates to ≤6 splits; unpartitioned table with 50 input partitions consolidates to ≤5 splits
- [ ] Full regression (`mvn test`) — no existing tests affected

## Comparison with Iceberg

| Aspect | Iceberg | This PR |
|--------|---------|---------|
| Interface | `RequiresDistributionAndOrdering` | Same |
| Partitioned default | HASH | HASH |
| Unpartitioned default | **NONE** (explicitly forced) | HASH (single-column clustering) |
| `distributionStrictlyRequired` | `false` | `false` |
| Advisory size source | Table properties | Transaction log history or sampling ratio |
| Skew handling | AQE `RebalancePartitions` | Same |
| Unpartitioned consolidation | **Not supported** | Supported via single-column hash |
