### PR TITLE
quality: Merge System: Code Review Fixes

### DIFF
--- a/src/main/scala/io/indextables/spark/io/merge/MergeIOConfig.scala
+++ b/src/main/scala/io/indextables/spark/io/merge/MergeIOConfig.scala
@@ -133,31 +133,11 @@ object MergeIOConfig {
     if (value == null || value.isEmpty) default else value.toLong
   }
 
-  /** Parse a byte size string (e.g., "2G", "512M", "1024K") into bytes. */
-  def parseBytes(size: String): Long = {
-    val trimmed = size.trim.toUpperCase
-    val multiplier = trimmed.last match {
-      case 'K' => 1024L
-      case 'M' => 1024L * 1024
-      case 'G' => 1024L * 1024 * 1024
-      case 'T' => 1024L * 1024 * 1024 * 1024
-      case _   => 1L
-    }
-
-    val numericPart = if (multiplier > 1) {
-      trimmed.dropRight(1).trim
-    } else {
-      trimmed
-    }
-
-    numericPart.toLong * multiplier
-  }
+  /** Parse a byte size string (e.g., "2G", "512M", "1.5G", "1024K") into bytes. */
+  def parseBytes(size: String): Long =
+    io.indextables.spark.merge.AsyncMergeOnWriteConfig.parseBytes(size)
 
   /** Format bytes as a human-readable string. */
   def formatBytes(bytes: Long): String =
-    if (bytes >= 1024L * 1024 * 1024 * 1024) s"${bytes / (1024L * 1024 * 1024 * 1024)}T"
-    else if (bytes >= 1024L * 1024 * 1024) s"${bytes / (1024L * 1024 * 1024)}G"
-    else if (bytes >= 1024L * 1024) s"${bytes / (1024L * 1024)}M"
-    else if (bytes >= 1024L) s"${bytes / 1024L}K"
-    else s"${bytes}B"
+    io.indextables.spark.merge.AsyncMergeOnWriteConfig.formatBytes(bytes)
 }

--- a/src/main/scala/io/indextables/spark/merge/AsyncMergeOnWriteConfig.scala
+++ b/src/main/scala/io/indextables/spark/merge/AsyncMergeOnWriteConfig.scala
@@ -341,7 +341,7 @@ object AsyncMergeOnWriteConfig {
     }
   }
 
