### PR TITLE
Restructure backlog

### DIFF
--- a/.claude/BACKLOG.md
+++ b/.claude/BACKLOG.md
@@ -1,217 +1,136 @@
 # IndexTables4Spark Development Backlog
 
-## Blocking: Known Test Infrastructure Issues
+## Blocking
 
-### OOM running full test suite via `mvn test`
-**Status**: Open
-**Severity**: Blocking
+### IT-001: OOM running full test suite via `mvn test`
 **Reporter**: Scott
-**Description**: `mvn test` runs out of memory (at least on laptops). Scott has a script (`run_tests_individually.sh`) on the `fix/string-field-query-and-companion-aggregate-guard` branch that runs each test class separately via `mvn scalatest:test -DwildcardSuites=...`. It currently runs sequentially but Scott reports running 4-wide in parallel works fine. The script should be checked into main and documented in CLAUDE.md as the recommended way to run the full suite.
+**Description**: `mvn test` runs out of memory on laptops. A workaround script (`run_tests_individually.sh`) exists on the `fix/string-field-query-and-companion-aggregate-guard` branch that runs each test class separately.
 **Reference**: https://github.com/indextables/indextables_spark/blob/fix/string-field-query-and-companion-aggregate-guard/run_tests_individually.sh
+**Acceptance Criteria**:
+- [ ] Check `run_tests_individually.sh` into main
+- [ ] Add parallel execution support (Scott reports 4-wide works)
+- [ ] Document in CLAUDE.md as the recommended way to run the full suite
 
-### JVM shutdown crashes in tantivy4java tests
-**Status**: Open
-**Severity**: Blocking
+### IT-002: JVM shutdown crashes in tantivy4java tests
 **Reporter**: Scott
 **Upstream**: tantivy4java
-**Description**: Several tantivy4java test cases crash on JVM shutdown after the tests pass. Root cause unknown. This is an upstream issue in the tantivy4java dependency, not in indextables_spark itself.
+**Description**: Several tantivy4java test cases crash on JVM shutdown after tests pass. Root cause unknown.
+**Acceptance Criteria**:
+- [ ] Root cause identified
+- [ ] Fix applied upstream in tantivy4java or workaround documented
 
 ---
 
-## Critical: LLM Documentation Fixes
+## Critical
 
-> These issues cause LLM agents to generate broken code. Fix before other work.
+### IT-003: Fix IndexQuery usage in CLAUDE.md
+**Description**: CLAUDE.md line 84 shows wrong import path (`org.apache.spark.sql.indextables.IndexQueryExpression._`) and a DataFrame API syntax that doesn't exist. All tests use SQL syntax.
+**Acceptance Criteria**:
+- [ ] Replace with correct SQL-based usage pattern
+- [ ] Verify against actual test files
 
-### Fix IndexQuery usage in CLAUDE.md
-**Status**: Open
-**Severity**: Critical
-**Description**: CLAUDE.md line 84 shows a wrong import path (`org.apache.spark.sql.indextables.IndexQueryExpression._`) and a DataFrame API syntax (`$"content" indexquery "query"`) that doesn't exist. All tests use SQL syntax. Fix to show correct SQL-based usage:
-```scala
-df.createOrReplaceTempView("table")
-spark.sql("SELECT * FROM table WHERE content indexquery 'machine learning'")
-```
+### IT-004: Fix extensions registration syntax
+**Description**: CLAUDE.md and `docs/reference/sql-commands.md` show `spark.sparkSession.extensions.add(...)` which is not a valid Spark API.
+**Acceptance Criteria**:
+- [ ] Replace with `.config("spark.sql.extensions", "...")` pattern in both files
+- [ ] Verify against actual test files
 
