### PR TITLE
feature: Companion Split Query Coverage and COUNT(*) Null-Field Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <dependency>
             <groupId>io.indextables</groupId>
             <artifactId>tantivy4java</artifactId>
-            <version>0.30.0</version>
+            <version>0.30.1</version>
             <classifier>${platform.classifier}</classifier>
         </dependency>
 


### PR DESCRIPTION
# PR: Companion Split Query Coverage and COUNT(*) Null-Field Fix

## Summary

- **Fix incorrect COUNT(\*) on companion splits** with nullable fast fields — `IndexTables4SparkSimpleAggregateScan` now prefers `__pq_file_hash` (always non-null) over user fields that may contain nulls
- **Add 6 Spark-level integration tests** for companion split query types that mirror the tantivy4java PR #86 string-hash test cases: `COUNT(col)`, `GROUP BY` with metric sub-aggs, `IS NOT NULL`, `IS NULL`, `IN`, and the COUNT(\*) null-field regression

## Problem

### Bug: COUNT(\*) on companion splits could undercount

`IndexTables4SparkSimpleAggregateScan` translates `COUNT(*)` to a tantivy4java `value_count` aggregation on a chosen fast field. The field selection used the first numeric fast field found in the split's docMapping — but `value_count` counts only **non-null** occurrences of that field. If the chosen field contained null values, the returned count was smaller than the true number of documents in the split.

**Example:** A companion split with schema `(name: String, score: Option[Double])` where 3 of 5 rows have a null `score`. With a pushed-down filter, `COUNT(*)` was computed as `value_count(score)` = 2 instead of 5.

The root cause was that the field selection iterated a `Set` (non-deterministic order) and had no way to distinguish nullable from non-nullable user fields. Companion splits built with tantivy4java ≥ PR #81 always contain two non-null u64 fast fields — `__pq_file_hash` and `__pq_row_in_file` — that are written for every indexed document regardless of user field nullability. These were never being preferred.

### Missing Spark-level test coverage for companion splits

`LocalParquetSyncIntegrationTest` covered `COUNT(*)` and `GROUP BY string + count()` but was missing Spark-level tests for the operations changed by tantivy4java PR #86 (string hash fast-field optimization):

| Operation | tantivy4java path | Previously tested? |
|---|---|---|
| `COUNT(string_col)` | `value_count` on string hash field | No |
| `GROUP BY string + sum/avg` | `terms` + metric sub-agg | No (only `+ count()`) |
| `IS NOT NULL` on string | `exists` / FieldPresence (hash-redirected) | No |
| `IS NULL` on string | IS NULL query | No |
| `isin(...)` on string | multi-term IN query | No |
| `COUNT(*)` with nullable fast field | `value_count(__pq_file_hash)` | No |

## Solution

### Fix: prefer companion tracking fields for COUNT(\*)

**File:** `src/main/scala/io/indextables/spark/core/IndexTables4SparkSimpleAggregateScan.scala`

Before selecting a fast field for `COUNT(*)`, `getFastFieldsFromDocMapping()` is now called unconditionally and the result is checked for the presence of `__pq_file_hash` or `__pq_row_in_file`. If either is found, it is used immediately, before the existing fallback chain. The priority order becomes:

1. `__pq_file_hash` or `__pq_row_in_file` — companion tracking fields, guaranteed non-null on every document ← **new**
2. Numeric field referenced by another aggregation in the same query (e.g. `SUM(score)` alongside `COUNT(*)`)
3. Numeric fast field from docMapping
4. Any fast field from docMapping
5. Auto-detected field from schema (numeric first, then string)

Non-companion splits (no `__pq_file_hash` in docMapping) are unaffected; their field selection is identical to before.

### Tests: 6 new integration tests in `LocalParquetSyncIntegrationTest`

**File:** `src/test/scala/io/indextables/spark/sync/LocalParquetSyncIntegrationTest.scala`

| Test | What it validates |
|---|---|
| `COUNT(string column) should return value_count of non-null rows` | `count("name")` on companion split returns 20 (all non-null) |
| `GROUP BY string column with sum and avg should resolve hash bucket keys correctly` | `groupBy("name").agg(sum, avg)` resolves hash bucket keys to original strings and computes per-group sums and averages correctly |
| `IS NOT NULL filter on string column should return all non-null rows` | `filter(col("name").isNotNull)` returns all 15 rows |
| `IS NULL filter on string column should return zero rows when no nulls present` | `filter(col("name").isNull)` returns 0 rows |
| `COUNT(*) on companion split should count all rows even when numeric fast field has nulls` | Regression: 5 rows, 3 null scores — filtered `COUNT(*)` returns 5, not 2 |
| `IN filter on string column should return only the matching rows` | `filter(col("name").isin(...))` returns exactly the 3 specified rows |

## Files Changed

| File | Change |
|---|---|
| `src/main/scala/io/indextables/spark/core/IndexTables4SparkSimpleAggregateScan.scala` | Prefer `__pq_file_hash`/`__pq_row_in_file` over user fields for `COUNT(*)` on companion splits |
| `src/test/scala/io/indextables/spark/sync/LocalParquetSyncIntegrationTest.scala` | 6 new tests; added `import org.apache.spark.sql.functions.{avg, col, count, sum}` |

## Test Plan

All 24 tests in `LocalParquetSyncIntegrationTest` pass:

```
Run completed in 56 seconds, 988 milliseconds.
Total number of tests run: 24
Suites: completed 2, aborted 0
Tests: succeeded 24, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

## Related

- tantivy4java PR #81: introduced `__pq_file_hash` and `__pq_row_in_file` as merge-safe companion tracking fields
- tantivy4java PR #86: string hash fast-field optimization for `value_count`, `terms`, and `exists` on string fields in HYBRID mode