-  /** Parse a byte size string (e.g., "2G", "512M", "1024K") into bytes. */
+  /** Parse a byte size string (e.g., "2G", "512M", "1.5G", "1024K") into bytes. */
   def parseBytes(size: String): Long = {
     val trimmed = size.trim.toUpperCase
     val multiplier = trimmed.last match {
@@ -358,7 +358,7 @@ object AsyncMergeOnWriteConfig {
       trimmed
     }
 
-    numericPart.toLong * multiplier
+    (BigDecimal(numericPart) * multiplier).toLong
   }
 
   /** Format bytes as a human-readable string. */


### PR DESCRIPTION
# Merge System: Code Review Fixes

## Summary

Addresses findings from a full code review of the merge system (`MergeSplitsCommand`, `AsyncMergeOnWriteManager`, `WorkerLocalSplitMerger`, `MergeIOThreadPools`, `MergeUploader`, `MergeIOConfig`, `AsyncMergeOnWriteConfig`). Fixes a data correctness bug where merged split sizes were recorded incorrectly in the transaction log, two concurrency bugs (TOCTOU duplicate-job race and shared SparkSession conf mutation from async threads), eliminates CPU-spinning in `awaitCompletion`, fixes numeric data-skipping statistics, and removes a range of resource leaks, data races, and misleading log noise.

101 tests pass. Net: 213 insertions, 220 deletions.

---

## Changes

### Critical: Data Correctness & Thread Safety

- **Fix `MergedSplitInfo.size` records uncompressed size instead of actual file size** (`MergeSplitsCommand.scala`): `MergedSplitInfo` was constructed with `serializedMetadata.getUncompressedSizeBytes` — the uncompressed content size reported by tantivy4java — instead of `finalMergedSize`, the actual on-disk byte count after upload. Since `findMergeableGroups` uses `file.size` to decide whether a split is already large enough to skip, and `planAllMergeGroups` sums sizes to simulate merge output, uncompressed sizes (typically 2–5× larger) caused both to systematically overestimate split sizes, skipping files that should have been merged and mis-sizing merge groups. DESCRIBE STORAGE STATS also reported inflated totals.

- **Fix TOCTOU race in `submitMergeJob` duplicate-job check** (`AsyncMergeOnWriteManager.scala`): The previous code checked `isMergeInProgress(tablePath)` and then called `tableJobIds.put(tablePath, jobId)` as two separate operations. Two concurrent writes to the same table could both pass the check and register competing merge jobs, leading to conflicting transaction log commits. Replaced with `tableJobIds.putIfAbsent(tablePath, jobId)`, which is atomic on `ConcurrentHashMap`.

- **Fix `SparkSession.conf` mutation from async merge thread** (`AsyncMergeOnWriteManager.scala`, `MergeSplitsCommand.scala`): The async merge manager was setting `spark.indextables.merge.batchSize` and `spark.indextables.merge.maxConcurrentBatches` on the shared `SparkSession` before calling `MergeSplitsExecutor.merge()`, then restoring original values in a `finally` block. Concurrent async and sync merges clobbered each other's values. Fixed by adding `batchSizeOverride` and `maxConcurrentBatchesOverride` constructor parameters to `MergeSplitsExecutor`; `merge()` prefers these over SparkSession conf. The async manager passes them directly, eliminating the conf mutation entirely.

### High: Concurrency & Resource Safety

- **Replace busy-wait in `awaitCompletion` with `CountDownLatch`** (`AsyncMergeOnWriteManager.scala`): Added `completionLatch: CountDownLatch` to `AsyncMergeJob`. `completeJob` and `failJob` call `latch.countDown()` as their final action. `awaitCompletion` uses `latch.await(timeoutMs, MILLISECONDS)` — no polling, no CPU spin.

- **Fix data race on `failedBatchCount`/`successfulBatchCount`** (`MergeSplitsCommand.scala`): These were `var` integers incremented inside `.par.flatMap { }` running across a `ForkJoinPool`. Multiple threads incrementing a non-atomic `var` causes lost updates. Changed to `AtomicInteger` with `.incrementAndGet()`.

- **Detect all-batches-failed scenario** (`MergeSplitsCommand.scala`): When every batch fails, the previous code returned `partial_success` or `no_action` with no clear indication of total failure. Now throws `RuntimeException` when `failedBatchCount > 0 && successfulBatchCount == 0` so the error propagates clearly to the caller.

- **Eliminate 128MB heap allocation per multipart upload part** (`MergeUploader.scala`): `uploadMultipart` allocated `new Array[Byte](currentPartSize)` (up to 128MB) per part and called `raf.readFully(buffer)`. On memory-constrained executors, this triggered GC pressure or OOM during large merges. Replaced with `FileChannel.map(READ_ONLY, offset, size)` + `RequestBody.fromByteBuffer(mappedBuffer)`, using virtual memory (OS page cache) instead of heap.

- **Recover thread pools after shutdown** (`MergeIOThreadPools.scala`): Thread pools were `lazy val`, meaning after a `shutdown()` call they held references to terminated executors. Any subsequent merge attempt — common in long-running Spark sessions — would fail with `RejectedExecutionException`. Replaced with `@volatile var` fields and double-checked locking; each accessor detects `isShutdown` and recreates the pool transparently. `shutdown()` now uses the backing fields directly to avoid spuriously initializing pools during teardown. `downloadExecutionContext` reads `_downloadExecCtx` inside the same lock used to create it, ensuring it is always paired with the current live pool.

- **Fix numeric min/max statistics for data skipping** (`WorkerLocalSplitMerger.scala`): `computeUnionMinValues` and `computeUnionMaxValues` used `fieldValues.min`/`.max`, which applies implicit `String` ordering. For numeric fields this is wrong: `"9" > "10"` lexicographically, so a split with values `["9", "10"]` would compute `min = "10"` instead of `9`. Data skipping would incorrectly prune partitions. Added `statsValueOrdering` that tries `BigDecimal` comparison first and falls back to string ordering for non-numeric fields.

- **Fix broadcast variable leak on early failure** (`MergeSplitsCommand.scala`): `broadcastAzureConfig` and `broadcastTablePath` were created before the parallel batch loop but only destroyed if the loop completed without throwing. Added `destroy()` calls for both in the `finally` block that already shut down the `ForkJoinPool`.

- **Fix `parseBytes` rejecting decimal values** (`AsyncMergeOnWriteConfig.scala`, `MergeIOConfig.scala`): `numericPart.toLong` threw `NumberFormatException` for inputs like `"1.5G"` — a natural user input for target sizes. Changed to `(BigDecimal(numericPart) * multiplier).toLong`. Eliminated the duplicate implementation in `MergeIOConfig` by delegating to `AsyncMergeOnWriteConfig.parseBytes`.

### Medium: Error Handling & Reliability

- **Check `mkdirs()` return value** (`MergeSplitsCommand.scala`): Silent failure if the merge temp directory could not be created caused a confusing "file not found" error later. Now throws `RuntimeException` immediately with the directory path.

- **Add exponential backoff to merge retry** (`MergeSplitsCommand.scala`): `retryOnStreamingError` retried immediately after a transient failure. Added `1000ms × 2^(attempt-1)` delay between attempts (1s before attempt 2, 2s before attempt 3), reducing re-failures under throttling or transient load.

- **Improve Azure config extraction error reporting** (`MergeSplitsCommand.scala`): Previously caught all exceptions and logged at ERROR before returning empty config silently. Now only `NoSuchElementException` (expected: Azure not configured) is suppressed at DEBUG. All other exceptions log at WARN with the actual message, making Azure credential problems diagnosable.

- **Await old executor termination during reconfigure** (`AsyncMergeOnWriteManager.scala`): `configure()` called `executorService.shutdown()` and immediately replaced the service, leaving old tasks running on the discarded executor. Added `awaitTermination(5s)` / `shutdownNow()` before proceeding.

- **Downgrade diagnostic WARN/ERROR logging with emojis** (`MergeSplitsCommand.scala`): Several development-era `logger.warn("✅ ...")` and `logger.error("❌ ...")` messages were left in the batch processing loop. Downgraded to `logger.debug` or `logger.info`, removed emoji characters that can corrupt non-UTF-8 log sinks and complicate `grep`.

- **Make `docMappingJson` optional for older splits** (`MergeSplitsCommand.scala`): `executeMergeGroupDistributed` threw `IllegalStateException` if no source split carried a `docMappingJson` field, preventing merges on tables created before this field was introduced. Changed to `Option`, logs a WARN if absent, and conditionally calls `mergeConfigBuilder.docMappingUid(json)` only when present.

- **Bound thread pool queue** (`MergeIOThreadPools.scala`): `createThreadPool` used `new LinkedBlockingQueue[Runnable]()` (unbounded), making the `CallerRunsPolicy` rejection handler unreachable and allowing the queue to grow without limit if downloads stall. Changed to `LinkedBlockingQueue(1000)`.

### Low: Code Quality

- **`performPreCommitMerge` placeholder replaced with `UnsupportedOperationException`** (`MergeSplitsCommand.scala`): The method logged "Implementation pending" and returned a hardcoded `"pending"` row, giving the false impression the feature worked. Now throws `UnsupportedOperationException` with a clear message directing users to post-commit merge.

- **`MergeGroup.toString` no longer dumps full file list** (`MergeSplitsCommand.scala`): The default case class `toString` printed the entire `files: Seq[AddAction]` sequence — potentially thousands of entries — in log messages and exception strings. Added `override def toString` returning only partition and file count.

- **Remove no-op heartbeat thread** (`WorkerLocalSplitMerger.scala`): The heartbeat thread logged `"Merge in progress, sending heartbeat..."` but performed no actual action — Spark executor heartbeats are automatic. Removed the thread and the now-unused `TaskContext` import.

- **`batchResults` variable shadowing eliminated** (`MergeSplitsCommand.scala`): An inner `val batchResults` (the `Array[MergeResult]` returned from each batch) shadowed the outer `val batchResults` (the `ParSeq[(Seq[MergeGroup], Int)]` being iterated). While the shadowing produced correct output, it was a fragile implicit dependency. Renamed the inner variable to `perGroupResults`.

---

## Files Changed

| File | Changes |
|------|---------|
| `MergeSplitsCommand.scala` | C1 size fix, C3 batch config params, H3 AtomicInteger, H4 all-fail detection, H7 broadcast cleanup, M1 mkdirs check, M3 retry backoff, M4 Azure error reporting, M6 log cleanup, M7 optional docMappingJson, L2 UnsupportedOperationException, L5 MergeGroup.toString, inner `batchResults` rename |
| `AsyncMergeOnWriteManager.scala` | C2 putIfAbsent, C3 remove conf mutation, H1 CountDownLatch, M5 await termination on reconfigure |
| `MergeIOThreadPools.scala` | H9 recoverable pools (lazy val → getOrCreate), M8 bounded queue, shutdown uses backing fields, downloadExecutionContext reads under lock |
| `WorkerLocalSplitMerger.scala` | H8 numeric min/max ordering, L6 remove heartbeat thread |
| `MergeUploader.scala` | H5 memory-mapped multipart upload |
| `AsyncMergeOnWriteConfig.scala` | H6 BigDecimal parsing for decimal size strings |
| `MergeIOConfig.scala` | M2 consolidate duplicate parseBytes/formatBytes |

## Test Plan

- [x] `AsyncMergeOnWriteManagerTest` — job lifecycle, duplicate rejection, await completion
- [x] `AsyncMergeOnWriteConfigTest` — config parsing including size strings
- [x] `MergeIOConfigTest` — I/O configuration parsing
- [x] `MergeOperationsCorrectnessTest` — merge correctness end-to-end
- [x] `PostCommitMergeOnWriteTest` — post-commit merge-on-write integration
- [x] `AsyncMergeOnWriteIntegrationTest` — async job submission and tracking
- [x] `MergeSplitsPartitionTest` — partitioned merge correctness
- [x] `MergeSplitsSkippedFilesTest` — skipped file handling during merge
- [x] `FastFieldMergeTest` — fast field preservation across merge
- [x] `MergeOnWriteGroupCountBugTest` — group formation edge cases
- [x] 101 tests across 20 suites: all pass
