### PR TITLE
fix: Fix MERGE SPLITS Temp Directory Fallback When Configured Path Is Invalid

### DIFF
--- a/src/main/scala/io/indextables/spark/sql/MergeSplitsCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/MergeSplitsCommand.scala
@@ -1794,16 +1794,33 @@ object MergeSplitsExecutor {
     val isCloudPath = isS3Path || isAzurePath
 
     // Determine temp directory for downloads
-    val tempDir = awsConfig.tempDirectoryPath
+    val configuredTempDir = awsConfig.tempDirectoryPath
       .getOrElse(
         if (MergeSplitsCommand.isLocalDisk0Available()) "/local_disk0/tantivy4spark-merge"
         else System.getProperty("java.io.tmpdir")
       )
 
-    val mergeId     = java.util.UUID.randomUUID().toString
-    val downloadDir = new java.io.File(tempDir, s"merge-download-$mergeId")
-    if (!downloadDir.mkdirs() && !downloadDir.exists()) {
-      throw new RuntimeException(s"Failed to create merge temp directory: ${downloadDir.getAbsolutePath}")
+    val mergeId = java.util.UUID.randomUUID().toString
+
+    // Try the configured temp directory; fall back to system temp if it can't be created
+    val (tempDir, downloadDir) = {
+      val primaryDir = new java.io.File(configuredTempDir, s"merge-download-$mergeId")
+      if (primaryDir.mkdirs() || primaryDir.exists()) {
+        (configuredTempDir, primaryDir)
+      } else {
+        val systemTmpDir = System.getProperty("java.io.tmpdir")
+        logger.warn(
+          s"[EXECUTOR] Failed to create merge temp directory at configured path '$configuredTempDir', " +
+            s"falling back to system temp directory: $systemTmpDir"
+        )
+        val fallbackDir = new java.io.File(systemTmpDir, s"merge-download-$mergeId")
+        if (!fallbackDir.mkdirs() && !fallbackDir.exists()) {
+          throw new RuntimeException(
+            s"Failed to create merge temp directory: tried '$configuredTempDir' and system temp '$systemTmpDir'"
+          )
+        }
+        (systemTmpDir, fallbackDir)
+      }
     }
 
     // Extract docMappingJson from first file to preserve fast fields configuration.


### PR DESCRIPTION
# PR: Fix MERGE SPLITS Temp Directory Fallback When Configured Path Is Invalid

## Summary

When `spark.indextables.merge.tempDirectoryPath` is set to a path that cannot be created (e.g., a non-existent directory tree or a path with insufficient permissions), `MERGE SPLITS` now falls back to the JVM system temp directory instead of failing the entire merge operation.

## Problem

`MergeSplitsExecutor.createMergedSplitDistributed` resolves the temp directory from `SerializableAwsConfig.tempDirectoryPath` and immediately attempts `mkdirs()`. If that call returns `false` (directory cannot be created), the code threw:

```
java.lang.RuntimeException: Failed to create merge temp directory: /this/path/does/not/exist/...
```

This caused the entire merge batch to fail with:

```
java.lang.RuntimeException: All 1 merge batches failed in generation 1
```

No fallback was attempted, even though the rest of the merge infrastructure (local merge, file move) would have worked fine with a different temp directory.

## Solution

**File:** `src/main/scala/io/indextables/spark/sql/MergeSplitsCommand.scala`

In `createMergedSplitDistributed`, replaced the single attempt + hard failure with a two-step fallback:

1. Attempt to create the download directory under the configured path.
2. If `mkdirs()` fails and the directory doesn't exist, log a warning and retry under `System.getProperty("java.io.tmpdir")`.
3. Only throw `RuntimeException` if both attempts fail.

The resolved `tempDir` value (either the configured path or the system fallback) is used consistently for both the download staging directory and the `mergeConfigBuilder.tempDirectoryPath()` call passed to tantivy4java.

```scala
// Before
val tempDir = awsConfig.tempDirectoryPath.getOrElse(...)
val downloadDir = new java.io.File(tempDir, s"merge-download-$mergeId")
if (!downloadDir.mkdirs() && !downloadDir.exists()) {
  throw new RuntimeException(s"Failed to create merge temp directory: ...")
}

// After
val configuredTempDir = awsConfig.tempDirectoryPath.getOrElse(...)
val (tempDir, downloadDir) = {
  val primaryDir = new java.io.File(configuredTempDir, s"merge-download-$mergeId")
  if (primaryDir.mkdirs() || primaryDir.exists()) {
    (configuredTempDir, primaryDir)
  } else {
    val systemTmpDir = System.getProperty("java.io.tmpdir")
    logger.warn(s"[EXECUTOR] Failed to create merge temp directory at configured path " +
      s"'$configuredTempDir', falling back to system temp directory: $systemTmpDir")
    val fallbackDir = new java.io.File(systemTmpDir, s"merge-download-$mergeId")
    if (!fallbackDir.mkdirs() && !fallbackDir.exists()) {
      throw new RuntimeException(
        s"Failed to create merge temp directory: tried '$configuredTempDir' and system temp '$systemTmpDir'"
      )
    }
    (systemTmpDir, fallbackDir)
  }
}
```

## Files Changed

| File | Change |
|---|---|
| `src/main/scala/io/indextables/spark/sql/MergeSplitsCommand.scala` | Fallback to system temp directory when configured path cannot be created |

## Test Plan

All 7 tests in `MergeSplitsTempDirectoryTest` pass:

```
Run completed in 16 seconds, 878 milliseconds.
Total number of tests run: 7
Suites: completed 2, aborted 0
Tests: succeeded 7, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

The previously failing test:

> **MERGE SPLITS should fall back to system temp directory when custom path is invalid**

sets `spark.indextables.merge.tempDirectoryPath` to `/this/path/does/not/exist/and/should/not/be/created`, then verifies that `MERGE SPLITS` still completes successfully and preserves all 400 records.
