### PR TITLE
fix: merge error on SyncToExternalCommand

### DIFF
--- a/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
@@ -453,7 +453,7 @@ case class SyncToExternalCommand(
 
       // 7b. Apply WHERE partition filter
       val parquetFilesToIndex =
-        applyWhereFilter(rawParquetFiles, partitionColumns, sparkSession, effectiveWherePredicates, sourceSchema)
+        applyWhereFilter(rawParquetFiles, partitionColumns, sparkSession, effectiveWherePredicates, Some(sourceSchema))
 
       // Source version for commits (Delta version, Iceberg snapshot ID, or -1 for Parquet)
       val sourceVersion = sourceVersionOpt.getOrElse(-1L)


### PR DESCRIPTION
## Fix compilation error in SyncToExternalCommand

### Summary
- Fix type mismatch error in `SyncToExternalCommand.scala:456` that prevents `main` from compiling
- Wrap `sourceSchema` in `Some()` to match the `Option[StructType]` parameter expected by `applyWhereFilter`

### Root Cause
A merge resolution error introduced during the merge of `fix/prewarm_companion_root` into `main`. The `fix/prewarm_companion_root` branch introduced `val sourceSchema = Some(reader.schema())` in the dry-run code path (line ~289), but the existing code in the non-dry-run path at line 348 re-declares `val sourceSchema = reader.schema()` as a bare `StructType`. This shadowed variable is then passed to `applyWhereFilter` which expects `Option[StructType]`, causing the compilation failure.

### Changes
- `SyncToExternalCommand.scala`: Changed `applyWhereFilter(..., sourceSchema)` to `applyWhereFilter(..., Some(sourceSchema))` at line 456

### Test plan
- [x] `mvn clean compile` succeeds on `main` after the fix
