### PR TITLE
fix: correctness and perf issues related to string field querying, aggregate pushdown guards, and UC credential handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <dependency>
             <groupId>io.indextables</groupId>
             <artifactId>tantivy4java</artifactId>
-            <version>0.29.10</version>
+            <version>0.30.0</version>
             <classifier>${platform.classifier}</classifier>
         </dependency>
 

--- a/src/test/scala/io/indextables/spark/sync/CompanionRoundTripTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionRoundTripTest.scala
@@ -1,0 +1,571 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sync
+
+import java.io.File
+import java.nio.file.Files
+import java.sql.{Date, Timestamp}
+
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types._
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * Round-trip validation tests for companion indexes.
+ *
+ * Each test writes known data to a Delta table, builds a companion index, reads ALL rows back
+ * through the companion, and asserts that every column of every row matches the original source.
+ */
+class CompanionRoundTripTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
+
+  protected var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    SparkSession.getActiveSession.foreach(_.stop())
+    SparkSession.getDefaultSession.foreach(_.stop())
+
+    spark = SparkSession
+      .builder()
+      .appName("CompanionRoundTripTest")
+      .master("local[2]")
+      .config("spark.sql.warehouse.dir", Files.createTempDirectory("spark-warehouse").toString)
+      .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .config("spark.driver.host", "127.0.0.1")
+      .config("spark.driver.bindAddress", "127.0.0.1")
+      .config(
+        "spark.sql.extensions",
+        "io.indextables.spark.extensions.IndexTables4SparkExtensions," +
+          "io.delta.sql.DeltaSparkSessionExtension"
+      )
+      .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+      .config("spark.sql.adaptive.enabled", "false")
+      .config("spark.sql.adaptive.coalescePartitions.enabled", "false")
+      .config("spark.indextables.aws.accessKey", "test-default-access-key")
+      .config("spark.indextables.aws.secretKey", "test-default-secret-key")
+      .config("spark.indextables.aws.sessionToken", "test-default-session-token")
+      .config("spark.indextables.s3.pathStyleAccess", "true")
+      .config("spark.indextables.aws.region", "us-east-1")
+      .config("spark.indextables.s3.endpoint", "http://localhost:10101")
+      .getOrCreate()
+
+    spark.sparkContext.setLogLevel("WARN")
+
+    _root_.io.indextables.spark.storage.SplitConversionThrottle.initialize(
+      maxParallelism = Runtime.getRuntime.availableProcessors() max 1
+    )
+  }
+
+  override def afterAll(): Unit =
+    if (spark != null) {
+      spark.stop()
+    }
+
+  private def withTempPath(f: String => Unit): Unit = {
+    val path = Files.createTempDirectory("tantivy4spark-roundtrip").toString
+    try {
+      try {
+        import _root_.io.indextables.spark.storage.{DriverSplitLocalityManager, GlobalSplitCacheManager}
+        GlobalSplitCacheManager.flushAllCaches()
+        DriverSplitLocalityManager.clear()
+      } catch {
+        case _: Exception =>
+      }
+      f(path)
+    } finally
+      deleteRecursively(new File(path))
+  }
+
+  private def deleteRecursively(file: File): Unit = {
+    if (file.isDirectory) {
+      Option(file.listFiles()).foreach(_.foreach(deleteRecursively))
+    }
+    file.delete()
+  }
+
+  private def buildAndReadCompanion(deltaPath: String, indexPath: String): DataFrame = {
+    val syncResult = spark.sql(
+      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+    )
+    syncResult.collect()(0).getString(2) shouldBe "success"
+
+    spark.read
+      .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+      .option("spark.indextables.read.defaultLimit", "1000")
+      .load(indexPath)
+  }
+
+  /**
+   * Compare two sets of rows column-by-column, ignoring row order.
+   * Rows are keyed by the given column name for deterministic matching.
+   */
+  private def assertRowsMatch(
+    source: Array[Row],
+    companion: Array[Row],
+    schema: StructType,
+    keyColumn: String
+  ): Unit = {
+    source.length shouldBe companion.length
+
+    val keyIdx = schema.fieldIndex(keyColumn)
+
+    val sourceByKey    = source.map(r => String.valueOf(r.get(keyIdx)) -> r).toMap
+    val companionByKey = companion.map(r => String.valueOf(r.get(keyIdx)) -> r).toMap
+
+    sourceByKey.keySet shouldBe companionByKey.keySet
+
+    for ((key, sourceRow) <- sourceByKey) {
+      val companionRow = companionByKey(key)
+      for (field <- schema.fields) {
+        val idx = schema.fieldIndex(field.name)
+        val sourceVal    = sourceRow.get(idx)
+        val companionVal = companionRow.get(idx)
+
+        field.dataType match {
+          case FloatType =>
+            if (sourceVal == null) assert(companionVal == null)
+            else companionVal.asInstanceOf[Float] shouldBe sourceVal.asInstanceOf[Float] +- 0.001f
+          case DoubleType =>
+            if (sourceVal == null) assert(companionVal == null)
+            else companionVal.asInstanceOf[Double] shouldBe sourceVal.asInstanceOf[Double] +- 0.001
+          case _ =>
+            withClue(s"Mismatch at key=$key, column=${field.name}: ") {
+              companionVal shouldBe sourceVal
+            }
+        }
+      }
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  //  Round-trip: non-partitioned tables
+  // ═══════════════════════════════════════════════════════════════════
+
+  test("round-trip: scalar columns (String, Int, Long, Double, Boolean)") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      val ss = spark; import ss.implicits._
+      val sourceData = Seq(
+        (1, "alice",   100L, 1.5,  true),
+        (2, "bob",     200L, 2.7,  false),
+        (3, "charlie", 300L, 3.14, true),
+        (4, "dave",    400L, 0.0,  false),
+        (5, "eve",     500L, 99.9, true)
+      ).toDF("id", "name", "big_id", "score", "active")
+
+      sourceData.write.format("delta").save(deltaPath)
+
+      val companionDf = buildAndReadCompanion(deltaPath, indexPath)
+
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+      val schema        = sourceData.schema
+
+      assertRowsMatch(sourceRows, companionRows, schema, "id")
+    }
+  }
+
+  test("round-trip: Date and Timestamp columns") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      spark.sql(s"""CREATE TABLE delta.`$deltaPath` (
+                   |  id INT,
+                   |  event_date DATE,
+                   |  event_ts TIMESTAMP
+                   |) USING DELTA""".stripMargin)
+
+      spark.sql(s"""INSERT INTO delta.`$deltaPath` VALUES
+                   |  (1, DATE '2024-01-15', TIMESTAMP '2024-01-15 10:30:00'),
+                   |  (2, DATE '2024-06-20', TIMESTAMP '2024-06-20 14:00:00'),
+                   |  (3, DATE '2024-12-25', TIMESTAMP '2024-12-25 23:59:59')
+                   |""".stripMargin)
+
+      val companionDf = buildAndReadCompanion(deltaPath, indexPath)
+
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+
+      sourceRows.length shouldBe companionRows.length
+
+      // Key by id and compare date/timestamp values
+      val sourceById    = sourceRows.map(r => r.getInt(0) -> r).toMap
+      val companionById = companionRows.map(r => r.getInt(0) -> r).toMap
+
+      for ((id, src) <- sourceById) {
+        val comp = companionById(id)
+        withClue(s"id=$id date: ") {
+          comp.getAs[Date]("event_date") shouldBe src.getAs[Date]("event_date")
+        }
+        withClue(s"id=$id timestamp: ") {
+          comp.getAs[Timestamp]("event_ts") shouldBe src.getAs[Timestamp]("event_ts")
+        }
+      }
+    }
+  }
+
+  test("round-trip: Float column") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      val ss = spark; import ss.implicits._
+      Seq((1, 1.5f), (2, 2.7f), (3, -0.5f), (4, 0.0f))
+        .toDF("id", "value")
+        .write.format("delta").save(deltaPath)
+
+      val companionDf   = buildAndReadCompanion(deltaPath, indexPath)
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+      val schema        = StructType(Seq(StructField("id", IntegerType), StructField("value", FloatType)))
+
+      assertRowsMatch(sourceRows, companionRows, schema, "id")
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  //  Round-trip: partitioned tables
+  // ═══════════════════════════════════════════════════════════════════
+
+  test("round-trip: single String partition column") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      val ss = spark; import ss.implicits._
+      val sourceData = Seq(
+        (1, "alice", 85.0, "us-east"),
+        (2, "bob",   92.0, "us-west"),
+        (3, "charlie", 78.0, "eu-west"),
+        (4, "dave",  95.0, "us-east"),
+        (5, "eve",   88.0, "eu-west")
+      ).toDF("id", "name", "score", "region")
+
+      sourceData.write.format("delta").partitionBy("region").save(deltaPath)
+
+      val companionDf   = buildAndReadCompanion(deltaPath, indexPath)
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+      val schema        = sourceData.schema
+
+      assertRowsMatch(sourceRows, companionRows, schema, "id")
+    }
+  }
+
+  test("round-trip: Int partition column") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      val ss = spark; import ss.implicits._
+      Seq(
+        (1, "jan-report", 2023),
+        (2, "feb-report", 2023),
+        (3, "mar-report", 2024),
+        (4, "apr-report", 2024),
+        (5, "may-report", 2025)
+      ).toDF("id", "name", "year")
+        .write.format("delta").partitionBy("year").save(deltaPath)
+
+      val companionDf   = buildAndReadCompanion(deltaPath, indexPath)
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+      val schema        = StructType(Seq(
+        StructField("id", IntegerType),
+        StructField("name", StringType),
+        StructField("year", IntegerType)
+      ))
+
+      assertRowsMatch(sourceRows, companionRows, schema, "id")
+    }
+  }
+
+  test("round-trip: Date partition column") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      spark.sql(s"""CREATE TABLE delta.`$deltaPath` (
+                   |  id INT,
+                   |  name STRING,
+                   |  event_date DATE
+                   |) USING DELTA
+                   |PARTITIONED BY (event_date)""".stripMargin)
+
+      spark.sql(s"""INSERT INTO delta.`$deltaPath` VALUES
+                   |  (1, 'Alice',   DATE '2024-01-15'),
+                   |  (2, 'Bob',     DATE '2024-06-20'),
+                   |  (3, 'Charlie', DATE '2024-12-25')
+                   |""".stripMargin)
+
+      val companionDf   = buildAndReadCompanion(deltaPath, indexPath)
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+
+      val sourceById    = sourceRows.map(r => r.getAs[Int]("id") -> r).toMap
+      val companionById = companionRows.map(r => r.getAs[Int]("id") -> r).toMap
+
+      sourceById.keySet shouldBe companionById.keySet
+
+      for ((id, src) <- sourceById) {
+        val comp = companionById(id)
+        comp.getAs[String]("name") shouldBe src.getAs[String]("name")
+        comp.getAs[Date]("event_date") shouldBe src.getAs[Date]("event_date")
+      }
+    }
+  }
+
+  test("round-trip: multiple partition columns") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      spark.sql(s"""CREATE TABLE delta.`$deltaPath` (
+                   |  id INT,
+                   |  name STRING,
+                   |  region STRING,
+                   |  year INT
+                   |) USING DELTA
+                   |PARTITIONED BY (region, year)""".stripMargin)
+
+      spark.sql(s"""INSERT INTO delta.`$deltaPath` VALUES
+                   |  (1, 'Alice',   'us', 2023),
+                   |  (2, 'Bob',     'us', 2024),
+                   |  (3, 'Charlie', 'eu', 2023),
+                   |  (4, 'Dave',    'eu', 2024),
+                   |  (5, 'Eve',     'ap', 2025)
+                   |""".stripMargin)
+
+      val companionDf   = buildAndReadCompanion(deltaPath, indexPath)
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+
+      val sourceById    = sourceRows.map(r => r.getAs[Int]("id") -> r).toMap
+      val companionById = companionRows.map(r => r.getAs[Int]("id") -> r).toMap
+
+      sourceById.keySet shouldBe companionById.keySet
+
+      for ((id, src) <- sourceById) {
+        val comp = companionById(id)
+        comp.getAs[String]("name") shouldBe src.getAs[String]("name")
+        comp.getAs[String]("region") shouldBe src.getAs[String]("region")
+        comp.getAs[Int]("year") shouldBe src.getAs[Int]("year")
+      }
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  //  Round-trip: complex types
+  // ═══════════════════════════════════════════════════════════════════
+
+  test("round-trip: Array[String] column") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      val ss = spark; import ss.implicits._
+      Seq(
+        (1, "alice",   Seq("scala", "java")),
+        (2, "bob",     Seq("python")),
+        (3, "charlie", Seq("rust", "go", "c"))
+      ).toDF("id", "name", "tags")
+        .write.format("delta").save(deltaPath)
+
+      val companionDf   = buildAndReadCompanion(deltaPath, indexPath)
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+
+      val sourceById    = sourceRows.map(r => r.getAs[Int]("id") -> r).toMap
+      val companionById = companionRows.map(r => r.getAs[Int]("id") -> r).toMap
+
+      sourceById.keySet shouldBe companionById.keySet
+
+      for ((id, src) <- sourceById) {
+        val comp = companionById(id)
+        comp.getAs[String]("name") shouldBe src.getAs[String]("name")
+        comp.getAs[Seq[String]]("tags") shouldBe src.getAs[Seq[String]]("tags")
+      }
+    }
+  }
+
+  test("round-trip: Struct column") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      val schema = StructType(Seq(
+        StructField("id", IntegerType),
+        StructField("info", StructType(Seq(
+          StructField("first_name", StringType),
+          StructField("age", IntegerType)
+        )))
+      ))
+
+      val data = Seq(
+        Row(1, Row("Alice", 30)),
+        Row(2, Row("Bob", 25)),
+        Row(3, Row("Charlie", 35))
+      )
+
+      spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+        .write.format("delta").save(deltaPath)
+
+      val companionDf   = buildAndReadCompanion(deltaPath, indexPath)
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+
+      val sourceById    = sourceRows.map(r => r.getAs[Int]("id") -> r).toMap
+      val companionById = companionRows.map(r => r.getAs[Int]("id") -> r).toMap
+
+      sourceById.keySet shouldBe companionById.keySet
+
+      for ((id, src) <- sourceById) {
+        val comp     = companionById(id)
+        val srcInfo  = src.getAs[Row]("info")
+        val compInfo = comp.getAs[Row]("info")
+        compInfo.getAs[String]("first_name") shouldBe srcInfo.getAs[String]("first_name")
+        compInfo.getAs[Int]("age") shouldBe srcInfo.getAs[Int]("age")
+      }
+    }
+  }
+
+  test("round-trip: Map[String, String] column") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      val ss = spark; import ss.implicits._
+      Seq(
+        (1, "alice",   Map("color" -> "red", "size" -> "small")),
+        (2, "bob",     Map("color" -> "blue")),
+        (3, "charlie", Map("color" -> "green", "size" -> "large", "weight" -> "heavy"))
+      ).toDF("id", "name", "attrs")
+        .write.format("delta").save(deltaPath)
+
+      val companionDf   = buildAndReadCompanion(deltaPath, indexPath)
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+
+      val sourceById    = sourceRows.map(r => r.getAs[Int]("id") -> r).toMap
+      val companionById = companionRows.map(r => r.getAs[Int]("id") -> r).toMap
+
+      sourceById.keySet shouldBe companionById.keySet
+
+      for ((id, src) <- sourceById) {
+        val comp = companionById(id)
+        comp.getAs[String]("name") shouldBe src.getAs[String]("name")
+        comp.getAs[Map[String, String]]("attrs") shouldBe src.getAs[Map[String, String]]("attrs")
+      }
+    }
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  //  Round-trip: mixed scenario (all column types + partitioning)
+  // ═══════════════════════════════════════════════════════════════════
+
+  test("round-trip: mixed types with partition column") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      spark.sql(s"""CREATE TABLE delta.`$deltaPath` (
+                   |  id INT,
+                   |  name STRING,
+                   |  score DOUBLE,
+                   |  active BOOLEAN,
+                   |  event_date DATE,
+                   |  region STRING
+                   |) USING DELTA
+                   |PARTITIONED BY (region)""".stripMargin)
+
+      spark.sql(s"""INSERT INTO delta.`$deltaPath` VALUES
+                   |  (1, 'Alice',   85.5,  true,  DATE '2024-01-15', 'us-east'),
+                   |  (2, 'Bob',     92.0,  false, DATE '2024-03-20', 'us-west'),
+                   |  (3, 'Charlie', 78.3,  true,  DATE '2024-06-10', 'eu-west'),
+                   |  (4, 'Dave',    95.1,  false, DATE '2024-09-05', 'us-east'),
+                   |  (5, 'Eve',     88.8,  true,  DATE '2024-12-25', 'eu-west'),
+                   |  (6, 'Frank',   70.0,  false, DATE '2024-02-14', 'us-west')
+                   |""".stripMargin)
+
+      val companionDf   = buildAndReadCompanion(deltaPath, indexPath)
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+
+      sourceRows.length shouldBe 6
+      companionRows.length shouldBe 6
+
+      val sourceById    = sourceRows.map(r => r.getAs[Int]("id") -> r).toMap
+      val companionById = companionRows.map(r => r.getAs[Int]("id") -> r).toMap
+
+      sourceById.keySet shouldBe companionById.keySet
+
+      for ((id, src) <- sourceById) {
+        val comp = companionById(id)
+        withClue(s"id=$id: ") {
+          comp.getAs[String]("name") shouldBe src.getAs[String]("name")
+          comp.getAs[Double]("score") shouldBe src.getAs[Double]("score") +- 0.01
+          comp.getAs[Boolean]("active") shouldBe src.getAs[Boolean]("active")
+          comp.getAs[Date]("event_date") shouldBe src.getAs[Date]("event_date")
+          comp.getAs[String]("region") shouldBe src.getAs[String]("region")
+        }
+      }
+    }
+  }
+
+  test("round-trip: larger dataset (50 rows) with partition") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta").getAbsolutePath
+      val indexPath = new File(tempDir, "index").getAbsolutePath
+
+      val ss = spark; import ss.implicits._
+      val regions = Seq("us-east", "us-west", "eu-west", "ap-south")
+      val sourceData = (1 to 50).map { i =>
+        (i, s"user_$i", i * 1.1, i % 2 == 0, regions(i % regions.size))
+      }.toDF("id", "name", "score", "active", "region")
+
+      sourceData.write.format("delta").partitionBy("region").save(deltaPath)
+
+      val companionDf   = buildAndReadCompanion(deltaPath, indexPath)
+      val sourceRows    = spark.read.format("delta").load(deltaPath).collect()
+      val companionRows = companionDf.collect()
+
+      sourceRows.length shouldBe 50
+      companionRows.length shouldBe 50
+
+      val sourceById    = sourceRows.map(r => r.getAs[Int]("id") -> r).toMap
+      val companionById = companionRows.map(r => r.getAs[Int]("id") -> r).toMap
+
+      sourceById.keySet shouldBe companionById.keySet
+
+      for ((id, src) <- sourceById) {
+        val comp = companionById(id)
+        withClue(s"id=$id: ") {
+          comp.getAs[String]("name") shouldBe src.getAs[String]("name")
+          comp.getAs[Double]("score") shouldBe src.getAs[Double]("score") +- 0.001
+          comp.getAs[Boolean]("active") shouldBe src.getAs[Boolean]("active")
+          comp.getAs[String]("region") shouldBe src.getAs[String]("region")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This branch fixes several correctness and performance issues related to string field querying, aggregate pushdown guards, and Unity Catalog credential handling. The aggregate pushdown guard has been redesigned to use reliable local-instance tracking instead of heuristic query plan inspection, preventing both false positives (blocking valid non-aggregate queries) and false negatives (silently returning incorrect aggregate results). Unity Catalog API calls are optimized by requesting PATH_READ credentials directly on read paths, eliminating unnecessary PATH_READ_WRITE-then-fallback round trips.

## Changes

### Aggregate Pushdown Guard Redesign
- Replaced heuristic `detectAggregateInQueryPlan()` (which used schema inspection and string matching) with a reliable `_aggregationWasRequested` flag that tracks whether `pushAggregation()` was actually called on the current ScanBuilder instance
- Added `rejectAggregatePushdownFailure()` method that throws `IllegalStateException` when pushdown is rejected but the query requires it, preventing silently incorrect results (e.g., truncated by default row limit)
- The guard now fires for all tables (not just companion tables), since incorrect aggregate results affect any table where pushdown fails
- Guard is disableable via `spark.indextables.read.requireAggregatePushdown=false` (also supports legacy key `spark.indextables.read.companion.requireAggregatePushdown`)
- Added cross-instance tracking via `relationAggregationRequested` WeakHashMap in the companion object for cases where Spark creates multiple ScanBuilder instances for the same relation

### IsNull/IsNotNull on Partition Columns
- `isSupportedFilter()` now accepts `IsNull` and `IsNotNull` on partition columns (in addition to fast fields), since partition columns are directory-based and can never be null
- This prevents Spark's implicit `IsNotNull(partition_key)` from blocking aggregate pushdown on partitioned datasets (e.g., `df.filter($"region" === "region_0").count()` or `GROUP BY region`)

### StringPatternPushdown Behavior Change
- When string pattern pushdown is disabled (the default), aggregate queries with `StringStartsWith`/`StringEndsWith`/`StringContains` filters now fall through to Spark post-filtering instead of throwing an exception
- This provides correct (though slower) results by default, while users can still enable pushdown for performance

### Unity Catalog Credential Optimization
- Read paths (ScanBuilder, Scan, SimpleAggregateScan, GroupByAggregateScan, DescribeComponentSizes, PrewarmCache) now explicitly request `PATH_READ` credentials via `spark.indextables.databricks.credential.operation`
- This skips the default PATH_READ_WRITE-then-fallback-to-PATH_READ flow, cutting UC API calls in half for read operations
- Table credentials (`getTableCredentials`) now request `READ` directly since table credential paths are never used for writes
- Replaced `spark.indextables.databricks.fallback.enabled` boolean with `spark.indextables.databricks.credential.operation` enum (`PATH_READ` or `PATH_READ_WRITE`)
- Added `spark.indextables.companion.credential.preferPathCredentials` option to bypass table-based credential resolution for companion tables when path-based credentials are already available

### COUNT(*) Fast Field Selection
- COUNT(*) field selection now prefers numeric fast fields over string fast fields for performance (numeric fields are more compact and faster to scan)
- Selection priority: (1) numeric field from sibling aggregations, (2) numeric fast field from docMapping, (3) string fast field, (4) auto-fast-field from schema
- Numeric types include: `IntegerType`, `LongType`, `FloatType`, `DoubleType`, `DateType`, `TimestampType`, `BooleanType`

### LIMIT Query Parallelism
- `ScanBuilder.build()` now sets `spark.sql.limit.initialNumPartitions` to `defaultParallelism` if not already configured
- By default Spark uses only 1 partition for LIMIT queries, which serializes reads; this ensures LIMIT queries use all available partitions

### tantivy4java Version Bump
- Bumped tantivy4java from 0.29.7 to 0.30.0
- Includes fixes for string field type detection (Schema.getFieldInfo returning TEXT instead of STRING for raw-tokenized fields) and unified doc batch/grouping behavior

### Code Formatting
- Spotless formatting applied across the codebase for release 0.5.0 consistency

## Test Coverage

### New Tests
- **CompanionAggregateGuardTest** (4 tests): Validates that the aggregate guard fires on companion tables when pushdown fails, fires on non-companion tables equally, can be disabled via config, and COUNT(*) prefers numeric fast fields
- **AggregateExceptionTest** (3 tests): Tests COUNT with IsNotNull on partition columns, compound partition filters, and GROUP BY partition column with COUNT
- **StringFieldQueryTypeBugTest**: Reproduction tests for the tantivy4java string field type bug where string fields were incorrectly treated as text fields

### Fixed Tests
- **StringPatternPushdownTest**: 3 tests updated to verify Spark post-filtering instead of expecting `IllegalStateException` exceptions (matches new behavior where unsupported pattern filters fall through gracefully)
- **TokenizationTest**: Added typemap config at read time for text fields
- **IndexingConfigurationTest**: Added typemap config at read time for text fields
- **SimpleAggregatePushdownTest**: Added `category` to fast fields to ensure test validity
- **UnityCatalogAWSCredentialProviderTest**: Updated fallback tests for new `credential.operation` enum, added tests for explicit PATH_READ behavior and default PATH_READ_WRITE with fallback
- **DatabricksConfigPropagationTest**: Updated config key from `fallback.enabled` to `credential.operation`

## Breaking Changes
- `spark.indextables.databricks.fallback.enabled` configuration key has been replaced by `spark.indextables.databricks.credential.operation` (values: `PATH_READ` or `PATH_READ_WRITE`, default: `PATH_READ_WRITE`). The old key is no longer recognized. Users who explicitly set `fallback.enabled=false` should instead set `credential.operation=PATH_READ`.
- Aggregate queries that cannot be pushed down now throw `IllegalStateException` by default instead of returning silently incorrect results. To restore the old (silent) behavior, set `spark.indextables.read.requireAggregatePushdown=false`.
- String pattern filters (`StringStartsWith`, `StringEndsWith`, `StringContains`) with aggregates no longer throw exceptions when pushdown is disabled; they fall through to Spark post-filtering. This is a behavior change from exception to slower-but-correct results.