-### Fix extensions registration syntax in CLAUDE.md and sql-commands-reference.md
-**Status**: Open
-**Severity**: Critical
-**Description**: Both docs show `spark.sparkSession.extensions.add(...)` which is not a valid Spark API. Correct approach (per all test files):
-```scala
-SparkSession.builder()
-  .config("spark.sql.extensions", "io.indextables.spark.extensions.IndexTables4SparkExtensions")
-  .getOrCreate()
-```
-**Files**: CLAUDE.md line 107, docs/reference/sql-commands.md line 6
-
-### Remove or annotate unwired data skipping SQL commands
-**Status**: Open
-**Severity**: Critical
-**Description**: CLAUDE.md line 110 and docs/reference/sql-commands.md lines 325-333 document `DESCRIBE/FLUSH/INVALIDATE INDEXTABLES DATA SKIPPING` commands. The Command classes exist but are NOT wired into the ANTLR grammar — they cannot be invoked via `spark.sql(...)`. Either wire them into the parser or remove from docs.
+### IT-005: Remove or annotate unwired data skipping SQL commands
+**Description**: CLAUDE.md and `docs/reference/sql-commands.md` document `DESCRIBE/FLUSH/INVALIDATE INDEXTABLES DATA SKIPPING` commands that are NOT wired into the ANTLR grammar.
+**Acceptance Criteria**:
+- [ ] Either wire commands into parser with tests, OR remove from docs
 
 ---
 
-## High Priority: Documentation Accuracy
+## High
 
-### Document both class name aliases in CLAUDE.md
-**Status**: Open
-**Description**: README.md uses public aliases (`io.indextables.provider.IndexTablesProvider`, `io.indextables.extensions.IndexTablesSparkExtensions`). CLAUDE.md uses internal names (`io.indextables.spark.core.IndexTables4SparkTableProvider`). Both are valid. CLAUDE.md should acknowledge both and recommend the public alias as primary.
+### IT-006: Document both class name aliases in CLAUDE.md
+**Description**: README.md uses public aliases (`IndexTablesProvider`), CLAUDE.md uses internal names (`IndexTables4SparkTableProvider`). Both valid.
+**Acceptance Criteria**:
+- [ ] CLAUDE.md acknowledges both names
+- [ ] Recommends public alias as primary
 
-### Fix storage class names in CLAUDE.md
-**Status**: Open
-**Description**: CLAUDE.md line 128 references `S3OptimizedReader` and `StandardFileReader` which don't exist. Actual classes: `S3CloudStorageProvider` and `HadoopCloudStorageProvider`.
+### IT-007: Fix storage class names in CLAUDE.md
+**Description**: CLAUDE.md references `S3OptimizedReader` and `StandardFileReader` which don't exist. Actual: `S3CloudStorageProvider`, `HadoopCloudStorageProvider`.
+**Acceptance Criteria**:
+- [ ] Correct class names in CLAUDE.md
 
-### Document missing SQL commands
-**Status**: Open
-**Description**: These commands exist in the ANTLR grammar but are absent from CLAUDE.md and sql-commands-reference.md:
-- `BUILD INDEXTABLES COMPANION FOR DELTA|PARQUET|ICEBERG <source> AT LOCATION <dest>`
-- `DESCRIBE INDEXTABLES COMPONENT SIZES <path>`
-- `DESCRIBE INDEXTABLES PREWARM JOBS`
-- `WAIT FOR INDEXTABLES PREWARM JOBS`
-- `DESCRIBE INDEXTABLES TRANSACTION LOG <path>`
-- `REPAIR INDEXFILES TRANSACTION LOG <source> AT LOCATION <target>`
-- `FLUSH INDEXTABLES SEARCHER CACHE`
-- `INVALIDATE INDEXTABLES TRANSACTION LOG CACHE`
+### IT-008: Document missing SQL commands
+**Description**: 8 commands exist in ANTLR grammar but are absent from docs: `BUILD COMPANION`, `DESCRIBE COMPONENT SIZES`, `DESCRIBE PREWARM JOBS`, `WAIT FOR PREWARM JOBS`, `DESCRIBE TRANSACTION LOG`, `REPAIR INDEXFILES TRANSACTION LOG`, `FLUSH SEARCHER CACHE`, `INVALIDATE TRANSACTION LOG CACHE`.
+**Acceptance Criteria**:
+- [ ] All grammar-wired commands documented in `docs/reference/sql-commands.md`
+- [ ] CLAUDE.md SQL Extensions section updated
 
