### PR TITLE
Expose disk cache write queue configuration via Spark config

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -194,6 +194,9 @@ spark.indextables.cache.disk.maxSize: "100G" (default: 0 = auto, 2/3 available d
 spark.indextables.cache.disk.compression: "lz4" (options: lz4, zstd, none)
 spark.indextables.cache.disk.minCompressSize: "4K" (default: 4096 bytes)
 spark.indextables.cache.disk.manifestSyncInterval: 30 (default: 30 seconds)
+spark.indextables.cache.disk.writeQueue.mode: "size" (options: fragment, size)
+spark.indextables.cache.disk.writeQueue.capacity: "1G" (size mode: byte limit e.g. "500M", "2G"; fragment mode: slot count e.g. "32")
+spark.indextables.cache.disk.dropWritesWhenFull: true (drop query-path writes instead of blocking)
 spark.indextables.cache.coalesceMaxGap: "512K" (default: 512KB, max gap between parquet byte ranges to coalesce)
 ```
 

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkOptions.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkOptions.scala
@@ -349,6 +349,18 @@ class IndexTables4SparkOptions(options: CaseInsensitiveStringMap) {
   def diskCacheManifestSyncInterval: Option[Int] =
     Option(options.get("spark.indextables.cache.disk.manifestSyncInterval")).map(_.toInt)
 
+  /** Write queue mode: "fragment" or "size". Default: "size". */
+  def diskCacheWriteQueueMode: Option[String] =
+    Option(options.get("spark.indextables.cache.disk.writeQueue.mode"))
+
+  /** Write queue capacity. Fragment: slot count (int). Size: byte limit ("1G"). */
+  def diskCacheWriteQueueCapacity: Option[String] =
+    Option(options.get("spark.indextables.cache.disk.writeQueue.capacity"))
+
+  /** Drop query-path writes when queue is full instead of blocking. Default: true. */
+  def diskCacheDropWritesWhenFull: Option[Boolean] =
+    Option(options.get("spark.indextables.cache.disk.dropWritesWhenFull")).map(_.toBoolean)
+
   /**
    * Max gap between byte ranges to coalesce into a single request. Supports "64K", "512K", "1M" formats. Default:
    * 512KB.
@@ -522,4 +534,7 @@ object IndexTables4SparkOptions {
   val DISK_CACHE_COMPRESSION            = "spark.indextables.cache.disk.compression"
   val DISK_CACHE_MIN_COMPRESS_SIZE      = "spark.indextables.cache.disk.minCompressSize"
   val DISK_CACHE_MANIFEST_SYNC_INTERVAL = "spark.indextables.cache.disk.manifestSyncInterval"
+  val DISK_CACHE_WRITE_QUEUE_MODE      = "spark.indextables.cache.disk.writeQueue.mode"
+  val DISK_CACHE_WRITE_QUEUE_CAPACITY  = "spark.indextables.cache.disk.writeQueue.capacity"
+  val DISK_CACHE_DROP_WRITES_WHEN_FULL = "spark.indextables.cache.disk.dropWritesWhenFull"
 }

--- a/src/main/scala/io/indextables/spark/storage/SplitManager.scala
+++ b/src/main/scala/io/indextables/spark/storage/SplitManager.scala
@@ -449,6 +449,9 @@ case class SplitCacheConfig(
   diskCacheCompression: Option[String] = None,       // "lz4" (default), "zstd", "none"
   diskCacheMinCompressSize: Option[Long] = None,     // Skip compression below threshold (default: 4096)
   diskCacheManifestSyncInterval: Option[Int] = None, // Seconds between manifest writes (default: 30)
+  diskCacheWriteQueueMode: Option[String] = None,          // "fragment" or "size" (default: size)
+  diskCacheWriteQueueCapacity: Option[String] = None,       // Fragment: slot count; Size: byte limit ("1G")
+  diskCacheDropWritesWhenFull: Option[Boolean] = None,       // Drop query-path writes when full (default: true)
   // Parquet coalesce configuration
   coalesceMaxGap: Option[Long] = None, // Max gap between byte ranges to coalesce (default: 512KB)
   // Companion mode (parquet companion splits)
@@ -791,6 +794,29 @@ case class SplitCacheConfig(
           logger.debug(s"L2 Disk cache manifest sync interval: $interval seconds")
           tieredConfig = tieredConfig.withManifestSyncInterval(interval)
         }
+
+        // Apply write queue mode (default: size-based, 1GB, drop when full)
+        val effectiveMode = diskCacheWriteQueueMode.map(_.toLowerCase).getOrElse("size")
+        effectiveMode match {
+          case "fragment" =>
+            val capacity = diskCacheWriteQueueCapacity.map(_.toInt).getOrElse(16)
+            logger.debug(s"L2 Disk cache write queue: fragment mode, capacity=$capacity slots")
+            tieredConfig = tieredConfig.withWriteQueueFragmentCapacity(capacity)
+          case "size" | "size_based" | "sizebased" =>
+            val maxBytes = diskCacheWriteQueueCapacity
+              .map(SplitCacheConfig.parseSizeString)
+              .getOrElse(1L * 1024L * 1024L * 1024L) // 1GB default
+            logger.debug(s"L2 Disk cache write queue: size-based mode, limit=$maxBytes bytes")
+            tieredConfig = tieredConfig.withWriteQueueSizeLimit(maxBytes)
+          case other =>
+            logger.warn(s"Unknown write queue mode: '$other'. Valid: fragment, size. Using size default.")
+            tieredConfig = tieredConfig.withWriteQueueSizeLimit(1L * 1024L * 1024L * 1024L)
+        }
+
+        // Apply drop-writes-when-full (default: true)
+        val dropWrites = diskCacheDropWritesWhenFull.getOrElse(true)
+        logger.debug(s"L2 Disk cache drop writes when full: $dropWrites")
+        tieredConfig = tieredConfig.withDropWritesWhenFull(dropWrites)
 
         logger.info(s"L2 Disk cache enabled at: $path")
         Some(tieredConfig)

--- a/src/main/scala/io/indextables/spark/util/ConfigUtils.scala
+++ b/src/main/scala/io/indextables/spark/util/ConfigUtils.scala
@@ -183,6 +183,9 @@ object ConfigUtils {
       diskCacheMinCompressSize = getConfigOption("spark.indextables.cache.disk.minCompressSize")
         .map(SplitCacheConfig.parseSizeString),
       diskCacheManifestSyncInterval = getConfigOption("spark.indextables.cache.disk.manifestSyncInterval").map(_.toInt),
+      diskCacheWriteQueueMode = getConfigOption("spark.indextables.cache.disk.writeQueue.mode"),
+      diskCacheWriteQueueCapacity = getConfigOption("spark.indextables.cache.disk.writeQueue.capacity"),
+      diskCacheDropWritesWhenFull = getConfigOption("spark.indextables.cache.disk.dropWritesWhenFull").map(_.toBoolean),
       // Parquet coalesce configuration
       coalesceMaxGap = getConfigOption("spark.indextables.cache.coalesceMaxGap")
         .map(SplitCacheConfig.parseSizeString),

--- a/src/test/scala/io/indextables/spark/core/DiskCacheConfigTest.scala
+++ b/src/test/scala/io/indextables/spark/core/DiskCacheConfigTest.scala
@@ -506,6 +506,175 @@ class DiskCacheConfigTest extends AnyFunSuite with Matchers {
     }
   }
 
+  // ===== Write Queue Configuration Tests =====
+
+  test("SplitCacheConfig - write queue fragment mode with custom capacity") {
+    val config = SplitCacheConfig(
+      diskCacheEnabled = Some(true),
+      diskCachePath = Some("/tmp/test_cache"),
+      diskCacheWriteQueueMode = Some("fragment"),
+      diskCacheWriteQueueCapacity = Some("32")
+    )
+
+    config.diskCacheWriteQueueMode shouldBe Some("fragment")
+    config.diskCacheWriteQueueCapacity shouldBe Some("32")
+
+    val javaConfig = config.toJavaCacheConfig()
+    javaConfig should not be null
+  }
+
+  test("SplitCacheConfig - write queue size-based mode with byte limit") {
+    val config = SplitCacheConfig(
+      diskCacheEnabled = Some(true),
+      diskCachePath = Some("/tmp/test_cache"),
+      diskCacheWriteQueueMode = Some("size"),
+      diskCacheWriteQueueCapacity = Some("2G")
+    )
+
+    config.diskCacheWriteQueueMode shouldBe Some("size")
+    config.diskCacheWriteQueueCapacity shouldBe Some("2G")
+
+    val javaConfig = config.toJavaCacheConfig()
+    javaConfig should not be null
+  }
+
+  test("SplitCacheConfig - size-based mode with default capacity (no explicit capacity)") {
+    val config = SplitCacheConfig(
+      diskCacheEnabled = Some(true),
+      diskCachePath = Some("/tmp/test_cache"),
+      diskCacheWriteQueueMode = Some("size")
+      // No capacity → defaults to 1GB
+    )
+
+    config.diskCacheWriteQueueMode shouldBe Some("size")
+    config.diskCacheWriteQueueCapacity shouldBe None
+
+    val javaConfig = config.toJavaCacheConfig()
+    javaConfig should not be null
+  }
+
+  test("SplitCacheConfig - drop writes when full enabled") {
+    val config = SplitCacheConfig(
+      diskCacheEnabled = Some(true),
+      diskCachePath = Some("/tmp/test_cache"),
+      diskCacheDropWritesWhenFull = Some(true)
+    )
+
+    config.diskCacheDropWritesWhenFull shouldBe Some(true)
+
+    val javaConfig = config.toJavaCacheConfig()
+    javaConfig should not be null
+  }
+
+  test("SplitCacheConfig - drop writes when full disabled") {
+    val config = SplitCacheConfig(
+      diskCacheEnabled = Some(true),
+      diskCachePath = Some("/tmp/test_cache"),
+      diskCacheDropWritesWhenFull = Some(false)
+    )
+
+    config.diskCacheDropWritesWhenFull shouldBe Some(false)
+
+    val javaConfig = config.toJavaCacheConfig()
+    javaConfig should not be null
+  }
+
+  test("SplitCacheConfig - unknown write queue mode falls back to size default") {
+    val config = SplitCacheConfig(
+      diskCacheEnabled = Some(true),
+      diskCachePath = Some("/tmp/test_cache"),
+      diskCacheWriteQueueMode = Some("unknown-mode")
+    )
+
+    // Should not throw, should fall back to size-based default
+    val javaConfig = config.toJavaCacheConfig()
+    javaConfig should not be null
+  }
+
+  test("ConfigUtils.createSplitCacheConfig - write queue config round-trip") {
+    val configMap = Map(
+      "spark.indextables.cache.disk.enabled"              -> "true",
+      "spark.indextables.cache.disk.path"                 -> "/tmp/wq_test",
+      "spark.indextables.cache.disk.writeQueue.mode"      -> "fragment",
+      "spark.indextables.cache.disk.writeQueue.capacity"  -> "64",
+      "spark.indextables.cache.disk.dropWritesWhenFull"   -> "false"
+    )
+
+    val config = ConfigUtils.createSplitCacheConfig(configMap, Some("test-table"))
+
+    config.diskCacheWriteQueueMode shouldBe Some("fragment")
+    config.diskCacheWriteQueueCapacity shouldBe Some("64")
+    config.diskCacheDropWritesWhenFull shouldBe Some(false)
+
+    val javaConfig = config.toJavaCacheConfig()
+    javaConfig should not be null
+  }
+
+  test("ConfigUtils.createSplitCacheConfig - size-based write queue round-trip") {
+    val configMap = Map(
+      "spark.indextables.cache.disk.enabled"              -> "true",
+      "spark.indextables.cache.disk.path"                 -> "/tmp/wq_test",
+      "spark.indextables.cache.disk.writeQueue.mode"      -> "size",
+      "spark.indextables.cache.disk.writeQueue.capacity"  -> "500M",
+      "spark.indextables.cache.disk.dropWritesWhenFull"   -> "true"
+    )
+
+    val config = ConfigUtils.createSplitCacheConfig(configMap, Some("test-table"))
+
+    config.diskCacheWriteQueueMode shouldBe Some("size")
+    config.diskCacheWriteQueueCapacity shouldBe Some("500M")
+    config.diskCacheDropWritesWhenFull shouldBe Some(true)
+
+    val javaConfig = config.toJavaCacheConfig()
+    javaConfig should not be null
+  }
+
+  test("full config flow - disk cache with write queue and all settings") {
+    val options = Map(
+      "spark.indextables.cache.disk.enabled"              -> "true",
+      "spark.indextables.cache.disk.path"                 -> "/local_disk0/tantivy_cache",
+      "spark.indextables.cache.disk.maxSize"              -> "200G",
+      "spark.indextables.cache.disk.compression"          -> "lz4",
+      "spark.indextables.cache.disk.manifestSyncInterval" -> "30",
+      "spark.indextables.cache.disk.writeQueue.mode"      -> "size",
+      "spark.indextables.cache.disk.writeQueue.capacity"  -> "2G",
+      "spark.indextables.cache.disk.dropWritesWhenFull"   -> "true"
+    )
+
+    val sparkOpts = IndexTables4SparkOptions(options)
+
+    sparkOpts.diskCacheEnabled shouldBe Some(true)
+    sparkOpts.diskCacheWriteQueueMode shouldBe Some("size")
+    sparkOpts.diskCacheWriteQueueCapacity shouldBe Some("2G")
+    sparkOpts.diskCacheDropWritesWhenFull shouldBe Some(true)
+
+    val config = ConfigUtils.createSplitCacheConfig(options, Some("test-table"))
+
+    config.diskCacheWriteQueueMode shouldBe Some("size")
+    config.diskCacheWriteQueueCapacity shouldBe Some("2G")
+    config.diskCacheDropWritesWhenFull shouldBe Some(true)
+
+    val javaConfig = config.toJavaCacheConfig()
+    javaConfig should not be null
+  }
+
+  test("IndexTables4SparkOptions - write queue config parsing") {
+    val opts = IndexTables4SparkOptions(Map(
+      "spark.indextables.cache.disk.writeQueue.mode"     -> "fragment",
+      "spark.indextables.cache.disk.writeQueue.capacity" -> "16",
+      "spark.indextables.cache.disk.dropWritesWhenFull"  -> "false"
+    ))
+
+    opts.diskCacheWriteQueueMode shouldBe Some("fragment")
+    opts.diskCacheWriteQueueCapacity shouldBe Some("16")
+    opts.diskCacheDropWritesWhenFull shouldBe Some(false)
+
+    val missingOpts = IndexTables4SparkOptions(Map.empty[String, String])
+    missingOpts.diskCacheWriteQueueMode shouldBe None
+    missingOpts.diskCacheWriteQueueCapacity shouldBe None
+    missingOpts.diskCacheDropWritesWhenFull shouldBe None
+  }
+
   // ===== Integration with Batch Optimization =====
 
   test("disk cache and batch optimization can be configured together") {


### PR DESCRIPTION
## Summary

- Add three new Spark config keys to control the L2 disk cache write queue (backed by tantivy4java 0.31.0 `TieredCacheConfig`):
  - `spark.indextables.cache.disk.writeQueue.mode` — select `"fragment"` (bounded slots) or `"size"` (byte-based backpressure)
  - `spark.indextables.cache.disk.writeQueue.capacity` — slot count (fragment mode) or byte limit like `"1G"` (size mode)
  - `spark.indextables.cache.disk.dropWritesWhenFull` — drop query-path writes instead of blocking (default: `true`)
- Defaults: size-based mode, 1GB limit, drop writes enabled

## Test plan

- [x] `DiskCacheConfigTest` — 11 new tests covering fragment mode, size-based mode, default capacity, drop-writes enabled/disabled, unknown mode fallback, ConfigUtils round-trips, full config flow, and Options parsing (44/44 passing)