### PR TITLE
feature: Expose parquet coalesce max gap configuration

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -194,6 +194,7 @@ spark.indextables.cache.disk.maxSize: "100G" (default: 0 = auto, 2/3 available d
 spark.indextables.cache.disk.compression: "lz4" (options: lz4, zstd, none)
 spark.indextables.cache.disk.minCompressSize: "4K" (default: 4096 bytes)
 spark.indextables.cache.disk.manifestSyncInterval: 30 (default: 30 seconds)
+spark.indextables.cache.coalesceMaxGap: "512K" (default: 512KB, max gap between parquet byte ranges to coalesce)
 ```
 
 ## Read Limits

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <dependency>
             <groupId>io.indextables</groupId>
             <artifactId>tantivy4java</artifactId>
-            <version>0.30.6</version>
+            <version>0.30.7</version>
             <classifier>${platform.classifier}</classifier>
         </dependency>
 

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkOptions.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkOptions.scala
@@ -349,6 +349,10 @@ class IndexTables4SparkOptions(options: CaseInsensitiveStringMap) {
   def diskCacheManifestSyncInterval: Option[Int] =
     Option(options.get("spark.indextables.cache.disk.manifestSyncInterval")).map(_.toInt)
 
+  /** Max gap between byte ranges to coalesce into a single request. Supports "64K", "512K", "1M" formats. Default: 512KB. */
+  def coalesceMaxGap: Option[String] =
+    Option(options.get("spark.indextables.cache.coalesceMaxGap"))
+
   /** Get indexing configuration for a specific field. */
   def getFieldIndexingConfig(fieldName: String): FieldIndexingConfig = {
     val fieldTypeMapping         = getFieldTypeMapping

--- a/src/main/scala/io/indextables/spark/storage/SplitManager.scala
+++ b/src/main/scala/io/indextables/spark/storage/SplitManager.scala
@@ -449,6 +449,8 @@ case class SplitCacheConfig(
   diskCacheCompression: Option[String] = None,       // "lz4" (default), "zstd", "none"
   diskCacheMinCompressSize: Option[Long] = None,     // Skip compression below threshold (default: 4096)
   diskCacheManifestSyncInterval: Option[Int] = None, // Seconds between manifest writes (default: 30)
+  // Parquet coalesce configuration
+  coalesceMaxGap: Option[Long] = None,               // Max gap between byte ranges to coalesce (default: 512KB)
   // Companion mode (parquet companion splits)
   companionSourceTableRoot: Option[String] = None, // Root path of parquet table for companion splits
   // Parquet-specific credentials (resolved for the Delta table path, may differ from split credentials)
@@ -606,6 +608,12 @@ case class SplitCacheConfig(
     createTieredCacheConfig().foreach { tieredConfig =>
       logger.info(s"L2 Disk cache configured")
       config = config.withTieredCache(tieredConfig)
+    }
+
+    // Configure parquet coalesce max gap
+    coalesceMaxGap.foreach { gap =>
+      logger.debug(s"Parquet coalesce max gap: $gap bytes")
+      config = config.withCoalesceMaxGap(gap)
     }
 
     // Note: Companion mode parquet config (parquetTableRoot and parquetStorageConfig)

--- a/src/main/scala/io/indextables/spark/util/ConfigUtils.scala
+++ b/src/main/scala/io/indextables/spark/util/ConfigUtils.scala
@@ -183,6 +183,9 @@ object ConfigUtils {
       diskCacheMinCompressSize = getConfigOption("spark.indextables.cache.disk.minCompressSize")
         .map(SplitCacheConfig.parseSizeString),
       diskCacheManifestSyncInterval = getConfigOption("spark.indextables.cache.disk.manifestSyncInterval").map(_.toInt),
+      // Parquet coalesce configuration
+      coalesceMaxGap = getConfigOption("spark.indextables.cache.coalesceMaxGap")
+        .map(SplitCacheConfig.parseSizeString),
       // Companion mode (parquet companion splits)
       companionSourceTableRoot = companionTableRoot,
       // Parquet-specific credentials (resolved on driver for the Delta table path)


### PR DESCRIPTION
# Expose parquet coalesce max gap configuration

## Summary

- Expose tantivy4java's `withCoalesceMaxGap()` as a new Spark config option `spark.indextables.cache.coalesceMaxGap`
- Controls how aggressively nearby parquet byte ranges are merged into fewer storage requests
- Reduces over-fetch for narrow projections on wide parquet tables (companion mode)

## Problem

When reading companion parquet tables, tantivy4java coalesces nearby byte ranges into single fetch requests to reduce round-trip latency. The default 512KB gap works well when most columns are projected, but causes ~83% over-fetch for narrow projections on wide tables (e.g., selecting 2 columns from a 50-column table). There was no way to tune this from Spark without modifying tantivy4java code.

## Solution

Added `spark.indextables.cache.coalesceMaxGap` config option that flows through the existing cache configuration pipeline:

```scala
// Example: reduce gap to 64KB for narrow projections on wide tables
spark.conf.set("spark.indextables.cache.coalesceMaxGap", "64K")
```

Accepts human-readable size strings ("64K", "512K", "1M") via the existing `SplitCacheConfig.parseSizeString` parser. When unset, tantivy4java uses its built-in default (512KB).

## Changes

| File | Change |
|------|--------|
| `SplitManager.scala` | Add `coalesceMaxGap: Option[Long]` field to `SplitCacheConfig`, wire into `toJavaCacheConfig()` via `config.withCoalesceMaxGap(gap)` |
| `IndexTables4SparkOptions.scala` | Add `coalesceMaxGap` accessor for `spark.indextables.cache.coalesceMaxGap` |
| `ConfigUtils.scala` | Parse option in `createSplitCacheConfig()` using `SplitCacheConfig.parseSizeString` |
| `docs/reference/configuration.md` | Document the new option in the cache configuration section |

## Test plan

- [x] `mvn clean compile` — compiles cleanly
- [x] `DiskCacheConfigTest` — all 34 tests pass (existing cache config tests unaffected)
- [ ] Manual: compare fetch waste % with default 512KB vs 64KB on a wide companion parquet table using `TANTIVY4JAVA_PERFLOG=1`