-### Archive stale design documents
-**Status**: Complete
-**Description**: Completed design documents archived to `docs/archive/`. Active design docs moved to `docs/design/` with normalized naming. Reference docs moved to `docs/reference/`. llms.txt updated to reflect new structure. Remaining items in `docs/archive/` from prior work: `dup_code_reduction/`, JSON field completion summaries, checkpoint truncation implementation, repair transaction log summaries, and `GITHUB_ISSUE_16_RESOLUTION.md`.
-
----
-
-## Medium Priority: Documentation Completeness
-
-### Document companion/sync feature
-**Status**: Open
-**Description**: 7 source files in `src/main/scala/io/indextables/spark/sync/`, 14+ test files, and a SQL command (`BUILD INDEXTABLES COMPANION`) — entirely absent from CLAUDE.md and all reference docs.
-
-### Fix deprecated config in features-reference.md
-**Status**: Open
-**Description**: Line 185 uses `mergeOnWrite.mergeGroupMultiplier` which docs/reference/features.md marks as deprecated.
-
-### Expand or remove performance-tuning.md
-**Status**: Complete
-**Description**: Removed. Content was a 27-line stub duplicating configuration-reference.md. Redirected to `docs/reference/configuration.md`.
-
-### Improve llms.txt
-**Status**: Complete
-**Description**: Moved llms.txt to repo root. Restructured with project description, protocol section, proper hierarchy (Primary/Reference/Design/Archived sections), and updated all paths to match new docs/ directory structure.
-
-### Document IP address fields and structured streaming
-**Status**: Open
-**Description**: Test files exist for IP address field types (`IpAddressFieldTest.scala`, `IpAddressIndexQueryTest.scala`) and structured streaming (`StructuredStreamingTest.scala`) but neither feature is documented anywhere.
-
----
-
-## High Priority Features
-
-### ReplaceWhere with Partition Predicates
+### IT-009: ReplaceWhere with Partition Predicates
 **Status**: Design Complete
-**Design Document**: [docs/design/replace-where.md](../docs/design/replace-where.md)
-**Description**: Implement Delta Lake-style replaceWhere functionality for selective partition replacement based on predicate conditions.
+**Design**: [docs/design/replace-where.md](../docs/design/replace-where.md)
+**Description**: Delta Lake-style replaceWhere for selective partition replacement.
+**Acceptance Criteria**:
+- [ ] Predicate parser for `=`, `IN`, `AND` on partition columns
+- [ ] Transaction log ReplaceWhereAction integration
+- [ ] Validation and error handling
+- [ ] Test coverage
 
-**Key Features**:
-- Selective partition replacement using SQL predicates
-- Support for `=`, `IN`, and `AND` operators on partition columns
-- Transaction log integration with ReplaceWhereAction
-- Comprehensive validation and error handling
-- Full test coverage with integration tests
-
-**Priority**: High - Enables advanced data management patterns
-
----
-
-### Transaction Log Compaction (Parquet-based)
-**Status**: Needs Review
-**Design Document**: [docs/design/log-compaction.md](../docs/design/log-compaction.md)
-**Description**: Parquet-based checkpoint system for transaction log consolidation. Note: Avro-based checkpoints are already implemented (Protocol V4, default). This item may be partially superseded — review whether Parquet-based approach is still needed on top of existing Avro state format.
-
-**Priority**: Needs re-triage
+### IT-010: Transaction Log Compaction (Parquet-based) — Needs Re-triage
+**Design**: [docs/design/log-compaction.md](../docs/design/log-compaction.md)
+**Description**: Parquet-based checkpoint system. May be partially superseded by existing Avro state format (Protocol V4).
+**Acceptance Criteria**:
+- [ ] Determine if Parquet-based approach is still needed on top of Avro state
+- [ ] If yes, implement. If no, close and archive design doc.
 
 ---
 
