### PR TITLE
feature: Delta UC Table Name Resolution for BUILD INDEXTABLES COMPANION

### DIFF
--- a/src/main/scala/io/indextables/spark/sql/parser/IndexTables4SparkSqlAstBuilder.scala
+++ b/src/main/scala/io/indextables/spark/sql/parser/IndexTables4SparkSqlAstBuilder.scala
@@ -738,11 +738,11 @@ class IndexTables4SparkSqlAstBuilder extends IndexTables4SparkSqlBaseBaseVisitor
         None
       }
 
-      // CATALOG (Iceberg only)
+      // CATALOG (Iceberg and Delta only - used for UC table name resolution)
       val catalogName: Option[String] = if (ctx.catalogName != null) {
         val name = ParserUtils.string(ctx.catalogName)
-        if (sourceFormat != "iceberg") {
-          throw new IllegalArgumentException("CATALOG is only valid with FOR ICEBERG")
+        if (sourceFormat == "parquet") {
+          throw new IllegalArgumentException("CATALOG is only valid with FOR DELTA or FOR ICEBERG")
         }
         logger.debug(s"Catalog name: $name")
         Some(name)
@@ -750,11 +750,11 @@ class IndexTables4SparkSqlAstBuilder extends IndexTables4SparkSqlBaseBaseVisitor
         None
       }
 
-      // CATALOG TYPE (Iceberg only, sub-clause of CATALOG)
+      // CATALOG TYPE (Iceberg and Delta only, sub-clause of CATALOG)
       val catalogType: Option[String] = if (ctx.catalogType != null) {
         val ct = ParserUtils.string(ctx.catalogType)
-        if (sourceFormat != "iceberg") {
-          throw new IllegalArgumentException("CATALOG TYPE is only valid with FOR ICEBERG")
+        if (sourceFormat == "parquet") {
+          throw new IllegalArgumentException("CATALOG TYPE is only valid with FOR DELTA or FOR ICEBERG")
         }
         logger.debug(s"Catalog type: $ct")
         Some(ct)


### PR DESCRIPTION
# Delta UC Table Name Resolution for BUILD INDEXTABLES COMPANION

## Summary

- Add Unity Catalog table name resolution for `BUILD INDEXTABLES COMPANION FOR DELTA`, matching the existing Iceberg capability
- Users can now pass a UC table identifier (e.g., `'schema.events'`) instead of a raw S3/ABFSS path, and the system resolves `storage_location` and credentials via UC APIs
- Read-path credential resolution automatically refreshes table-based credentials when querying Delta UC companion indexes

## Motivation

Previously, `BUILD INDEXTABLES COMPANION FOR DELTA` required an explicit storage path (`'s3://bucket/delta_table'`). On Databricks with Unity Catalog, users already know their table by name (`'schema.events'`), and the storage location is managed by UC. Requiring the raw path is inconvenient and error-prone -- users must look it up manually, and it may change during table migrations.

The Iceberg variant already supported catalog-based table name resolution. This PR extends the same capability to Delta tables.

## Changes

### `TableCredentialProvider.scala`
- Added `TableInfo(tableId, storageLocation)` case class
- Added `resolveTableInfo` method with default implementation (delegates to `resolveTableId` for backward compatibility)

### `UnityCatalogAWSCredentialProvider.scala`
- Extracted `fetchTableInfoInternal` shared method that calls `GET /tables/{name}` and returns both `table_id` and `storage_location`
- `resolveTableId` now delegates to `fetchTableInfoInternal` (returns ID only)
- Added `resolveTableInfo` override (returns both ID and storage location from a single HTTP call)

### `IndexTables4SparkSqlAstBuilder.scala`
- Relaxed `CATALOG` / `CATALOG TYPE` validation from Iceberg-only to allow Delta (Parquet still rejected)

### `SyncToExternalCommand.scala`
- Unified credential provider block handles both Delta and Iceberg table name resolution
- Added `isTableName()` helper to distinguish `"schema.table"` from `"s3://bucket/path"`
- When Delta + UC + table name: calls `resolveTableInfo` to get storage location, passes it to `DeltaSourceReader`
- Stores `deltaTableName`, `deltaCatalog`, and `parquetStorageRoot` in companion metadata for read-path resolution
- Threaded `resolvedStorageLocation` through the dispatch chain; renamed `icebergStorageRoot` parameter to `externalStorageRoot` for generality

### `IndexTables4SparkScanBuilder.scala`
- Added `tryResolveDeltaTableCredentials` method (mirrors `tryResolveIcebergTableCredentials`)
- Updated `effectiveConfig` to detect Delta UC companions via `indextables.companion.deltaTableName` metadata and resolve table-based credentials at read time

## Usage

```sql
-- Before: required raw storage path
BUILD INDEXTABLES COMPANION FOR DELTA 's3://bucket/warehouse/schema/events'
  AT LOCATION 's3://bucket/companion/events'

-- After: can use UC table name (storage_location resolved automatically)
BUILD INDEXTABLES COMPANION FOR DELTA 'schema.events'
  CATALOG 'unity_catalog'
  AT LOCATION 's3://bucket/companion/events'

-- With all options
BUILD INDEXTABLES COMPANION FOR DELTA 'schema.events'
  CATALOG 'unity_catalog' TYPE 'rest'
  INDEXING MODES ('content':'text', 'title':'string')
  FROM VERSION 42
  WHERE date = '2024-01-01'
  AT LOCATION 's3://bucket/companion/events'
  DRY RUN
```

Path-based syntax continues to work unchanged.

## Test plan

- [x] `SyncToExternalParsingTest` -- 64/64 tests pass
  - New: Delta with CATALOG, Delta with CATALOG TYPE, Delta with all options, PARQUET rejects CATALOG TYPE, Delta rejects WAREHOUSE
  - Updated: "DELTA should not accept CATALOG TYPE" -> positive test
- [x] `UnityCatalogAWSCredentialProviderTest` -- 19/19 tests pass
  - New: `resolveTableId` via mock, `resolveTableInfo` returns both fields, empty `storageLocation` handling, consistency between `resolveTableId` and `resolveTableInfo`
- [x] `mvn clean compile` succeeds
- [ ] Manual: end-to-end test with real Databricks Unity Catalog (Delta table name -> companion build -> companion read)
