### PR TITLE
Document class name aliases in CLAUDE.md and sql-commands.md (IT-006)

### DIFF
--- a/.claude/BACKLOG.md
+++ b/.claude/BACKLOG.md
@@ -33,11 +33,8 @@ Moved to Completed.
 
 ## High
 
-### IT-006: Document both class name aliases in CLAUDE.md
-**Description**: README.md uses public aliases (`IndexTablesProvider`), CLAUDE.md uses internal names (`IndexTables4SparkTableProvider`). Both valid.
-**Acceptance Criteria**:
-- [ ] CLAUDE.md acknowledges both names
-- [ ] Recommends public alias as primary
+### ~~IT-006: Document both class name aliases in CLAUDE.md~~ **DONE**
+Moved to Completed.
 
 ### ~~IT-007: Fix storage class names in CLAUDE.md~~ **DONE**
 Moved to Completed.
@@ -127,3 +124,4 @@ Moved to Completed.
 | IT-004 | Fix extensions registration syntax | 2026-02 |
 | IT-005 | Annotate unwired data skipping SQL commands | 2026-02 |
 | IT-007 | Fix storage class names in CLAUDE.md | 2026-02 |
+| IT-006 | Document both class name aliases in CLAUDE.md | 2026-02 |

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -64,17 +64,17 @@ See `docs/reference/field-indexing.md` for tokenizers, index record options, tok
 ## Common Usage
 
 ### DataSource API
-Use `io.indextables.spark.core.IndexTables4SparkTableProvider` for all read/write operations.
+Use `io.indextables.provider.IndexTablesProvider` for all read/write operations. This is the recommended public alias. The internal class `io.indextables.spark.core.IndexTables4SparkTableProvider` is also valid and used extensively in tests — both are interchangeable.
 
 ### Basic Write
 ```scala
-df.write.format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+df.write.format("io.indextables.provider.IndexTablesProvider")
   .save("s3://bucket/path")
 ```
 
 ### Write with Field Configuration
 ```scala
-df.write.format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+df.write.format("io.indextables.provider.IndexTablesProvider")
   .option("spark.indextables.indexing.typemap.title", "string")
   .option("spark.indextables.indexing.typemap.content", "text")
   .option("spark.indextables.indexing.fastfields", "score")
@@ -83,7 +83,7 @@ df.write.format("io.indextables.spark.core.IndexTables4SparkTableProvider")
 
 ### Optimized Write (shuffle before writing)
 ```scala
-df.write.format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+df.write.format("io.indextables.provider.IndexTablesProvider")
   .option("spark.indextables.write.optimizeWrite.enabled", "true")
   .option("spark.indextables.write.optimizeWrite.targetSplitSize", "1G")
   .partitionBy("date")
@@ -92,7 +92,7 @@ df.write.format("io.indextables.spark.core.IndexTables4SparkTableProvider")
 
 ### Read & Query
 ```scala
-val df = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load("s3://bucket/path")
+val df = spark.read.format("io.indextables.provider.IndexTablesProvider").load("s3://bucket/path")
 
 // Standard filters (pushed down for string fields)
 df.filter($"title" === "exact title").show()
@@ -108,22 +108,22 @@ df.agg(count("*"), sum("score"), avg("score")).show()
 ### Partitioned Datasets
 ```scala
 // Write
-df.write.format("io.indextables.spark.core.IndexTables4SparkTableProvider")
+df.write.format("io.indextables.provider.IndexTablesProvider")
   .partitionBy("date", "hour")
   .save("s3://bucket/path")
 
 // Read with partition pruning
-val df = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load("s3://bucket/path")
+val df = spark.read.format("io.indextables.provider.IndexTablesProvider").load("s3://bucket/path")
 df.filter($"date" === "2024-01-01" && $"hour" === 10).show()
 ```
 
 ## SQL Extensions
 
-Register extensions for SQL commands:
+Register extensions for SQL commands. The public alias `io.indextables.extensions.IndexTablesSparkExtensions` is recommended. The internal class `io.indextables.spark.extensions.IndexTables4SparkExtensions` is also valid — both are interchangeable.
 ```scala
 // In SparkSession builder:
 val spark = SparkSession.builder()
-  .config("spark.sql.extensions", "io.indextables.spark.extensions.IndexTables4SparkExtensions")
+  .config("spark.sql.extensions", "io.indextables.extensions.IndexTablesSparkExtensions")
   .getOrCreate()
 ```
 

--- a/docs/reference/sql-commands.md
+++ b/docs/reference/sql-commands.md
@@ -5,7 +5,7 @@ All SQL commands require the extensions to be registered:
 ```scala
 // In SparkSession builder:
 val spark = SparkSession.builder()
-  .config("spark.sql.extensions", "io.indextables.spark.extensions.IndexTables4SparkExtensions")
+  .config("spark.sql.extensions", "io.indextables.extensions.IndexTablesSparkExtensions")
   .getOrCreate()
 ```
 


### PR DESCRIPTION
## Summary
- Switch all code examples in CLAUDE.md to public aliases (`IndexTablesProvider`, `IndexTablesSparkExtensions`) matching README.md
- Document both public and internal class names as interchangeable in DataSource API and SQL Extensions sections
- Update `sql-commands.md` extensions registration to use public alias for consistency

## Changes
- **`.claude/CLAUDE.md`**: 7 DataSource format string replacements + 1 extensions class replacement + 2 descriptive text updates documenting both aliases
- **`docs/reference/sql-commands.md`**: Extensions registration updated to public alias
- **`.claude/BACKLOG.md`**: IT-006 marked complete

## Test plan
- [ ] Verify all code examples in CLAUDE.md use public aliases
- [ ] Verify internal class names are mentioned only in explanatory notes
- [ ] Verify sql-commands.md extensions registration matches CLAUDE.md