-## Medium Priority Features
+## Medium
 
-### Enhanced Query Optimization
-- **Bloom Filters**: Implement bloom filters for better file skipping
-- **Column Statistics**: Enhanced min/max tracking for better pruning
-- **Join Optimization**: Better integration with Spark's join planning
+### IT-011: Document companion/sync feature
+**Description**: 7 source files in `src/main/scala/io/indextables/spark/sync/`, 14+ test files, `BUILD INDEXTABLES COMPANION` SQL command — entirely undocumented.
+**Acceptance Criteria**:
+- [ ] Feature documented in CLAUDE.md
+- [ ] SQL command documented in `docs/reference/sql-commands.md`
+- [ ] Usage examples in `docs/reference/features.md`
 
-### Storage Optimizations
-- **Compression Improvements**: Evaluate additional compression codecs
-- **Caching Enhancements**: Smarter cache eviction policies
-- **Async I/O**: Background prefetching for better performance
+### IT-012: Fix deprecated config in features.md
+**Description**: `docs/reference/features.md` line 185 uses `mergeOnWrite.mergeGroupMultiplier` which is deprecated.
+**Acceptance Criteria**:
+- [ ] Replace with current config key or remove
 
-### Monitoring and Observability
-- **Metrics Dashboard**: Comprehensive performance metrics
-- **Query Profiling**: Detailed query execution statistics
-- **Health Checks**: Automated table integrity validation
-
-## Low Priority Features
-
-### Advanced Text Search
-- **Fuzzy Search**: Approximate string matching
-- **Synonym Support**: Query expansion with synonyms
-- **Multi-language**: Enhanced tokenization for different languages
-
-### Schema Evolution
-- **Column Addition**: Support for adding new columns
-- **Type Changes**: Safe data type evolution
-- **Column Removal**: Deprecation and removal workflows
-
-### Ecosystem Integration
-- **Databricks Integration**: Certified compatibility
-- **Apache Iceberg**: Interoperability layer
-- **Apache Hudi**: Cross-format compatibility
+### IT-013: Document IP address fields and structured streaming
+**Description**: Test files exist (`IpAddressFieldTest.scala`, `IpAddressIndexQueryTest.scala`, `StructuredStreamingTest.scala`) but neither feature is documented.
+**Acceptance Criteria**:
+- [ ] IP address field type documented in `docs/reference/field-indexing.md`
+- [ ] Structured streaming documented in CLAUDE.md or `docs/reference/features.md`
 
 ---
 
-## Completed Features
+## Low
 
