### PR TITLE
fix: UC Credential Cache Poisoning Causes Upload Failures

### DIFF
--- a/src/main/scala/io/indextables/spark/sql/CheckpointCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/CheckpointCommand.scala
@@ -78,6 +78,8 @@ case class CheckpointCommand(tablePath: String) extends LeafRunnableCommand {
       sparkSession.conf.getAll.filter(_._1.startsWith("spark.indextables.")).foreach {
         case (k, v) => optionsMap.put(k, v)
       }
+      // Checkpoint writes files, so ensure PATH_READ_WRITE credentials
+      optionsMap.put("spark.indextables.databricks.credential.operation", "PATH_READ_WRITE")
       val options = new org.apache.spark.sql.util.CaseInsensitiveStringMap(optionsMap)
 
       // Create transaction log instance to read current state

--- a/src/main/scala/io/indextables/spark/sql/MergeSplitsCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/MergeSplitsCommand.scala
@@ -492,7 +492,7 @@ class MergeSplitsExecutor(
     logger.info(s"Merge config: ${mergedConfigs.size} entries, tempDir=${tempDirectoryPath.getOrElse("default")}")
 
     SerializableAwsConfig(
-      configs = mergedConfigs,
+      configs = mergedConfigs + ("spark.indextables.databricks.credential.operation" -> "PATH_READ_WRITE"),
       tablePath = tablePath.toString,
       tempDirectoryPath = tempDirectoryPath,
       heapSize = heapSize,

--- a/src/main/scala/io/indextables/spark/sql/PurgeOrphanedSplitsExecutor.scala
+++ b/src/main/scala/io/indextables/spark/sql/PurgeOrphanedSplitsExecutor.scala
@@ -1477,7 +1477,7 @@ class PurgeOrphanedSplitsExecutor(
     // Merge with override options (override takes precedence)
     // CloudStorageProvider will handle credential resolution with proper refresh logic
     // via V1ToV2CredentialsProviderAdapter
-    overrideOptions match {
+    val base = overrideOptions match {
       case Some(overrides) =>
         val merged = sparkConfigs ++ overrides.filter { case (key, _) => key.startsWith("spark.indextables.") }
         logger.info(s"Extracted ${merged.size} spark.indextables.* configuration keys (${sparkConfigs.size} from Spark session, ${overrides.size} from override options)")
@@ -1486,6 +1486,8 @@ class PurgeOrphanedSplitsExecutor(
         logger.info(s"Extracted ${sparkConfigs.size} spark.indextables.* configuration keys from Spark session")
         sparkConfigs
     }
+    // Purge operations delete split files, so ensure PATH_READ_WRITE credentials
+    base + ("spark.indextables.databricks.credential.operation" -> "PATH_READ_WRITE")
   }
 
   /**

--- a/src/main/scala/io/indextables/spark/sql/RepairIndexFilesTransactionLogCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/RepairIndexFilesTransactionLogCommand.scala
@@ -105,7 +105,10 @@ case class RepairIndexFilesTransactionLogCommand(
       // Create transaction log instance for source
       logger.info(s"Reading source transaction log from: $sourcePath")
       val sourceOptions = new org.apache.spark.sql.util.CaseInsensitiveStringMap(
-        Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava
+        Map(
+          "spark.indextables.transaction.allowDirectUsage" -> "true",
+          "spark.indextables.databricks.credential.operation" -> "PATH_READ_WRITE"
+        ).asJava
       )
 
       // Extract table path from transaction log path (remove /_transaction_log suffix)

--- a/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
@@ -147,7 +147,8 @@ case class SyncToExternalCommand(
     val hadoopConf        = sparkSession.sparkContext.hadoopConfiguration
     val sparkConfigs      = ConfigNormalization.extractTantivyConfigsFromSpark(sparkSession)
     val hadoopConfigs     = ConfigNormalization.extractTantivyConfigsFromHadoop(hadoopConf)
-    val baseMergedConfigs = ConfigNormalization.mergeWithPrecedence(hadoopConfigs, sparkConfigs)
+    val baseMergedConfigs = ConfigNormalization.mergeWithPrecedence(hadoopConfigs, sparkConfigs) +
+      ("spark.indextables.databricks.credential.operation" -> "PATH_READ_WRITE")
 
     // For Iceberg and Delta + table credential providers: auto-derive catalog config
     // defaults, resolve the table UUID (and storage location for Delta) on the driver,

--- a/src/main/scala/io/indextables/spark/sql/TruncateTimeTravelCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/TruncateTimeTravelCommand.scala
@@ -84,10 +84,11 @@ case class TruncateTimeTravelCommand(
       val hadoopConf    = sparkSession.sparkContext.hadoopConfiguration
       val sparkConfigs  = ConfigNormalization.extractTantivyConfigsFromSpark(sparkSession)
       val hadoopConfigs = ConfigNormalization.extractTantivyConfigsFromHadoop(hadoopConf)
-      val mergedConfigs = ConfigNormalization.mergeWithPrecedence(hadoopConfigs, sparkConfigs)
+      val mergedConfigs = ConfigNormalization.mergeWithPrecedence(hadoopConfigs, sparkConfigs) +
+        ("spark.indextables.databricks.credential.operation" -> "PATH_READ_WRITE")
 
-      // Create transaction log - CloudStorageProvider will handle credential resolution
-      // with proper refresh logic via V1ToV2CredentialsProviderAdapter
+      // Create transaction log with PATH_READ_WRITE credentials since truncate
+      // deletes old version files and creates checkpoints
       val options        = new org.apache.spark.sql.util.CaseInsensitiveStringMap(mergedConfigs.asJava)
       val transactionLog = TransactionLogFactory.create(resolvedPath, sparkSession, options)
 

--- a/src/main/scala/io/indextables/spark/sync/SyncTaskExecutor.scala
+++ b/src/main/scala/io/indextables/spark/sync/SyncTaskExecutor.scala
@@ -378,7 +378,8 @@ object SyncTaskExecutor {
     // Remove source table ID from config so uploads resolve credentials for the
     // DESTINATION path, not the source Iceberg table. The table ID is only valid
     // for the source table's storage location.
-    val uploadConfig = storageConfig - "spark.indextables.iceberg.uc.tableId"
+    val uploadConfig = storageConfig - "spark.indextables.iceberg.uc.tableId" +
+      ("spark.indextables.databricks.credential.operation" -> "PATH_READ_WRITE")
     io.indextables.spark.io.merge.MergeUploader.uploadWithRetry(localPath, destPath, uploadConfig, tablePath)
   }
 


### PR DESCRIPTION
# Fix: UC Credential Cache Poisoning Causes Upload Failures

## Summary

When Unity Catalog is the credential provider, merge uploads (and other write operations) can silently fail because they receive `PATH_READ` credentials instead of `PATH_READ_WRITE`. This happens because the UC credential cache key (`tokenHash:path`) does not include the credential operation type, so a preceding read query poisons the cache with read-only credentials for the same table path.

## Root Cause

The `buildCacheKey` method in `UnityCatalogAWSCredentialProvider` produced keys of the form `tokenHash:path`. When a read query ran first (with `credential.operation=PATH_READ`), the resulting read-only credentials were cached under `tokenHash:s3://bucket/table`. A subsequent write operation (merge, purge, drop partitions, etc.) for the same table hit the cache and silently received `PATH_READ` credentials, causing S3 `PutObject` / `DeleteObject` to fail with 403.

## Fix

**Cache key now includes credential operation** — format changed from `tokenHash:path` to `tokenHash:credentialOperation:path`, ensuring `PATH_READ` and `PATH_READ_WRITE` get independent cache entries.

**All write-path SQL commands explicitly set `PATH_READ_WRITE`** — rather than relying on the default, every command that performs writes now explicitly includes `spark.indextables.databricks.credential.operation=PATH_READ_WRITE` in its config. This makes the intent clear and guards against future default changes.

## Changes

| File | Change |
|------|--------|
| `UnityCatalogAWSCredentialProvider.scala` | `buildCacheKey` includes `credentialOperation` in key; updated both call sites (`getCredentials`, `refresh`) |
| `MergeSplitsCommand.scala` | `extractAwsConfig()` adds `credential.operation=PATH_READ_WRITE` to `SerializableAwsConfig` configs |
| `SyncTaskExecutor.scala` | `uploadSplit()` adds `PATH_READ_WRITE` to `uploadConfig` |
| `DropPartitionsCommand.scala` | `writeConfigs` with `PATH_READ_WRITE` used for `TransactionLogFactory.create()` |
| `PurgeOrphanedSplitsExecutor.scala` | `extractCloudStorageConfigs()` appends `PATH_READ_WRITE` |
| `SyncToExternalCommand.scala` | `baseMergedConfigs` includes `PATH_READ_WRITE` |
| `TruncateTimeTravelCommand.scala` | `mergedConfigs` includes `PATH_READ_WRITE` |
| `CheckpointCommand.scala` | `optionsMap` includes `PATH_READ_WRITE` |
| `RepairIndexFilesTransactionLogCommand.scala` | `sourceOptions` includes `PATH_READ_WRITE` |
| `UnityCatalogAWSCredentialProviderTest.scala` | Two new regression tests for cache poisoning in both directions |

## Test Plan

- [x] `UnityCatalogAWSCredentialProviderTest` — 26/26 pass, including two new regression tests:
  - `PATH_READ cached credentials do not satisfy PATH_READ_WRITE request`
  - `PATH_READ_WRITE cached credentials do not satisfy PATH_READ request`
- [ ] `PostCommitMergeCredentialBugTest` — verify merge uploads succeed with UC credentials
- [ ] Full local test suite (`make test`) — verify no regressions
- [ ] Manual validation on Databricks with UC-enabled table: run a read query followed by a merge, confirm merge upload succeeds
