### PR TITLE
quality: Transaction Log Subsystem: Code Review Fixes

### DIFF
--- a/src/main/scala/io/indextables/spark/transaction/Actions.scala
+++ b/src/main/scala/io/indextables/spark/transaction/Actions.scala
@@ -47,6 +47,7 @@ case class DocMappingMetadata(
 
 object DocMappingMetadata {
   private val mapper = new ObjectMapper()
+  private val logger = org.slf4j.LoggerFactory.getLogger(DocMappingMetadata.getClass)
 
   /** Empty metadata for when no docMappingJson is available */
   val empty: DocMappingMetadata = DocMappingMetadata(Set.empty, Set.empty, Map.empty, Set.empty, Set.empty)
@@ -105,7 +106,9 @@ object DocMappingMetadata {
 
       DocMappingMetadata(fieldNames.toSet, fastFields.toSet, fieldTypes.toMap, indexedFields.toSet, storedFields.toSet)
     } catch {
-      case _: Exception => empty
+      case e: Exception =>
+        logger.warn(s"Failed to parse docMappingJson, returning empty metadata: ${e.getMessage}")
+        empty
     }
   }
 }

--- a/src/main/scala/io/indextables/spark/transaction/FilterSelectivityEstimator.scala
+++ b/src/main/scala/io/indextables/spark/transaction/FilterSelectivityEstimator.scala
@@ -106,8 +106,8 @@ object FilterSelectivityEstimator {
         math.max(estimateSelectivity(left), estimateSelectivity(right))
 
       case Not(child) =>
-        // NOT inverts selectivity, but we use same score for simplicity
-        estimateSelectivity(child)
+        // NOT inverts selectivity: highly selective child -> low selectivity NOT
+        math.min(UNKNOWN_SCORE - estimateSelectivity(child), UNKNOWN_SCORE)
 
       // Unknown filter types
       case _ => UNKNOWN_SCORE

--- a/src/main/scala/io/indextables/spark/transaction/TransactionLogMetrics.scala
+++ b/src/main/scala/io/indextables/spark/transaction/TransactionLogMetrics.scala
@@ -280,9 +280,8 @@ object TransactionLogMetrics {
     logger.info("=====================================")
   }
 
-  /** Reset all metrics */
+  /** Reset all metrics (resets counters without removing registered metrics) */
   def reset(): Unit = {
-    metricRegistry.removeMatching(MetricFilter.ALL)
     sequentialReadTimes.set(0)
     parallelReadTimes.set(0)
     sequentialReadCount.set(0)

--- a/src/main/scala/io/indextables/spark/transaction/avro/AvroSchemas.scala
+++ b/src/main/scala/io/indextables/spark/transaction/avro/AvroSchemas.scala
@@ -17,7 +17,6 @@
 
 package io.indextables.spark.transaction.avro
 
-import scala.io.Source
 import scala.util.Try
 
 import org.apache.avro.generic.GenericRecord
@@ -367,26 +366,6 @@ object AvroSchemas {
 
   /** Parsed StateManifest schema (lazily initialized) */
   lazy val STATE_MANIFEST_SCHEMA: Schema = new Schema.Parser().parse(STATE_MANIFEST_SCHEMA_JSON)
-
-  /**
-   * Load schema from resources (alternative to embedded schema).
-   *
-   * @param resourcePath
-   *   Path to schema resource file
-   * @return
-   *   Parsed Avro schema
-   */
-  def loadSchemaFromResource(resourcePath: String): Schema = {
-    val stream = getClass.getResourceAsStream(resourcePath)
-    if (stream == null) {
-      throw new IllegalArgumentException(s"Schema resource not found: $resourcePath")
-    }
-    try {
-      val schemaJson = Source.fromInputStream(stream).mkString
-      new Schema.Parser().parse(schemaJson)
-    } finally
-      stream.close()
-  }
 
   /**
    * Convert a GenericRecord to a FileEntry.

--- a/src/main/scala/io/indextables/spark/transaction/compression/GzipCompressionCodec.scala
+++ b/src/main/scala/io/indextables/spark/transaction/compression/GzipCompressionCodec.scala
@@ -28,9 +28,12 @@ class GzipCompressionCodec(level: Int = 6) extends CompressionCodec {
       var bytesRead = 0
       while ({ bytesRead = input.read(buffer); bytesRead != -1 })
         gzipOut.write(buffer, 0, bytesRead)
+      // Use finish() instead of close() to finalize GZIP stream without closing the underlying output stream
+      gzipOut.finish()
       gzipOut.flush()
-    } finally
-      gzipOut.close()
+    } finally {
+      // Do not close gzipOut here as it would close the caller's output stream
+    }
   }
 
   override def decompress(input: InputStream, output: OutputStream): Unit = {

--- a/src/test/scala/io/indextables/spark/transaction/PartitionPruningDateFilterTest.scala
+++ b/src/test/scala/io/indextables/spark/transaction/PartitionPruningDateFilterTest.scala
@@ -721,11 +721,10 @@ class PartitionPruningDateFilterTest extends AnyFunSuite with Matchers with Befo
       )
     )
     val complexResult = PartitionPruning.prunePartitions(addActions, partitionColumns, complexMixedFilter)
-    // Should extract and apply: (date >= 2023-02-01 AND region = us)
-    // This matches only: 2023-03-10/us
-    complexResult should have length 1
-    complexResult.head.partitionValues("date") shouldBe "2023-03-10"
-    complexResult.head.partitionValues("region") shouldBe "us"
+    // When an OR has one branch with all non-partition columns, the entire OR cannot be
+    // safely used for partition pruning (the non-partition branch might match any partition).
+    // All partitions should be returned and the full filter applied post-read.
+    complexResult should have length 3
   }
 
   test("Multiple partition columns should work with date filtering") {


### PR DESCRIPTION
# Transaction Log Subsystem: Code Review Fixes

## Summary

Addresses 32 findings from a comprehensive code review of the transaction log subsystem, spanning data correctness bugs, performance improvements, thread safety fixes, and code hygiene. The most critical fix prevents silent data loss from incorrect OR filter handling in partition pruning.

## Changes

### Critical: Data Correctness

- **Fix OR filter extraction data loss** (`PartitionPruning.scala`): When an OR filter had one branch referencing partition columns and the other referencing non-partition columns, the non-partition branch was silently dropped. This caused incorrect partition pruning — rows that should have been returned were filtered out. Now returns `None` (no pruning) when either OR branch can't be fully evaluated.

- **Add `@volatile` to TransactionLogCache vars** (`TransactionLogCache.scala`): Five mutable `var` fields (`cachedVersionsList`, `cachedFilesList`, `cachedMetadata`, `cachedProtocol`, `cachedPartitionIndex`) were read from the cleanup thread and written under `synchronized` blocks but lacked `@volatile`. Without it, the cleanup thread could see stale values due to JVM memory model visibility guarantees.

### High: Performance & Correctness

- **Fix `initializeProtocolIfNeeded` reading all versions** (`TransactionLog.scala`): Was calling `getVersions().flatMap(readVersion)` to scan every version file looking for a protocol action. Now uses `getProtocol()` which leverages caching and checkpoint-first lookup.

- **Add missing protocol action parsing** (`ParallelTransactionLogOperations.scala`): Both `parseActionsFromStream` and `parseActionsFromContent` parsed `metaData`, `add`, `remove`, and `mergeskip` actions but silently dropped `protocol` actions. This caused protocol upgrades to be invisible when read through the parallel operations path.

- **Add `withWriteOptions` try/finally helper** (`TransactionLog.scala`): `setWriteOptions`/`clearWriteOptions` had no RAII pattern, risking leaked thread-local state if the write threw an exception. Added `withWriteOptions[T](options)(body)` that guarantees cleanup.

- **Log parse errors instead of swallowing** (`ParallelTransactionLogOperations.scala`): `readVersionDirect` wrapped parsing in `Try{...}.getOrElse(Seq.empty)`, silently swallowing all exceptions including actual parse failures. Now logs a warning with the exception before returning empty.

- **Add missing `evaluateFilter` cases** (`PartitionPruning.scala`): `evaluateFilter` handled only 7 of 13 filter types. Added `EqualNullSafe`, `IsNull`, `IsNotNull`, `Not`, `StringStartsWith`, `StringEndsWith`, and `StringContains`. Previously these fell through to the default `true` case, disabling pruning for any query using these predicates.

- **Fix `TransactionLogMetrics.reset()`** (`TransactionLogMetrics.scala`): Was calling `metricRegistry.removeMatching(MetricFilter.ALL)` which deregisters all metrics. Since the histograms, counters, meters, and gauges are stored as `val` fields, subsequent calls to these fields would operate on orphaned objects no longer tracked by the registry. Now only resets the atomic counters.

- **Fix PartitionFilterCache hash collision risk** (`PartitionFilterCache.scala`): Cache key was a `Long` composed of two 32-bit hashes packed together. Different filter/partition combinations could collide, returning incorrect cached results. Replaced with a typed `FilterCacheKey` case class containing the actual filter strings and partition values map.

- **Fix O(n^2) file removal in `listFiles`** (`TransactionLog.scala`): File list was built using `ListBuffer` with `files --= files.filter(_.path == remove.path)` for each remove action — O(n) scan per removal. Replaced with `HashMap[String, AddAction]` keyed by path for O(1) add/remove operations.

- **Fix `invalidateCaches` missing PartitionIndex** (`PartitionPruning.scala`): `invalidateCaches()` cleared `PartitionFilterCache` but not `PartitionIndex`, causing stale partition index data after cache invalidation. Added `PartitionIndex.invalidateCache()` call.

### Medium: Performance & Resource Management

- **Fix N+1 cloud calls in `cleanupOldVersions`** (`TransactionLogCheckpoint.scala`): For each version to check, called `cloudProvider.exists()` followed by `cloudProvider.listFiles()` inside the loop. Now calls `listFiles()` once at the start and uses a `Map` for O(1) lookups.

- **~~Try version 0 first in `getMetadata` fallback~~** (`TransactionLog.scala`): Reverted — metadata can be updated in later versions (e.g., with schema registry), so the reverse chronological scan from latest to version 0 is the correct approach. The version 0 "optimization" was unsafe because it returned stale metadata missing the schema registry.

- **Fix `compress()` closing caller's stream** (`GzipCompressionCodec.scala`): The streaming `compress(input, output)` method called `gzipOut.close()` in the finally block, which also closes the underlying `output` stream owned by the caller. Replaced with `gzipOut.finish()` which finalizes the GZIP stream without closing the underlying stream.

- **Fix timestamp format mismatch** (`PartitionPruning.scala`): Timestamp comparison tried JDBC format (`Timestamp.valueOf`) first, but partition values are stored in ISO-8601 format. Now tries `Instant.parse` (ISO-8601) first, with JDBC format and epoch millis as fallbacks.

- **Fix cleanup thread leak** (`TransactionLogCache.scala`): Each `TransactionLogCache` instance created its own `ScheduledExecutorService` with a dedicated thread. In applications creating many cache instances, this leaked threads. Replaced with a shared static `ScheduledExecutorService` in the companion object; individual instances now schedule tasks on the shared executor and cancel them on shutdown.

- **Fix `shutdown()` force-initializing lazy pools** (`TransactionLogThreadPools.scala`): `shutdown()` referenced all 6 lazy thread pools, forcing their initialization. If only 2 pools were used, shutdown would create 4 unnecessary pools just to immediately shut them down. Added `@volatile` initialization tracking flags and only shuts down pools that were actually accessed.

- **Fix `NonFateSharingFuture` double-execution risk** (`TransactionLogThreadPools.scala`): On timeout, the fallback executed `body` synchronously without checking if the async future had completed in the meantime. Added a completion check before synchronous fallback to avoid double-execution.

- **Fix O(n*m) tombstone filtering** (`StreamingStateReader.scala`): Tombstone filtering used `manifest.tombstones.contains(e.path)` (O(n) per entry) and `allEntries.exists(_.path == path)` (O(m) per tombstone). Converted both to `Set` for O(1) lookups.

- **Fix `findNextAvailableVersion` recursive listing** (`StateWriter.scala`): Called `cloudProvider.listFiles(transactionLogPath, recursive = true)` which lists the entire transaction log directory tree. Replaced with sequential version probing that checks `_manifest.avro` existence starting from `afterVersion + 1`.

### Low: Code Quality

- **Add warning log to `DocMappingMetadata.parse`** (`Actions.scala`): Parse failures were silently returning `empty`. Now logs a warning with the exception message before returning empty, aiding debugging of malformed docMappingJson.

- **Downgrade hot-path `logger.info` to `logger.debug`** (various files): Changed partition pruning application logging and cache miss/populate logging from `info` to `debug` to reduce log noise in production.

- **Remove dead `getReferencedColumns` method** (`PartitionPruning.scala`): Unused private method removed.

- **Fix `FilterSelectivityEstimator` Not selectivity** (`FilterSelectivityEstimator.scala`): `Not(child)` returned the same selectivity as `child`. Since NOT inverts selectivity (e.g., `NOT EqualTo` matches almost everything), now computes `UNKNOWN_SCORE - estimateSelectivity(child)`.

- **Remove dead `loadSchemaFromResource` method** (`AvroSchemas.scala`): Unused method and its `scala.io.Source` import removed.

- **Fix `String.contains` path matching** (`EnhancedTransactionLogCache.scala`): Cache invalidation for Avro state manifests used `.contains(tablePath)` which could match `/table1` against `/table10`. Changed to `startsWith` with trailing separator for proper path prefix matching.

- **Cache `MessageDigest.getInstance`** (`SchemaDeduplication.scala`): `MessageDigest.getInstance("SHA-256")` performs a JCE provider lookup on each call. Added `ThreadLocal[MessageDigest]` to reuse instances, calling `reset()` before each use.

## Files Changed

| File | Changes |
|------|---------|
| `PartitionPruning.scala` | Fix OR filter extraction, add evaluateFilter cases, add PartitionIndex invalidation, remove dead code, downgrade log level |
| `TransactionLogCache.scala` | Add `@volatile`, shared cleanup executor, companion object |
| `EnhancedTransactionLogCache.scala` | Fix path matching, downgrade hot-path logs |
| `ParallelTransactionLogOperations.scala` | Add protocol action parsing, log parse errors |
| `TransactionLog.scala` | Fix initializeProtocolIfNeeded, add withWriteOptions, O(1) file removal, try version 0 first |
| `TransactionLogMetrics.scala` | Fix reset() to not deregister metrics |
| `PartitionFilterCache.scala` | Typed cache key instead of packed Long |
| `StateWriter.scala` | Sequential version probing, document totalBytes limitation |
| `TransactionLogCheckpoint.scala` | Single listFiles call for cleanup |
| `GzipCompressionCodec.scala` | Use finish() instead of close() |
| `TransactionLogThreadPools.scala` | Lazy pool init tracking, NonFateSharingFuture fix |
| `StreamingStateReader.scala` | Set-based tombstone filtering |
| `FilterSelectivityEstimator.scala` | Fix Not selectivity inversion |
| `Actions.scala` | Add warning log on parse failure |
| `AvroSchemas.scala` | Remove dead method and unused import |
| `SchemaDeduplication.scala` | ThreadLocal MessageDigest |

## Skipped Items

Three findings were intentionally deferred:

- **H5** (TransactionLogAdapter double-initialization): Requires inheritance hierarchy refactor with high risk of breaking existing behavior.
- **M1** (Code duplication between TransactionLog and OptimizedTransactionLog): Large architectural refactor better suited for a dedicated PR.
- **L2** (Per-instance thread pool in TransactionLogCheckpoint): Low impact, requires lifecycle changes.

## Test Plan

- [ ] `mvn clean compile` passes
- [ ] Full test suite passes (`mvn test`)
- [ ] Verify partition pruning tests pass (C1, H6 changes are correctness-critical)
- [ ] Verify cache-related tests pass (C2, H8 changes)
- [ ] Verify transaction log read/write tests pass (H1, H2, H4, H9 changes)
- [ ] Verify GZIP compression tests pass (M5 change)
