### PR TITLE
quality: Companion Read Path: Code Review Fixes

### DIFF
--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkSimpleAggregateScan.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkSimpleAggregateScan.scala
@@ -67,7 +67,7 @@ class IndexTables4SparkSimpleAggregateScan(
     val tablePath = transactionLog.getTablePath()
     // Read path only needs PATH_READ credentials
     val readConfig = config + ("spark.indextables.databricks.credential.operation" -> "PATH_READ")
-    resolveCredentialsOnDriver(readConfig, tablePath)
+    io.indextables.spark.utils.CredentialProviderFactory.resolveCredentialsOnDriver(readConfig, tablePath.toString)
   }
 
   override def readSchema(): StructType =
@@ -91,50 +91,7 @@ class IndexTables4SparkSimpleAggregateScan(
     )
   }
 
-  /**
-   * Resolve AWS credentials on the driver and return a modified config. See
-   * IndexTables4SparkScan.resolveCredentialsOnDriver for detailed documentation.
-   */
-  private def resolveCredentialsOnDriver(config: Map[String, String], tablePath: org.apache.hadoop.fs.Path)
-    : Map[String, String] = {
-    val providerClass = config
-      .get("spark.indextables.aws.credentialsProviderClass")
-      .orElse(config.get("spark.indextables.aws.credentialsproviderclass"))
-
-    providerClass match {
-      case Some(className) if className.nonEmpty =>
-        try {
-          val normalizedPath = io.indextables.spark.util.TablePathNormalizer.normalizeToTablePath(tablePath.toString)
-          val credentials = io.indextables.spark.utils.CredentialProviderFactory.resolveAWSCredentialsFromConfig(
-            config,
-            normalizedPath
-          )
-
-          credentials match {
-            case Some(creds) =>
-              logger.info(s"[DRIVER] Resolved AWS credentials from provider: $className")
-              var newConfig = config -
-                "spark.indextables.aws.credentialsProviderClass" -
-                "spark.indextables.aws.credentialsproviderclass" +
-                ("spark.indextables.aws.accessKey" -> creds.accessKey) +
-                ("spark.indextables.aws.secretKey" -> creds.secretKey)
-
-              creds.sessionToken.foreach(token => newConfig = newConfig + ("spark.indextables.aws.sessionToken" -> token))
-              newConfig
-
-            case None =>
-              logger.warn(s"[DRIVER] Failed to resolve credentials from provider $className, passing to executors")
-              config
-          }
-        } catch {
-          case ex: Exception =>
-            logger.warn(s"[DRIVER] Driver-side credential resolution failed: ${ex.getMessage}, passing to executors")
-            config
-        }
-
-      case None => config
-    }
-  }
+  // Credential resolution centralized in CredentialProviderFactory.resolveCredentialsOnDriver()
 
   override def description(): String = {
     val aggDesc = aggregation.aggregateExpressions.map(_.toString).mkString(", ")

--- a/src/main/scala/io/indextables/spark/sql/DescribeComponentSizesCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/DescribeComponentSizesCommand.scala
@@ -73,49 +73,7 @@ case class DescribeComponentSizesCommand(
     AttributeReference("field_name", StringType, nullable = true)()
   )
 
-  /**
-   * Resolve AWS credentials on the driver and return a modified config. This eliminates executor-side HTTP calls for
-   * credential providers like UnityCatalogAWSCredentialProvider.
-   */
-  private def resolveCredentialsOnDriver(config: Map[String, String], tablePath: String): Map[String, String] = {
-    val providerClass = config
-      .get("spark.indextables.aws.credentialsProviderClass")
-      .orElse(config.get("spark.indextables.aws.credentialsproviderclass"))
-
-    providerClass match {
-      case Some(className) if className.nonEmpty =>
-        try {
-          val normalizedPath = io.indextables.spark.util.TablePathNormalizer.normalizeToTablePath(tablePath)
-          val credentials = io.indextables.spark.utils.CredentialProviderFactory.resolveAWSCredentialsFromConfig(
-            config,
-            normalizedPath
-          )
-
-          credentials match {
-            case Some(creds) =>
-              logger.info(s"[DRIVER] Resolved AWS credentials from provider: $className")
-              var newConfig = config -
-                "spark.indextables.aws.credentialsProviderClass" -
-                "spark.indextables.aws.credentialsproviderclass" +
-                ("spark.indextables.aws.accessKey" -> creds.accessKey) +
-                ("spark.indextables.aws.secretKey" -> creds.secretKey)
-
-              creds.sessionToken.foreach(token => newConfig = newConfig + ("spark.indextables.aws.sessionToken" -> token))
-              newConfig
-
-            case None =>
-              logger.warn(s"[DRIVER] Failed to resolve credentials from provider $className, passing to executors")
-              config
-          }
-        } catch {
-          case ex: Exception =>
-            logger.warn(s"[DRIVER] Driver-side credential resolution failed: ${ex.getMessage}, passing to executors")
-            config
-        }
-
-      case None => config
-    }
-  }
+  // Credential resolution centralized in CredentialProviderFactory.resolveCredentialsOnDriver()
 
   override def run(sparkSession: SparkSession): Seq[Row] =
     try {
@@ -133,7 +91,7 @@ case class DescribeComponentSizesCommand(
       // PERFORMANCE OPTIMIZATION: Resolve credentials on driver to avoid executor-side HTTP calls
       // Describe is read-only, request PATH_READ credentials
       val readConfig   = baseConfig + ("spark.indextables.databricks.credential.operation" -> "PATH_READ")
-      val mergedConfig = resolveCredentialsOnDriver(readConfig, resolvedPath.toString)
+      val mergedConfig = io.indextables.spark.utils.CredentialProviderFactory.resolveCredentialsOnDriver(readConfig, resolvedPath.toString)
 
       // Create transaction log
       val transactionLog = TransactionLogFactory.create(

--- a/src/main/scala/io/indextables/spark/util/ConfigUtils.scala
+++ b/src/main/scala/io/indextables/spark/util/ConfigUtils.scala
@@ -402,5 +402,8 @@ object ConfigUtils {
   private def normalizeStorageUrl(url: String): String =
     if (url.startsWith("s3a://")) url.replaceFirst("s3a://", "s3://")
     else if (url.startsWith("s3n://")) url.replaceFirst("s3n://", "s3://")
+    else if (url.startsWith("abfss://")) url.replaceFirst("abfss://", "azure://")
+    else if (url.startsWith("abfs://")) url.replaceFirst("abfs://", "azure://")
+    else if (url.startsWith("wasbs://")) url.replaceFirst("wasbs://", "azure://")
     else url
 }


### PR DESCRIPTION
# Companion Read Path: Code Review Fixes

## Summary

Addresses performance and correctness issues identified during code review of the companion read paths. Eliminates ~170 lines of duplicated code, fixes thread safety issues, adds fail-fast error handling, and improves Azure storage compatibility.

## Changes

### Critical: Performance
- **Memoize `getActualFastFieldsFromSchema()`** (`IndexTables4SparkScanBuilder.scala`): This method reads the transaction log to determine fast field configuration. It was being called per-filter in `isSupportedFilter()`, meaning a query with 10 filters triggered 10+ `transactionLog.listFiles()` calls. Now cached via `lazy val cachedActualFastFields`.

### High: Correctness & Deduplication
- **Centralize `resolveCredentialsOnDriver()` into `CredentialProviderFactory`**: Five identical copies across `IndexTables4SparkScan`, `SimpleAggregateScan`, `GroupByAggregateScan`, `PrewarmCacheCommand`, and `DescribeComponentSizesCommand` consolidated into a single shared method. Reduces maintenance burden and ensures consistent credential resolution behavior. (-170 lines of duplicated code)
- **Fix `cachedFilteredActions` thread safety** (`IndexTables4SparkScan.scala`): Replaced `@volatile` var with non-atomic check-then-act pattern with a `lazy val` for thread-safe, once-only initialization. The previous pattern could cause duplicate `listFiles()` + `applyDataSkipping()` calls under concurrent access from `planInputPartitions()` and `estimateStatistics()`.
- **Share Jackson ObjectMapper** (`IndexTables4SparkScanBuilder.scala`): Moved per-invocation `new ObjectMapper()` allocation to a shared singleton in the companion object. ObjectMapper is thread-safe for reads and expensive to construct.

### Medium: Error Handling & Compatibility
- **Fail fast on missing companion config** (`IndexTables4SparkPartitions.scala`): Changed defensive companion config check from `logger.error()` + continue to `throw IllegalStateException`. The previous behavior logged an error but proceeded to create a search engine without the required parquet table root, resulting in an opaque "parquet_table_root was not set" error from tantivy4java.
- **Add error handling to `convertPartitionValue()`** (`IndexTables4SparkPartitions.scala`): Wrapped type conversion in try/catch with a descriptive `IllegalArgumentException`. Previously, a malformed partition value (e.g., non-numeric string for IntegerType) would produce a raw `NumberFormatException` with no context.
- **Add Azure URL normalization** (`ConfigUtils.scala`): Extended `normalizeStorageUrl()` to handle `abfss://`, `abfs://`, and `wasbs://` protocols, normalizing them to `azure://` for the native Rust layer. Previously only S3 protocols (`s3a://`, `s3n://`) were normalized.
- **Return `Option` from `buildParquetStorageConfig()`** (`SplitSearchEngine.scala`): Replaced `null` return with `Option[ParquetStorageConfig]` for idiomatic Scala null safety. Call site uses `.orNull` for the Java interop boundary.

### Low: Code Quality
- **Document IsNotNull stripping rationale** (`IndexTables4SparkScanBuilder.scala`): Added explanation for why `removeRedundantIsNotNull` is companion-mode-only. In non-companion mode, an unsupported IsNotNull correctly prevents Spark from attempting aggregate pushdown for text fields lacking fast field configuration.
- **Remove emoji from log messages** (`SplitSearchEngine.scala`, `IndexTables4SparkPartitions.scala`): Replaced emoji characters in log messages with plain text for better compatibility with log aggregation systems and terminals.

## Files Changed

| File | Change |
|------|--------|
| `CredentialProviderFactory.scala` | +51 lines: Added shared `resolveCredentialsOnDriver()` method |
| `IndexTables4SparkScanBuilder.scala` | Memoized fast fields, shared ObjectMapper, documented IsNotNull |
| `IndexTables4SparkScan.scala` | Thread-safe cached actions, removed duplicate credential method |
| `IndexTables4SparkSimpleAggregateScan.scala` | Removed duplicate credential method |
| `IndexTables4SparkGroupByAggregateScan.scala` | Removed duplicate credential method |
| `PrewarmCacheCommand.scala` | Removed duplicate credential method |
| `DescribeComponentSizesCommand.scala` | Removed duplicate credential method |
| `IndexTables4SparkPartitions.scala` | Fail-fast config check, error handling, emoji cleanup |
| `SplitSearchEngine.scala` | Option return type, emoji cleanup |
| `ConfigUtils.scala` | Azure URL normalization |

## Test Plan

- [x] `SimpleAggregatePushdownTest` (22 tests) - validates aggregate pushdown correctness
- [x] `AggregatePushdownIntegrationTest` + `AggregateExceptionTest` + `GroupByAggregatePushdownTest` (17 tests) - validates aggregate edge cases
- [x] `CompanionModeTest` + `CompanionSplitBugReproductionTest` (25 tests) - validates companion read paths
- [x] `PartitionedDatasetTest` (7 tests) - validates partition handling including text field filtering
- [x] Clean compile with no warnings
- [x] Net reduction: -173 lines (157 insertions, 330 deletions)