-### Core Transaction Log
-- Delta Lake-style transaction log with ADD/REMOVE actions
-- Overwrite and append modes with atomic operations
-- Partition tracking and pruning integration
-- JSON serialization with proper type handling
-- Avro state format (10x faster checkpoint reads, default since Protocol V4)
-- Transaction log compression (GZIP, 60-70% reduction)
-- Concurrent write retry with exponential backoff
-
-### Search and Query
-- Full-text search via IndexQuery operator (Tantivy syntax)
-- Aggregate pushdown (COUNT, SUM, AVG, MIN, MAX)
-- Bucket aggregations (DateHistogram, Histogram, Range)
-- JSON field support (Struct/Array/Map with filter pushdown)
-- Statistics truncation for long text fields
-- Data skipping via min/max statistics
-
-### Storage and Performance
-- S3-optimized storage with path flattening
-- Split-based architecture with immutable index files
-- JVM-wide caching with GlobalSplitCacheManager
-- L2 Disk Cache (auto-enabled on Databricks/EMR)
-- Batch retrieval optimization (90-95% S3 GET reduction)
-- Optimized writes (Iceberg-style shuffle)
-- AWS session token support for temporary credentials
-
-### Operations
-- MERGE SPLITS (split consolidation)
-- PURGE INDEXTABLE (orphan cleanup)
-- DROP INDEXTABLES PARTITIONS
-- CHECKPOINT/COMPACT INDEXTABLES
-- PREWARM INDEXTABLES CACHE
-- Purge-on-write (automatic table hygiene)
-- Merge-on-write (async post-commit)
-- Multi-cloud (S3, Azure Blob Storage, Unity Catalog)
-
-### Error Handling and Validation
-- Proper exception throwing for missing tables
-- Schema validation and type safety
-- Comprehensive error messages and debugging
-- Production-ready logging
+| ID | Item | Description |
+|----|------|-------------|
+| IT-014 | Bloom filters | Better file skipping via bloom filters |
+| IT-015 | Column statistics | Improved min/max tracking for pruning |
+| IT-016 | Join optimization | Better Spark join planning integration |
+| IT-017 | Compression | Evaluate additional compression codecs |
+| IT-018 | Cache eviction | Smarter cache eviction policies |
+| IT-019 | Async I/O | Background prefetching for read performance |
+| IT-020 | Metrics dashboard | Comprehensive performance metrics |
+| IT-021 | Query profiling | Detailed query execution statistics |
+| IT-022 | Health checks | Automated table integrity validation |
+| IT-023 | Fuzzy search | Approximate string matching |
+| IT-024 | Synonym support | Query expansion with synonyms |
+| IT-025 | Multi-language | Enhanced tokenization for different languages |
+| IT-026 | Schema evolution | Column addition, type changes, removal |
+| IT-027 | Iceberg interop | Cross-format compatibility layer |
+| IT-028 | Hudi interop | Cross-format compatibility layer |
 
 ---
 
-## Notes
-- **Design First**: All major features should have design documents before implementation
-- **Test Coverage**: Maintain 100% test pass rate (381 test files, 350+ tests)
-- **Performance**: Benchmark all major features against baseline
-- **Documentation**: Keep CLAUDE.md and reference docs updated with implementation details
+## Completed
+
+| ID | Item | Date |
+|----|------|------|
+| IT-029 | Archive stale design documents | 2026-02 |
+| IT-030 | Remove performance-tuning.md stub | 2026-02 |
+| IT-031 | Restructure llms.txt with proper hierarchy | 2026-02 |
+| IT-032 | Reorganize docs/ into reference/design/archive | 2026-02 |
+| IT-033 | Move CLAUDE.md and BACKLOG.md to .claude/ | 2026-02 |
+| IT-034 | Move PROTOCOL.md and TABLE_PROTOCOL.md to docs/reference/ | 2026-02 |

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -142,6 +142,13 @@ All commands support both `INDEXTABLES` and `TANTIVY4SPARK` keywords. See `docs/
 - PURGE INDEXTABLE: 40/40, Purge-on-write: 8/8, DESCRIBE ENVIRONMENT: 10/10
 - Merge I/O: 34/34, Optimized Writes: 44/44
 
+## Development Principles
+
+- **Design First**: All major features should have design documents before implementation
+- **Test Coverage**: Maintain 100% test pass rate with comprehensive integration tests
+- **Performance**: Benchmark all major features against baseline
+- **Documentation**: Keep CLAUDE.md and reference docs updated with implementation details
+
 ## Reference Documentation
 
 - `docs/reference/configuration.md` - All configuration settings (writer, state, merge, cache, read optimization, etc.)


### PR DESCRIPTION
## Summary
- Apply BACKLOG.md structure: single `IT-*` prefix with sequential IDs (IT-001 through IT-034), acceptance criteria on all actionable items, compact completed summary table
- Move development principles from backlog notes into CLAUDE.md where they belong as project guidance

## Test plan
- [ ] Verify BACKLOG.md renders correctly on GitHub
- [ ] Verify CLAUDE.md Development Principles section is present
- [ ] Confirm no content was lost from the original backlog