### PR TITLE
Apply spotless formatting and bump README to 0.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ IndexTables runs entirely within your existing Spark cluster with no additional 
 
 ### Installation
 
-1. Add the [IndexTables JAR](https://repo1.maven.org/maven2/io/indextables/indextables_spark/0.5.1_spark_3.5.3/indextables_spark-0.5.1_spark_3.5.3-linux-x86_64-shaded.jar) to your Spark classpath
+1. Add the [IndexTables JAR](https://repo1.maven.org/maven2/io/indextables/indextables_spark/0.5.3_spark_3.5.3/indextables_spark-0.5.3_spark_3.5.3-linux-x86_64-shaded.jar) to your Spark classpath
 2. Set `spark.sql.extensions=io.indextables.extensions.IndexTablesSparkExtensions`
 3. Requires Java 11+
 

--- a/src/main/scala/io/indextables/spark/arrow/ArrowFfiBridge.scala
+++ b/src/main/scala/io/indextables/spark/arrow/ArrowFfiBridge.scala
@@ -17,10 +17,11 @@
 
 package io.indextables.spark.arrow
 
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnVector, ColumnarBatch}
+
 import org.apache.arrow.c.{ArrowArray, ArrowSchema, CDataDictionaryProvider, Data}
 import org.apache.arrow.memory.RootAllocator
 import org.apache.arrow.vector.FieldVector
-import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
 import org.slf4j.LoggerFactory
 
 /**
@@ -31,8 +32,8 @@ import org.slf4j.LoggerFactory
  */
 class ArrowFfiBridge extends AutoCloseable {
 
-  private val logger             = LoggerFactory.getLogger(classOf[ArrowFfiBridge])
-  private val allocator          = ArrowFfiBridge.allocator
+  private val logger    = LoggerFactory.getLogger(classOf[ArrowFfiBridge])
+  private val allocator = ArrowFfiBridge.allocator
   // NOTE: dictionaryProvider accumulates state across importAsColumnarBatch calls.
   // Safe for single-batch-per-reader model but would need per-batch cleanup for multi-batch streaming.
   private val dictionaryProvider = new CDataDictionaryProvider()
@@ -57,8 +58,8 @@ class ArrowFfiBridge extends AutoCloseable {
   /**
    * Import filled Arrow C structs into a Spark ColumnarBatch.
    *
-   * After this call, the ArrowArray/ArrowSchema structs have been consumed (ownership transferred to the
-   * FieldVectors). The returned ColumnarBatch owns the native memory — call batch.close() when done.
+   * After this call, the ArrowArray/ArrowSchema structs have been consumed (ownership transferred to the FieldVectors).
+   * The returned ColumnarBatch owns the native memory — call batch.close() when done.
    *
    * @param arrays
    *   ArrowArray structs filled by native FFI call
@@ -86,10 +87,23 @@ class ArrowFfiBridge extends AutoCloseable {
     } catch {
       case ex: Exception =>
         // Close already-imported vectors to prevent native memory leak
-        importedVectors.foreach(v => try v.close() catch { case _: Exception => })
+        importedVectors.foreach(v =>
+          try v.close()
+          catch { case _: Exception => }
+        )
         // Close unconsumed FFI structs
-        arrays.drop(importedVectors.size).foreach(a => try a.close() catch { case _: Exception => })
-        schemas.drop(importedVectors.size).foreach(s => try s.close() catch { case _: Exception => })
+        arrays
+          .drop(importedVectors.size)
+          .foreach(a =>
+            try a.close()
+            catch { case _: Exception => }
+          )
+        schemas
+          .drop(importedVectors.size)
+          .foreach(s =>
+            try s.close()
+            catch { case _: Exception => }
+          )
         throw ex
     }
   }

--- a/src/main/scala/io/indextables/spark/core/CompanionColumnarMultiSplitPartitionReader.scala
+++ b/src/main/scala/io/indextables/spark/core/CompanionColumnarMultiSplitPartitionReader.scala
@@ -42,8 +42,8 @@ class CompanionColumnarMultiSplitPartitionReader(
   config: Map[String, String],
   tablePath: Path,
   indexQueryFilters: Array[Any] = Array.empty,
-  metricsAccumulator: Option[io.indextables.spark.storage.BatchOptimizationMetricsAccumulator] = None
-) extends PartitionReader[ColumnarBatch] {
+  metricsAccumulator: Option[io.indextables.spark.storage.BatchOptimizationMetricsAccumulator] = None)
+    extends PartitionReader[ColumnarBatch] {
 
   private val logger = LoggerFactory.getLogger(classOf[CompanionColumnarMultiSplitPartitionReader])
 
@@ -55,10 +55,10 @@ class CompanionColumnarMultiSplitPartitionReader(
   private val effectiveLimit: Int = limit.getOrElse(configuredDefaultLimit)
 
   // Multi-split iteration state
-  private var currentSplitIndex                                                = 0
-  private var currentReader: Option[CompanionColumnarPartitionReader]           = None
-  private var totalRowsReturned                                                = 0L
-  private var initialized                                                      = false
+  private var currentSplitIndex                                       = 0
+  private var currentReader: Option[CompanionColumnarPartitionReader] = None
+  private var totalRowsReturned                                       = 0L
+  private var initialized                                             = false
 
   // Capture baseline metrics
   private val baselineMetrics: io.indextables.spark.storage.BatchOptMetrics =

--- a/src/main/scala/io/indextables/spark/core/CompanionColumnarPartitionReader.scala
+++ b/src/main/scala/io/indextables/spark/core/CompanionColumnarPartitionReader.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.connector.read.PartitionReader
 import org.apache.spark.sql.execution.vectorized.ConstantColumnVector
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types._
-import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch, ColumnVector}
+import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnVector, ColumnarBatch}
 import org.apache.spark.unsafe.types.UTF8String
 
 import org.apache.hadoop.fs.Path
@@ -43,12 +43,12 @@ import org.slf4j.LoggerFactory
  * Uses the Arrow C Data Interface to transfer parquet data directly from the native Rust layer as Arrow columnar
  * batches — zero serialization, zero row conversion.
  *
- * Single-batch model: next() executes search + Arrow FFI retrieval once, get() returns the ColumnarBatch, close()
- * frees resources.
+ * Single-batch model: next() executes search + Arrow FFI retrieval once, get() returns the ColumnarBatch, close() frees
+ * resources.
  *
  * Shared initialization logic (effective limit, path resolution, cache config, companion validation, path
- * normalization, footer validation, SplitMetadata reconstruction, SplitSearchEngine creation, query building)
- * is delegated to [[SplitReaderContext]].
+ * normalization, footer validation, SplitMetadata reconstruction, SplitSearchEngine creation, query building) is
+ * delegated to [[SplitReaderContext]].
  */
 class CompanionColumnarPartitionReader(
   addAction: AddAction,
@@ -59,25 +59,32 @@ class CompanionColumnarPartitionReader(
   config: Map[String, String],
   tablePath: Path,
   indexQueryFilters: Array[Any] = Array.empty,
-  metricsAccumulator: Option[io.indextables.spark.storage.BatchOptimizationMetricsAccumulator] = None
-) extends PartitionReader[ColumnarBatch] {
+  metricsAccumulator: Option[io.indextables.spark.storage.BatchOptimizationMetricsAccumulator] = None)
+    extends PartitionReader[ColumnarBatch] {
 
   private val logger = LoggerFactory.getLogger(classOf[CompanionColumnarPartitionReader])
 
   private val ctx = new SplitReaderContext(
-    addAction, readSchema, fullTableSchema, filters, limit,
-    config, tablePath, indexQueryFilters, metricsAccumulator
+    addAction,
+    readSchema,
+    fullTableSchema,
+    filters,
+    limit,
+    config,
+    tablePath,
+    indexQueryFilters,
+    metricsAccumulator
   )
 
-  private def effectiveLimit = ctx.effectiveLimit
+  private def effectiveLimit       = ctx.effectiveLimit
   private def partitionColumnNames = ctx.partitionColumnNames
-  private def dataFieldNames = ctx.dataFieldNames
+  private def dataFieldNames       = ctx.dataFieldNames
 
-  private val bridge                                = new ArrowFfiBridge()
-  private var splitSearchEngine: SplitSearchEngine  = _
-  private var batch: ColumnarBatch                  = _
-  private var initialized                           = false
-  private var consumed                              = false
+  private val bridge                               = new ArrowFfiBridge()
+  private var splitSearchEngine: SplitSearchEngine = _
+  private var batch: ColumnarBatch                 = _
+  private var initialized                          = false
+  private var consumed                             = false
 
   // NOTE: Pre-warm join is intentionally omitted for columnar companion reader.
   // Companion splits use parquet-native reads which don't benefit from the tantivy
@@ -87,7 +94,9 @@ class CompanionColumnarPartitionReader(
       try {
         splitSearchEngine = ctx.createSplitSearchEngine()
         initialized = true
-        logger.info(s"CompanionColumnarPartitionReader initialized for ${addAction.path}, effectiveLimit=$effectiveLimit")
+        logger.info(
+          s"CompanionColumnarPartitionReader initialized for ${addAction.path}, effectiveLimit=$effectiveLimit"
+        )
       } catch {
         case ex: Exception =>
           logger.error(s"Failed to initialize columnar reader for ${addAction.path}", ex)
@@ -143,28 +152,41 @@ class CompanionColumnarPartitionReader(
         val (arrays, schemas, arrayAddrs, schemaAddrs) = bridge.allocateStructs(numCols)
 
         // Call native FFI export — wrap in try/catch to clean up FFI structs on failure
-        val numRows = try {
-          val n = searcher.docBatchArrowFfi(docAddresses, arrayAddrs, schemaAddrs, dataFieldNames: _*)
+        val numRows =
+          try {
+            val n = searcher.docBatchArrowFfi(docAddresses, arrayAddrs, schemaAddrs, dataFieldNames: _*)
 
-          if (n < 0) {
-            // FFI returned -1 despite supportsArrowFfi() check — unexpected
-            arrays.foreach(a => try a.close() catch { case _: Exception => })
-            schemas.foreach(s => try s.close() catch { case _: Exception => })
-            throw new IllegalStateException(
-              s"docBatchArrowFfi returned -1 for companion split ${addAction.path} " +
-                "despite supportsArrowFfi() returning true. " +
-                "Arrow FFI not available — the split may not have a parquet manifest."
-            )
+            if (n < 0) {
+              // FFI returned -1 despite supportsArrowFfi() check — unexpected
+              arrays.foreach(a =>
+                try a.close()
+                catch { case _: Exception => }
+              )
+              schemas.foreach(s =>
+                try s.close()
+                catch { case _: Exception => }
+              )
+              throw new IllegalStateException(
+                s"docBatchArrowFfi returned -1 for companion split ${addAction.path} " +
+                  "despite supportsArrowFfi() returning true. " +
+                  "Arrow FFI not available — the split may not have a parquet manifest."
+              )
+            }
+            n
+          } catch {
+            case ex: IllegalStateException => throw ex // re-throw our own exception
+            case ex: Exception             =>
+              // Clean up FFI structs not yet consumed by importVector
+              arrays.foreach(a =>
+                try a.close()
+                catch { case _: Exception => }
+              )
+              schemas.foreach(s =>
+                try s.close()
+                catch { case _: Exception => }
+              )
+              throw ex
           }
-          n
-        } catch {
-          case ex: IllegalStateException => throw ex // re-throw our own exception
-          case ex: Exception =>
-            // Clean up FFI structs not yet consumed by importVector
-            arrays.foreach(a => try a.close() catch { case _: Exception => })
-            schemas.foreach(s => try s.close() catch { case _: Exception => })
-            throw ex
-        }
 
         // Import into ColumnarBatch via ArrowFfiBridge
         val dataBatch = bridge.importAsColumnarBatch(arrays, schemas, numRows)
@@ -208,11 +230,11 @@ class CompanionColumnarPartitionReader(
   }
 
   /**
-   * Assemble the final ColumnarBatch in readSchema column order by interleaving data columns (from FFI) with
-   * partition columns (as ConstantColumnVector).
+   * Assemble the final ColumnarBatch in readSchema column order by interleaving data columns (from FFI) with partition
+   * columns (as ConstantColumnVector).
    *
-   * Uses name-based mapping from actual FFI vector field names (not positional), since the native FFI export
-   * may return columns in parquet schema order rather than the requested dataFieldNames order.
+   * Uses name-based mapping from actual FFI vector field names (not positional), since the native FFI export may return
+   * columns in parquet schema order rather than the requested dataFieldNames order.
    */
   private def assembleColumnarBatch(dataBatch: ColumnarBatch, numRows: Int): ColumnarBatch = {
     // Build name→index map from actual FFI vector field names (not positional assumption).
@@ -260,15 +282,15 @@ class CompanionColumnarPartitionReader(
       vec.setNull()
     } else {
       dataType match {
-        case StringType    => vec.setUtf8String(UTF8String.fromString(value))
-        case IntegerType   => vec.setInt(value.toInt)
-        case LongType      => vec.setLong(value.toLong)
-        case DoubleType    => vec.setDouble(value.toDouble)
-        case FloatType     => vec.setFloat(value.toFloat)
-        case BooleanType   => vec.setBoolean(value.toBoolean)
-        case ShortType     => vec.setShort(value.toShort)
-        case ByteType      => vec.setByte(value.toByte)
-        case DateType      =>
+        case StringType  => vec.setUtf8String(UTF8String.fromString(value))
+        case IntegerType => vec.setInt(value.toInt)
+        case LongType    => vec.setLong(value.toLong)
+        case DoubleType  => vec.setDouble(value.toDouble)
+        case FloatType   => vec.setFloat(value.toFloat)
+        case BooleanType => vec.setBoolean(value.toBoolean)
+        case ShortType   => vec.setShort(value.toShort)
+        case ByteType    => vec.setByte(value.toByte)
+        case DateType =>
           vec.setInt(java.time.LocalDate.parse(value).toEpochDay.toInt)
         case TimestampType =>
           val instant = if (value.contains("T")) {

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkOptions.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkOptions.scala
@@ -534,7 +534,7 @@ object IndexTables4SparkOptions {
   val DISK_CACHE_COMPRESSION            = "spark.indextables.cache.disk.compression"
   val DISK_CACHE_MIN_COMPRESS_SIZE      = "spark.indextables.cache.disk.minCompressSize"
   val DISK_CACHE_MANIFEST_SYNC_INTERVAL = "spark.indextables.cache.disk.manifestSyncInterval"
-  val DISK_CACHE_WRITE_QUEUE_MODE      = "spark.indextables.cache.disk.writeQueue.mode"
-  val DISK_CACHE_WRITE_QUEUE_CAPACITY  = "spark.indextables.cache.disk.writeQueue.capacity"
-  val DISK_CACHE_DROP_WRITES_WHEN_FULL = "spark.indextables.cache.disk.dropWritesWhenFull"
+  val DISK_CACHE_WRITE_QUEUE_MODE       = "spark.indextables.cache.disk.writeQueue.mode"
+  val DISK_CACHE_WRITE_QUEUE_CAPACITY   = "spark.indextables.cache.disk.writeQueue.capacity"
+  val DISK_CACHE_DROP_WRITES_WHEN_FULL  = "spark.indextables.cache.disk.dropWritesWhenFull"
 }

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkPartitions.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkPartitions.scala
@@ -269,8 +269,15 @@ class IndexTables4SparkPartitionReader(
   private val logger = LoggerFactory.getLogger(classOf[IndexTables4SparkPartitionReader])
 
   private val ctx = new SplitReaderContext(
-    addAction, readSchema, fullTableSchema, filters, limit,
-    config, tablePath, indexQueryFilters, metricsAccumulator
+    addAction,
+    readSchema,
+    fullTableSchema,
+    filters,
+    limit,
+    config,
+    tablePath,
+    indexQueryFilters,
+    metricsAccumulator
   )
 
   private def effectiveLimit = ctx.effectiveLimit
@@ -279,7 +286,7 @@ class IndexTables4SparkPartitionReader(
   private var resultIterator: Iterator[InternalRow] = Iterator.empty
   private var initialized                           = false
 
-  private def initialize(): Unit = {
+  private def initialize(): Unit =
     if (!initialized) {
       try {
         // Check if pre-warm is enabled and try to join warmup future
@@ -319,7 +326,6 @@ class IndexTables4SparkPartitionReader(
           throw new IOException(s"Failed to read Tantivy index: ${ex.getMessage}", ex)
       }
     }
-  }
 
   override def next(): Boolean =
     try {

--- a/src/main/scala/io/indextables/spark/core/SplitReaderContext.scala
+++ b/src/main/scala/io/indextables/spark/core/SplitReaderContext.scala
@@ -38,14 +38,13 @@ import org.slf4j.LoggerFactory
 /**
  * Shared initialization context for split-based partition readers (both row and columnar).
  *
- * Encapsulates the duplicated logic for: effective limit calculation, path resolution, cache config,
- * companion validation, path normalization, footer validation, SplitMetadata reconstruction,
- * SplitSearchEngine creation, split field name retrieval, partition filter separation, range filter
- * stats optimization, IndexQuery cleanup, and SplitQuery building.
+ * Encapsulates the duplicated logic for: effective limit calculation, path resolution, cache config, companion
+ * validation, path normalization, footer validation, SplitMetadata reconstruction, SplitSearchEngine creation, split
+ * field name retrieval, partition filter separation, range filter stats optimization, IndexQuery cleanup, and
+ * SplitQuery building.
  *
- * Both [[IndexTables4SparkPartitionReader]] and [[CompanionColumnarPartitionReader]] compose this
- * class (has-a) rather than inheriting from it, avoiding trait mixin complexity with different
- * `PartitionReader[T]` type parameters.
+ * Both [[IndexTables4SparkPartitionReader]] and [[CompanionColumnarPartitionReader]] compose this class (has-a) rather
+ * than inheriting from it, avoiding trait mixin complexity with different `PartitionReader[T]` type parameters.
  */
 class SplitReaderContext(
   addAction: AddAction,
@@ -56,8 +55,7 @@ class SplitReaderContext(
   config: Map[String, String],
   tablePath: Path,
   indexQueryFilters: Array[Any],
-  metricsAccumulator: Option[BatchOptimizationMetricsAccumulator]
-) {
+  metricsAccumulator: Option[BatchOptimizationMetricsAccumulator]) {
 
   private val logger = LoggerFactory.getLogger(classOf[SplitReaderContext])
 
@@ -105,8 +103,8 @@ class SplitReaderContext(
   /**
    * Create a SplitSearchEngine from the AddAction metadata.
    *
-   * Handles companion validation, path normalization, footer validation, SplitMetadata
-   * reconstruction, and SplitSearchEngine creation.
+   * Handles companion validation, path normalization, footer validation, SplitMetadata reconstruction, and
+   * SplitSearchEngine creation.
    */
   def createSplitSearchEngine(): SplitSearchEngine = {
     val cacheConfig = createCacheConfig()
@@ -167,8 +165,8 @@ class SplitReaderContext(
   /**
    * Build a SplitQuery from the filters and IndexQuery filters.
    *
-   * Handles split field name retrieval, partition filter separation, range filter stats
-   * optimization, IndexQuery cleanup, and filter-to-query conversion.
+   * Handles split field name retrieval, partition filter separation, range filter stats optimization, IndexQuery
+   * cleanup, and filter-to-query conversion.
    */
   def buildSplitQuery(engine: SplitSearchEngine): SplitQuery = {
     // Get field names from split schema
@@ -191,7 +189,9 @@ class SplitReaderContext(
       val (partitionOnly, nonPartition) =
         filters.partition(f => MixedBooleanFilter.isPartitionOnlyFilter(f, partitionColumnNames))
       if (partitionOnly.nonEmpty)
-        logger.info(s"Excluding ${partitionOnly.length} partition filter(s) from Tantivy query: ${partitionOnly.mkString(", ")}")
+        logger.info(
+          s"Excluding ${partitionOnly.length} partition filter(s) from Tantivy query: ${partitionOnly.mkString(", ")}"
+        )
       nonPartition
     } else {
       filters
@@ -213,7 +213,9 @@ class SplitReaderContext(
     val cleanedIndexQueryFilters = if (partitionColumnNames.nonEmpty && indexQueryFilters.nonEmpty) {
       val cleaned = MixedBooleanFilter.stripPartitionFiltersFromArray(indexQueryFilters, partitionColumnNames)
       if (cleaned.length != indexQueryFilters.length)
-        logger.info(s"Stripped ${indexQueryFilters.length - cleaned.length} partition-only IndexQuery filter(s) from Tantivy query")
+        logger.info(
+          s"Stripped ${indexQueryFilters.length - cleaned.length} partition-only IndexQuery filter(s) from Tantivy query"
+        )
       cleaned
     } else {
       indexQueryFilters
@@ -224,7 +226,10 @@ class SplitReaderContext(
     val splitQuery = if (allFilters.nonEmpty) {
       if (splitFieldNames.nonEmpty) {
         val q = FiltersToQueryConverter.convertToSplitQuery(
-          allFilters, engine, Some(splitFieldNames), Some(cachedOptionsMap)
+          allFilters,
+          engine,
+          Some(splitFieldNames),
+          Some(cachedOptionsMap)
         )
         logger.debug(s"SplitQuery (with schema validation): ${q.getClass.getSimpleName}")
         q
@@ -240,7 +245,7 @@ class SplitReaderContext(
   }
 
   /** Collect batch optimization metrics delta and add to accumulator. */
-  def collectMetricsDelta(): Unit = {
+  def collectMetricsDelta(): Unit =
     metricsAccumulator.foreach { acc =>
       try {
         val currentMetrics = BatchOptMetrics.fromJavaMetrics()
@@ -263,7 +268,6 @@ class SplitReaderContext(
           logger.warn(s"Error collecting batch optimization metrics for ${addAction.path}", ex)
       }
     }
-  }
 
   /** Report bytesRead to Spark UI. */
   def reportBytesRead(): Unit = {
@@ -285,9 +289,8 @@ class SplitReaderContext(
   }
 
   /**
-   * Check if a range filter is redundant based on min/max statistics. A filter is redundant if the
-   * split's entire data range is within the filter's range, meaning all records in the split would
-   * pass the filter anyway.
+   * Check if a range filter is redundant based on min/max statistics. A filter is redundant if the split's entire data
+   * range is within the filter's range, meaning all records in the split would pass the filter anyway.
    *
    * Only applies to Date and Timestamp columns to avoid type conversion complexity.
    */
@@ -357,7 +360,11 @@ class SplitReaderContext(
       case _       => None
     }
 
-    def parseValue(value: Any, dataType: DataType, fromStats: Boolean): Option[Long] = dataType match {
+    def parseValue(
+      value: Any,
+      dataType: DataType,
+      fromStats: Boolean
+    ): Option[Long] = dataType match {
       case TimestampType => parseTimestamp(value, fromStats)
       case DateType      => parseDate(value, fromStats)
       case _             => None

--- a/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
@@ -30,10 +30,10 @@ import org.apache.hadoop.fs.Path
 import io.indextables.spark.sync.{
   CompanionSourceFile,
   CompanionSourceReader,
+  DeltaSourceReader,
   DistributedAntiJoin,
   DistributedScanResult,
   DistributedSourceScanner,
-  DeltaSourceReader,
   IcebergSourceReader,
   ParquetDirectoryReader,
   SyncConfig,
@@ -285,7 +285,14 @@ case class SyncToExternalCommand(
               if (parts.length == 2) (parts(0), parts(1))
               else throw new IllegalArgumentException(s"Invalid Iceberg table identifier: $sourcePath")
             }
-            scanner.scanIcebergTable(effectiveCatalogName.getOrElse("default"), ns, tbl, icebergConfig, fromSnapshot, wherePredicates = wherePredicates)
+            scanner.scanIcebergTable(
+              effectiveCatalogName.getOrElse("default"),
+              ns,
+              tbl,
+              icebergConfig,
+              fromSnapshot,
+              wherePredicates = wherePredicates
+            )
           case "parquet" =>
             val sourceCredentials = resolveCredentials(mergedConfigs, sourcePath)
             scanner.scanParquetDirectory(sourcePath, sourceCredentials, wherePredicates = wherePredicates)
@@ -330,7 +337,7 @@ case class SyncToExternalCommand(
     // Check for non-existent source (Delta: version -1, Parquet: empty dir, Iceberg: no snapshot)
     val sourceIsEmpty = allSourceFiles match {
       case Some(files) => files.isEmpty && sourceFormat == "delta" && sourceVersionOpt.isEmpty
-      case None =>
+      case None        =>
         // For distributed: check if version indicates empty
         sourceFormat == "delta" && sourceVersionOpt.isEmpty
     }
@@ -524,17 +531,18 @@ case class SyncToExternalCommand(
       // Scope invalidation: when WHERE clause is present and INVALIDATE ALL PARTITIONS is not set,
       // only consider companion splits whose partition values match the WHERE predicate.
       // Splits outside the WHERE range are left untouched.
-      val scopedExistingFiles = if (!invalidateAllPartitions && effectiveWherePredicates.nonEmpty && partitionColumns.nonEmpty) {
-        val partitionSchema = PartitionPredicateUtils.buildPartitionSchema(partitionColumns, Some(sourceSchema))
-        val parsedPredicates = PartitionPredicateUtils.parseAndValidatePredicates(
-          effectiveWherePredicates, partitionSchema, sparkSession)
-        val filtered = PartitionPredicateUtils.filterAddActionsByPredicates(
-          existingFiles, partitionSchema, parsedPredicates)
-        logger.info(s"WHERE-scoped invalidation: ${existingFiles.size} -> ${filtered.size} companion splits in scope")
-        filtered
-      } else {
-        existingFiles
-      }
+      val scopedExistingFiles =
+        if (!invalidateAllPartitions && effectiveWherePredicates.nonEmpty && partitionColumns.nonEmpty) {
+          val partitionSchema = PartitionPredicateUtils.buildPartitionSchema(partitionColumns, Some(sourceSchema))
+          val parsedPredicates =
+            PartitionPredicateUtils.parseAndValidatePredicates(effectiveWherePredicates, partitionSchema, sparkSession)
+          val filtered =
+            PartitionPredicateUtils.filterAddActionsByPredicates(existingFiles, partitionSchema, parsedPredicates)
+          logger.info(s"WHERE-scoped invalidation: ${existingFiles.size} -> ${filtered.size} companion splits in scope")
+          filtered
+        } else {
+          existingFiles
+        }
 
       val (rawParquetFiles, splitsToInvalidate) = distributedRDD match {
         case Some(rdd) =>
@@ -547,10 +555,14 @@ case class SyncToExternalCommand(
           computeAntiJoinChanges(allSourceFiles.get, scopedExistingFiles, isInitialSync)
       }
 
-      logger.info(s"Anti-join result: ${rawParquetFiles.size} files to index, ${splitsToInvalidate.size} splits to invalidate")
+      logger.info(
+        s"Anti-join result: ${rawParquetFiles.size} files to index, ${splitsToInvalidate.size} splits to invalidate"
+      )
       if (rawParquetFiles.nonEmpty) {
         val sample = rawParquetFiles.head
-        logger.info(s"Anti-join sample file: path=${sample.path}, partitionValues=${sample.partitionValues}, size=${sample.size}")
+        logger.info(
+          s"Anti-join sample file: path=${sample.path}, partitionValues=${sample.partitionValues}, size=${sample.size}"
+        )
       }
 
       // 7b. Apply WHERE partition filter
@@ -647,9 +659,10 @@ case class SyncToExternalCommand(
                       icebergConfig
                     )
                 }
-                val fieldIdToName  = icebergTableSchema.getFieldIdToNameMap
-                val storageConfig  = IcebergSourceReader.buildParquetReaderStorageConfig(icebergConfig)
-                val mapping        = io.indextables.tantivy4java.parquet.ParquetSchemaReader.readColumnMapping(url, fieldIdToName, storageConfig)
+                val fieldIdToName = icebergTableSchema.getFieldIdToNameMap
+                val storageConfig = IcebergSourceReader.buildParquetReaderStorageConfig(icebergConfig)
+                val mapping = io.indextables.tantivy4java.parquet.ParquetSchemaReader
+                  .readColumnMapping(url, fieldIdToName, storageConfig)
                 if (mapping != null && !mapping.isEmpty) mapping.asScala.toMap else Map.empty[String, String]
               } catch {
                 case e: Exception =>
@@ -903,13 +916,17 @@ case class SyncToExternalCommand(
   ): Seq[CompanionSourceFile] = {
     val effectivePreds = if (predicates.nonEmpty) predicates else wherePredicates
     if (effectivePreds.isEmpty || partitionColumns.isEmpty) {
-      logger.info(s"applyWhereFilter: skipped (predicates=${effectivePreds.size}, partitionColumns=${partitionColumns.size})")
+      logger.info(
+        s"applyWhereFilter: skipped (predicates=${effectivePreds.size}, partitionColumns=${partitionColumns.size})"
+      )
       return files
     }
 
-    logger.info(s"applyWhereFilter: ${files.size} files, partitionColumns=[${partitionColumns.mkString(",")}], " +
-      s"predicates=[${effectivePreds.mkString("; ")}], " +
-      s"schemaFields=${fullSchema.map(_.fieldNames.mkString(",")).getOrElse("none")}")
+    logger.info(
+      s"applyWhereFilter: ${files.size} files, partitionColumns=[${partitionColumns.mkString(",")}], " +
+        s"predicates=[${effectivePreds.mkString("; ")}], " +
+        s"schemaFields=${fullSchema.map(_.fieldNames.mkString(",")).getOrElse("none")}"
+    )
 
     // Log sample partition values for diagnosis
     files.headOption.foreach { f =>
@@ -917,7 +934,9 @@ case class SyncToExternalCommand(
     }
 
     val partitionSchema = PartitionPredicateUtils.buildPartitionSchema(partitionColumns, fullSchema)
-    logger.info(s"applyWhereFilter: partitionSchema=${partitionSchema.fields.map(f => s"${f.name}:${f.dataType}").mkString(",")}")
+    logger.info(
+      s"applyWhereFilter: partitionSchema=${partitionSchema.fields.map(f => s"${f.name}:${f.dataType}").mkString(",")}"
+    )
 
     val parsedPredicates =
       PartitionPredicateUtils.parseAndValidatePredicates(effectivePreds, partitionSchema, sparkSession)

--- a/src/main/scala/io/indextables/spark/storage/SplitManager.scala
+++ b/src/main/scala/io/indextables/spark/storage/SplitManager.scala
@@ -443,15 +443,15 @@ case class SplitCacheConfig(
   adaptiveTuningEnabled: Option[Boolean] = None,
   adaptiveTuningMinBatches: Option[Int] = None,
   // L2 Disk Cache configuration (persistent NVMe caching)
-  diskCacheEnabled: Option[Boolean] = None,          // Master switch (auto-enabled on /local_disk0)
-  diskCachePath: Option[String] = None,              // Cache directory path
-  diskCacheMaxSize: Option[Long] = None,             // Max size in bytes (0 = auto: 2/3 available disk)
-  diskCacheCompression: Option[String] = None,       // "lz4" (default), "zstd", "none"
-  diskCacheMinCompressSize: Option[Long] = None,     // Skip compression below threshold (default: 4096)
-  diskCacheManifestSyncInterval: Option[Int] = None, // Seconds between manifest writes (default: 30)
-  diskCacheWriteQueueMode: Option[String] = None,          // "fragment" or "size" (default: size)
-  diskCacheWriteQueueCapacity: Option[String] = None,       // Fragment: slot count; Size: byte limit ("1G")
-  diskCacheDropWritesWhenFull: Option[Boolean] = None,       // Drop query-path writes when full (default: true)
+  diskCacheEnabled: Option[Boolean] = None,            // Master switch (auto-enabled on /local_disk0)
+  diskCachePath: Option[String] = None,                // Cache directory path
+  diskCacheMaxSize: Option[Long] = None,               // Max size in bytes (0 = auto: 2/3 available disk)
+  diskCacheCompression: Option[String] = None,         // "lz4" (default), "zstd", "none"
+  diskCacheMinCompressSize: Option[Long] = None,       // Skip compression below threshold (default: 4096)
+  diskCacheManifestSyncInterval: Option[Int] = None,   // Seconds between manifest writes (default: 30)
+  diskCacheWriteQueueMode: Option[String] = None,      // "fragment" or "size" (default: size)
+  diskCacheWriteQueueCapacity: Option[String] = None,  // Fragment: slot count; Size: byte limit ("1G")
+  diskCacheDropWritesWhenFull: Option[Boolean] = None, // Drop query-path writes when full (default: true)
   // Parquet coalesce configuration
   coalesceMaxGap: Option[Long] = None, // Max gap between byte ranges to coalesce (default: 512KB)
   // Companion mode (parquet companion splits)

--- a/src/main/scala/io/indextables/spark/sync/DistributedAntiJoin.scala
+++ b/src/main/scala/io/indextables/spark/sync/DistributedAntiJoin.scala
@@ -56,9 +56,9 @@ object DistributedAntiJoin {
  * computeAntiJoinChanges() for large tables where materializing all source files on the driver would OOM.
  *
  * The anti-join identifies:
- *   1. New files: in source but not tracked by any companion split → need indexing
- *   2. Gone files: tracked by companion splits but absent from source → splits need invalidation
- *   3. Remaining files: still-valid files from invalidated splits → need re-indexing
+ *   1. New files: in source but not tracked by any companion split → need indexing 2. Gone files: tracked by companion
+ *      splits but absent from source → splits need invalidation 3. Remaining files: still-valid files from invalidated
+ *      splits → need re-indexing
  */
 class DistributedAntiJoin(spark: SparkSession) {
   import DistributedAntiJoin.normalizePath
@@ -109,9 +109,7 @@ class DistributedAntiJoin(spark: SparkSession) {
 
     // Compute new files: source files not tracked by any companion split.
     // This runs distributed — only the matching files are collected to driver.
-    val newFilesRDD = sourceFilesRDD.filter { f =>
-      !broadcastCompanionPaths.value.contains(normalizePath(f.path))
-    }
+    val newFilesRDD = sourceFilesRDD.filter(f => !broadcastCompanionPaths.value.contains(normalizePath(f.path)))
 
     // Compute source paths for "gone files" check.
     // keyBy normalized path, then collect just the distinct paths.

--- a/src/main/scala/io/indextables/spark/sync/DistributedSourceScanner.scala
+++ b/src/main/scala/io/indextables/spark/sync/DistributedSourceScanner.scala
@@ -20,9 +20,8 @@ package io.indextables.spark.sync
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.SparkSession
-
 import org.apache.spark.sql.types.{DataType, StructType}
+import org.apache.spark.sql.SparkSession
 
 import io.indextables.spark.arrow.ArrowFfiBridge
 import io.indextables.tantivy4java.delta.{DeltaFileEntry, DeltaSnapshotInfo, DeltaTableReader}
@@ -96,16 +95,16 @@ object DistributedSourceScanner {
     // Normalize: strip file: URI scheme, ensure consistent leading-slash handling.
     // The native ParquetTableReader may return local paths without leading slash (e.g. "var/folders/...")
     // while the basePath has one ("/var/folders/...").
-    val absolutePath = normalizeLocalPath(stripFileScheme(rawPath))
+    val absolutePath   = normalizeLocalPath(stripFileScheme(rawPath))
     val normalizedBase = normalizeLocalPath(stripFileScheme(basePath)).stripSuffix("/")
-    val normalizedAbs = absolutePath.stripSuffix("/")
+    val normalizedAbs  = absolutePath.stripSuffix("/")
     val relativePath = if (normalizedAbs.startsWith(normalizedBase)) {
       normalizedAbs.substring(normalizedBase.length).stripPrefix("/")
     } else {
       // The native ParquetTableReader may return S3 object keys without the scheme+bucket prefix
       // (e.g. "path/to/data/part.parquet" instead of "s3a://bucket/path/to/data/part.parquet").
       // Extract the key portion from basePath and try matching against the raw path.
-      val baseKey = ParquetDirectoryReader.extractObjectKey(basePath)
+      val baseKey       = ParquetDirectoryReader.extractObjectKey(basePath)
       val rawNormalized = rawPath.stripSuffix("/")
       if (baseKey.nonEmpty && rawNormalized.startsWith(baseKey)) {
         rawNormalized.substring(baseKey.length).stripPrefix("/")
@@ -121,7 +120,6 @@ object DistributedSourceScanner {
     )
   }
 
-
   private[sync] def stripFileScheme(path: String): String =
     if (path.startsWith("file:///")) path.substring(7)
     else if (path.startsWith("file:/")) path.substring(5)
@@ -129,8 +127,10 @@ object DistributedSourceScanner {
 
   /** Ensure local filesystem paths have a leading slash for consistent comparison. */
   private[sync] def normalizeLocalPath(path: String): String =
-    if (!path.startsWith("/") && !path.startsWith("s3://") && !path.startsWith("s3a://") &&
-      !path.startsWith("abfss://") && !path.startsWith("wasbs://") && !path.startsWith("az://")) {
+    if (
+      !path.startsWith("/") && !path.startsWith("s3://") && !path.startsWith("s3a://") &&
+      !path.startsWith("abfss://") && !path.startsWith("wasbs://") && !path.startsWith("az://")
+    ) {
       "/" + path
     } else {
       path
@@ -189,7 +189,15 @@ object DistributedSourceScanner {
     val bridge  = new ArrowFfiBridge()
     try {
       val (arrays, schemas, arrayAddrs, schemaAddrs) = bridge.allocateStructs(numCols)
-      val numRows = DeltaTableReader.readCheckpointPartArrowFfi(kernelPath, config, partPath, filter, snapshotInfo, arrayAddrs, schemaAddrs)
+      val numRows = DeltaTableReader.readCheckpointPartArrowFfi(
+        kernelPath,
+        config,
+        partPath,
+        filter,
+        snapshotInfo,
+        arrayAddrs,
+        schemaAddrs
+      )
       if (numRows == 0) {
         arrays.foreach(_.close())
         schemas.foreach(_.close())
@@ -198,30 +206,35 @@ object DistributedSourceScanner {
       }
       val batch = bridge.importAsColumnarBatch(arrays, schemas, numRows)
       try {
-        val mapper  = new com.fasterxml.jackson.databind.ObjectMapper()
-        val results = new scala.collection.mutable.ArrayBuffer[CompanionSourceFile](numRows)
-        var i       = 0
+        val mapper       = new com.fasterxml.jackson.databind.ObjectMapper()
+        val results      = new scala.collection.mutable.ArrayBuffer[CompanionSourceFile](numRows)
+        var i            = 0
         var loggedSample = false
         while (i < numRows) {
           val pathStr = batch.column(0).getUTF8String(i)
           if (pathStr != null) {
-            val path = pathStr.toString
-            val size = batch.column(1).getLong(i)
+            val path        = pathStr.toString
+            val size        = batch.column(1).getLong(i)
             val partJsonStr = batch.column(4).getUTF8String(i)
-            val partitionValues = parsePartitionValuesJson(
-              if (partJsonStr != null) partJsonStr.toString else null, mapper)
+            val partitionValues =
+              parsePartitionValuesJson(if (partJsonStr != null) partJsonStr.toString else null, mapper)
             // Log first file's partition values for diagnostic purposes
             if (!loggedSample) {
-              ffiLogger.info(s"Arrow FFI sample from ${partPath.substring(partPath.lastIndexOf('/') + 1)}: " +
-                s"numRows=$numRows, path=$path, partitionValuesJson=${if (partJsonStr != null) partJsonStr.toString else "null"}, " +
-                s"parsedPartitionValues=$partitionValues")
+              ffiLogger.info(
+                s"Arrow FFI sample from ${partPath.substring(partPath.lastIndexOf('/') + 1)}: " +
+                  s"numRows=$numRows, path=$path, partitionValuesJson=${if (partJsonStr != null) partJsonStr.toString
+                    else "null"}, " +
+                  s"parsedPartitionValues=$partitionValues"
+              )
               loggedSample = true
             }
             results += CompanionSourceFile(path = path, partitionValues = partitionValues, size = size)
           }
           i += 1
         }
-        ffiLogger.info(s"Arrow FFI: ${results.size} files from checkpoint part ${partPath.substring(partPath.lastIndexOf('/') + 1)}")
+        ffiLogger.info(
+          s"Arrow FFI: ${results.size} files from checkpoint part ${partPath.substring(partPath.lastIndexOf('/') + 1)}"
+        )
         results.iterator
       } finally
         batch.close()
@@ -248,7 +261,15 @@ object DistributedSourceScanner {
     try {
       val (arrays, schemas, arrayAddrs, schemaAddrs) = bridge.allocateStructs(numCols)
       val numRows = IcebergTableReader.readManifestFileArrowFfi(
-        catalogName, namespace, tableName, config, manifestPath, filter, arrayAddrs, schemaAddrs)
+        catalogName,
+        namespace,
+        tableName,
+        config,
+        manifestPath,
+        filter,
+        arrayAddrs,
+        schemaAddrs
+      )
       if (numRows == 0) {
         arrays.foreach(_.close())
         schemas.foreach(_.close())
@@ -268,8 +289,8 @@ object DistributedSourceScanner {
               val absolutePath = pathStr.toString
               val fileSize     = batch.column(3).getLong(i)
               val partJsonStr  = batch.column(4).getUTF8String(i)
-              val partitionValues = parsePartitionValuesJson(
-                if (partJsonStr != null) partJsonStr.toString else null, mapper)
+              val partitionValues =
+                parsePartitionValuesJson(if (partJsonStr != null) partJsonStr.toString else null, mapper)
 
               // Convert absolute path to relative
               val relativePath = storageRoot match {
@@ -287,7 +308,11 @@ object DistributedSourceScanner {
                 extractPartitionValuesFromPath(absolutePath, storageRoot.get)
               } else partitionValues
 
-              results += CompanionSourceFile(path = relativePath, partitionValues = effectivePartitionValues, size = fileSize)
+              results += CompanionSourceFile(
+                path = relativePath,
+                partitionValues = effectivePartitionValues,
+                size = fileSize
+              )
             }
           }
           i += 1
@@ -324,12 +349,11 @@ class DistributedSourceScanner(spark: SparkSession) {
    * Scan a Delta table using distributed checkpoint reading.
    *
    * Flow:
-   *   1. getSnapshotInfo() on driver → checkpoint part paths + commit file paths + schema + partition columns
-   *   2. Build PartitionFilter from WHERE predicates using snapshot metadata (no listFiles!)
-   *   3. readPostCheckpointChanges() on driver → adds/removes after checkpoint
-   *   4. sc.parallelize(checkpointPartPaths) → flatMap(readCheckpointPart) on executors
-   *   5. Filter out removed paths, union with post-checkpoint adds
-   *   6. Map DeltaFileEntry → CompanionSourceFile
+   *   1. getSnapshotInfo() on driver → checkpoint part paths + commit file paths + schema + partition columns 2. Build
+   *      PartitionFilter from WHERE predicates using snapshot metadata (no listFiles!) 3. readPostCheckpointChanges()
+   *      on driver → adds/removes after checkpoint 4. sc.parallelize(checkpointPartPaths) → flatMap(readCheckpointPart)
+   *      on executors 5. Filter out removed paths, union with post-checkpoint adds 6. Map DeltaFileEntry →
+   *      CompanionSourceFile
    */
   def scanDeltaTable(
     path: String,
@@ -340,41 +364,49 @@ class DistributedSourceScanner(spark: SparkSession) {
     val deltaKernelPath = DeltaLogReader.normalizeForDeltaKernel(path)
     val deltaConfig     = DeltaLogReader.translateCredentials(credentials)
 
-    logger.info(s"Distributed Delta scan: getting snapshot info for $path" +
-      partitionFilter.map(f => s" (native filter: ${f.toJson})").getOrElse(""))
+    logger.info(
+      s"Distributed Delta scan: getting snapshot info for $path" +
+        partitionFilter.map(f => s" (native filter: ${f.toJson})").getOrElse("")
+    )
     val snapshotInfo = DeltaTableReader.getSnapshotInfo(deltaKernelPath, deltaConfig)
 
     // getSnapshotInfo() returns logical partition column names (translated from physical IDs
     // for column mapping tables by tantivy4java 0.31.0).
     val snapshotPartCols = snapshotInfo.getPartitionColumns.asScala.toSeq
-    val schemaJson = snapshotInfo.getSchemaJson
+    val schemaJson       = snapshotInfo.getSchemaJson
     if (snapshotInfo.getColumnNameMapping != null && !snapshotInfo.getColumnNameMapping.isEmpty) {
       logger.info(s"Column mapping active: ${snapshotInfo.getColumnNameMapping.size} mapped columns")
     }
     logger.info(s"Snapshot partition columns: ${snapshotPartCols.mkString(", ")}")
 
     // Parse schema (using logical names from Delta schema JSON)
-    val schemaOpt = try {
-      Some(DataType.fromJson(schemaJson).asInstanceOf[StructType])
-    } catch { case _: Exception => None }
+    val schemaOpt =
+      try
+        Some(DataType.fromJson(schemaJson).asInstanceOf[StructType])
+      catch { case _: Exception => None }
 
     // Build PartitionFilter from WHERE predicates using snapshot metadata.
     // This avoids calling reader.partitionColumns() which triggers the blocking listFiles() call.
     val effectiveFilter = partitionFilter.orElse {
       if (wherePredicates.nonEmpty) {
-        try {
+        try
           if (snapshotPartCols.nonEmpty) {
-            logger.info(s"Building PartitionFilter: wherePredicates=${wherePredicates.mkString("; ")}, " +
-              s"partCols=${snapshotPartCols.mkString(",")}, schemaFields=${schemaOpt.map(_.fieldNames.mkString(",")).getOrElse("none")}")
+            logger.info(
+              s"Building PartitionFilter: wherePredicates=${wherePredicates.mkString("; ")}, " +
+                s"partCols=${snapshotPartCols.mkString(",")}, schemaFields=${schemaOpt.map(_.fieldNames.mkString(",")).getOrElse("none")}"
+            )
             val filter = SparkPredicateToPartitionFilter.convert(wherePredicates, snapshotPartCols, spark, schemaOpt)
             filter match {
               case Some(f) => logger.info(s"Built native PartitionFilter from snapshot metadata: ${f.toJson}")
-              case None    => logger.warn(s"PartitionFilter build returned None — WHERE predicates may reference columns " +
-                s"not in partition columns [${snapshotPartCols.mkString(",")}], or expressions are unsupported")
+              case None =>
+                logger.warn(
+                  s"PartitionFilter build returned None — WHERE predicates may reference columns " +
+                    s"not in partition columns [${snapshotPartCols.mkString(",")}], or expressions are unsupported"
+                )
             }
             filter
           } else None
-        } catch {
+        catch {
           case e: Exception =>
             logger.warn(s"Cannot build PartitionFilter from snapshot metadata: ${e.getMessage}")
             None
@@ -392,7 +424,12 @@ class DistributedSourceScanner(spark: SparkSession) {
     // Read post-checkpoint changes on driver (small: just JSON commit files after last checkpoint).
     // Pass snapshotInfo for column mapping translation of partition values.
     val postCheckpointChanges = DeltaTableReader.readPostCheckpointChanges(
-      deltaKernelPath, deltaConfig, snapshotInfo.getCommitFilePaths, effectiveFilter.orNull, snapshotInfo)
+      deltaKernelPath,
+      deltaConfig,
+      snapshotInfo.getCommitFilePaths,
+      effectiveFilter.orNull,
+      snapshotInfo
+    )
     val addedAfterCheckpoint = postCheckpointChanges.getAddedFiles.asScala.toSeq
     val removedPaths         = postCheckpointChanges.getRemovedPaths.asScala.toSet
 
@@ -422,7 +459,9 @@ class DistributedSourceScanner(spark: SparkSession) {
           if (broadcastArrowFfi.value) {
             readDeltaCheckpointPartArrowFfi(kernelPath, config, partPath, filter, snapInfo)
           } else {
-            DeltaTableReader.readCheckpointPart(kernelPath, config, partPath, filter, snapInfo).asScala
+            DeltaTableReader
+              .readCheckpointPart(kernelPath, config, partPath, filter, snapInfo)
+              .asScala
               .map(deltaEntryToCompanionFile)
           }
         }
@@ -459,10 +498,9 @@ class DistributedSourceScanner(spark: SparkSession) {
    * Scan an Iceberg table using distributed manifest reading.
    *
    * Flow:
-   *   1. getSnapshotInfo() on driver → manifest file paths + snapshot metadata
-   *   2. Read first manifest on driver for sampleFilePath, storageRoot, and partitionColumns
-   *   3. sc.parallelize(manifestPaths) → flatMap(readManifestFile) on executors
-   *   4. Filter parquet-only, map to CompanionSourceFile with relative paths
+   *   1. getSnapshotInfo() on driver → manifest file paths + snapshot metadata 2. Read first manifest on driver for
+   *      sampleFilePath, storageRoot, and partitionColumns 3. sc.parallelize(manifestPaths) → flatMap(readManifestFile)
+   *      on executors 4. Filter parquet-only, map to CompanionSourceFile with relative paths
    */
   def scanIcebergTable(
     catalogName: String,
@@ -473,8 +511,10 @@ class DistributedSourceScanner(spark: SparkSession) {
     partitionFilter: Option[PartitionFilter] = None,
     wherePredicates: Seq[String] = Seq.empty
   ): DistributedScanResult = {
-    logger.info(s"Distributed Iceberg scan: getting snapshot info for $catalogName.$namespace.$tableName" +
-      partitionFilter.map(f => s" (native filter: ${f.toJson})").getOrElse(""))
+    logger.info(
+      s"Distributed Iceberg scan: getting snapshot info for $catalogName.$namespace.$tableName" +
+        partitionFilter.map(f => s" (native filter: ${f.toJson})").getOrElse("")
+    )
     val snapshotInfo = snapshotId match {
       case Some(id) => IcebergTableReader.getSnapshotInfo(catalogName, namespace, tableName, icebergConfig, id)
       case None     => IcebergTableReader.getSnapshotInfo(catalogName, namespace, tableName, icebergConfig)
@@ -502,9 +542,9 @@ class DistributedSourceScanner(spark: SparkSession) {
     val partitionColumns    = firstEntry.map(_.getPartitionValues.keySet.asScala.toSeq.sorted).getOrElse(Seq.empty)
 
     // Distributed: read all manifests on executors
-    val sc              = spark.sparkContext
-    val broadcastConfig = sc.broadcast((catalogName, namespace, tableName, icebergConfig))
-    val broadcastRoot   = sc.broadcast(computedStorageRoot)
+    val sc                = spark.sparkContext
+    val broadcastConfig   = sc.broadcast((catalogName, namespace, tableName, icebergConfig))
+    val broadcastRoot     = sc.broadcast(computedStorageRoot)
     val broadcastFilter   = sc.broadcast(partitionFilter.orNull)
     val broadcastArrowFfi = sc.broadcast(arrowFfiEnabled)
 
@@ -519,16 +559,22 @@ class DistributedSourceScanner(spark: SparkSession) {
           readIcebergManifestArrowFfi(cat, ns, tbl, config, manifestPath, filter, root)
         } else if (filter != null) {
           val entries = IcebergTableReader.readManifestFile(cat, ns, tbl, config, manifestPath, false, filter)
-          entries.asScala.filter { entry =>
-            val fmt = entry.getFileFormat
-            fmt == null || fmt.equalsIgnoreCase("parquet")
-          }.map(entry => icebergEntryToCompanionFile(entry, root)).iterator
+          entries.asScala
+            .filter { entry =>
+              val fmt = entry.getFileFormat
+              fmt == null || fmt.equalsIgnoreCase("parquet")
+            }
+            .map(entry => icebergEntryToCompanionFile(entry, root))
+            .iterator
         } else {
           val entries = IcebergTableReader.readManifestFile(cat, ns, tbl, config, manifestPath)
-          entries.asScala.filter { entry =>
-            val fmt = entry.getFileFormat
-            fmt == null || fmt.equalsIgnoreCase("parquet")
-          }.map(entry => icebergEntryToCompanionFile(entry, root)).iterator
+          entries.asScala
+            .filter { entry =>
+              val fmt = entry.getFileFormat
+              fmt == null || fmt.equalsIgnoreCase("parquet")
+            }
+            .map(entry => icebergEntryToCompanionFile(entry, root))
+            .iterator
         }
       }
 
@@ -546,10 +592,9 @@ class DistributedSourceScanner(spark: SparkSession) {
    * Scan a bare Parquet directory using distributed partition directory listing.
    *
    * Flow:
-   *   1. getTableInfo() on driver → partition directories + root files
-   *   2. If partitioned: sc.parallelize(partitionDirs) → flatMap(listPartitionFiles)
-   *   3. If unpartitioned: sc.parallelize(rootFiles)
-   *   4. Map ParquetFileEntry → CompanionSourceFile
+   *   1. getTableInfo() on driver → partition directories + root files 2. If partitioned: sc.parallelize(partitionDirs)
+   *      → flatMap(listPartitionFiles) 3. If unpartitioned: sc.parallelize(rootFiles) 4. Map ParquetFileEntry →
+   *      CompanionSourceFile
    */
   def scanParquetDirectory(
     path: String,
@@ -560,8 +605,10 @@ class DistributedSourceScanner(spark: SparkSession) {
     val normalizedPath = ParquetDirectoryReader.normalizeForObjectStore(path)
     val nativeConfig   = ParquetDirectoryReader.translateCredentials(credentials)
 
-    logger.info(s"Distributed Parquet scan: getting table info for $path" +
-      partitionFilter.map(f => s" (native filter: ${f.toJson})").getOrElse(""))
+    logger.info(
+      s"Distributed Parquet scan: getting table info for $path" +
+        partitionFilter.map(f => s" (native filter: ${f.toJson})").getOrElse("")
+    )
     val tableInfo = partitionFilter match {
       case Some(filter) => ParquetTableReader.getTableInfo(normalizedPath, nativeConfig, filter)
       case None         => ParquetTableReader.getTableInfo(normalizedPath, nativeConfig)

--- a/src/main/scala/io/indextables/spark/sync/SparkPredicateToPartitionFilter.scala
+++ b/src/main/scala/io/indextables/spark/sync/SparkPredicateToPartitionFilter.scala
@@ -17,7 +17,6 @@
 
 package io.indextables.spark.sync
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
 import org.apache.spark.sql.catalyst.expressions.{And => CatalystAnd, Not => CatalystNot, Or => CatalystOr}
 import org.apache.spark.sql.catalyst.expressions.{EqualTo => CatalystEqualTo, GreaterThan => CatalystGreaterThan}
@@ -33,6 +32,7 @@ import org.apache.spark.sql.catalyst.expressions.{
   LessThanOrEqual => CatalystLessThanOrEqual
 }
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.SparkSession
 
 import io.indextables.spark.transaction.PartitionPredicateUtils
 import io.indextables.tantivy4java.filter.PartitionFilter
@@ -189,8 +189,10 @@ object SparkPredicateToPartitionFilter {
 
       // AND: left AND right
       case CatalystAnd(left, right) =>
-        (expressionToPartitionFilter(left, partColSet, partitionSchema),
-          expressionToPartitionFilter(right, partColSet, partitionSchema)) match {
+        (
+          expressionToPartitionFilter(left, partColSet, partitionSchema),
+          expressionToPartitionFilter(right, partColSet, partitionSchema)
+        ) match {
           case (Some(l), Some(r)) => Some(PartitionFilter.and(l, r))
           case (Some(l), None)    => Some(l)
           case (None, Some(r))    => Some(r)
@@ -199,8 +201,10 @@ object SparkPredicateToPartitionFilter {
 
       // OR: left OR right (both sides must convert)
       case CatalystOr(left, right) =>
-        (expressionToPartitionFilter(left, partColSet, partitionSchema),
-          expressionToPartitionFilter(right, partColSet, partitionSchema)) match {
+        (
+          expressionToPartitionFilter(left, partColSet, partitionSchema),
+          expressionToPartitionFilter(right, partColSet, partitionSchema)
+        ) match {
           case (Some(l), Some(r)) => Some(PartitionFilter.or(l, r))
           case _                  => None
         }
@@ -227,19 +231,23 @@ object SparkPredicateToPartitionFilter {
     }
 
   /** Add .withType("long") for IntegerType/LongType partition columns so Rust compares numerically. */
-  private def maybeWithType(filter: PartitionFilter, col: String, schema: StructType): PartitionFilter =
-    try {
+  private def maybeWithType(
+    filter: PartitionFilter,
+    col: String,
+    schema: StructType
+  ): PartitionFilter =
+    try
       schema(schema.fieldIndex(col)).dataType match {
         case IntegerType | LongType => filter.withType("long")
         case _                      => filter
       }
-    } catch {
+    catch {
       case _: IllegalArgumentException => filter
     }
 
   private def literalToString(value: Any): String = value match {
-    case null                                => null
+    case null                                           => null
     case utf8: org.apache.spark.unsafe.types.UTF8String => utf8.toString
-    case other                               => other.toString
+    case other                                          => other.toString
   }
 }

--- a/src/test/scala/io/indextables/spark/core/DiskCacheConfigTest.scala
+++ b/src/test/scala/io/indextables/spark/core/DiskCacheConfigTest.scala
@@ -593,11 +593,11 @@ class DiskCacheConfigTest extends AnyFunSuite with Matchers {
 
   test("ConfigUtils.createSplitCacheConfig - write queue config round-trip") {
     val configMap = Map(
-      "spark.indextables.cache.disk.enabled"              -> "true",
-      "spark.indextables.cache.disk.path"                 -> "/tmp/wq_test",
-      "spark.indextables.cache.disk.writeQueue.mode"      -> "fragment",
-      "spark.indextables.cache.disk.writeQueue.capacity"  -> "64",
-      "spark.indextables.cache.disk.dropWritesWhenFull"   -> "false"
+      "spark.indextables.cache.disk.enabled"             -> "true",
+      "spark.indextables.cache.disk.path"                -> "/tmp/wq_test",
+      "spark.indextables.cache.disk.writeQueue.mode"     -> "fragment",
+      "spark.indextables.cache.disk.writeQueue.capacity" -> "64",
+      "spark.indextables.cache.disk.dropWritesWhenFull"  -> "false"
     )
 
     val config = ConfigUtils.createSplitCacheConfig(configMap, Some("test-table"))
@@ -612,11 +612,11 @@ class DiskCacheConfigTest extends AnyFunSuite with Matchers {
 
   test("ConfigUtils.createSplitCacheConfig - size-based write queue round-trip") {
     val configMap = Map(
-      "spark.indextables.cache.disk.enabled"              -> "true",
-      "spark.indextables.cache.disk.path"                 -> "/tmp/wq_test",
-      "spark.indextables.cache.disk.writeQueue.mode"      -> "size",
-      "spark.indextables.cache.disk.writeQueue.capacity"  -> "500M",
-      "spark.indextables.cache.disk.dropWritesWhenFull"   -> "true"
+      "spark.indextables.cache.disk.enabled"             -> "true",
+      "spark.indextables.cache.disk.path"                -> "/tmp/wq_test",
+      "spark.indextables.cache.disk.writeQueue.mode"     -> "size",
+      "spark.indextables.cache.disk.writeQueue.capacity" -> "500M",
+      "spark.indextables.cache.disk.dropWritesWhenFull"  -> "true"
     )
 
     val config = ConfigUtils.createSplitCacheConfig(configMap, Some("test-table"))
@@ -659,11 +659,13 @@ class DiskCacheConfigTest extends AnyFunSuite with Matchers {
   }
 
   test("IndexTables4SparkOptions - write queue config parsing") {
-    val opts = IndexTables4SparkOptions(Map(
-      "spark.indextables.cache.disk.writeQueue.mode"     -> "fragment",
-      "spark.indextables.cache.disk.writeQueue.capacity" -> "16",
-      "spark.indextables.cache.disk.dropWritesWhenFull"  -> "false"
-    ))
+    val opts = IndexTables4SparkOptions(
+      Map(
+        "spark.indextables.cache.disk.writeQueue.mode"     -> "fragment",
+        "spark.indextables.cache.disk.writeQueue.capacity" -> "16",
+        "spark.indextables.cache.disk.dropWritesWhenFull"  -> "false"
+      )
+    )
 
     opts.diskCacheWriteQueueMode shouldBe Some("fragment")
     opts.diskCacheWriteQueueCapacity shouldBe Some("16")

--- a/src/test/scala/io/indextables/spark/sync/CloudAzureDistributedSyncTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CloudAzureDistributedSyncTest.scala
@@ -26,8 +26,8 @@ import io.indextables.spark.CloudAzureTestBase
 /**
  * Real Azure Blob Storage integration tests for the distributed log read feature of BUILD INDEXTABLES COMPANION.
  *
- * Validates that the distributed transaction log scanning (DistributedSourceScanner) works correctly
- * with real Azure paths, credentials, and Delta/Parquet data. Tests cover:
+ * Validates that the distributed transaction log scanning (DistributedSourceScanner) works correctly with real Azure
+ * paths, credentials, and Delta/Parquet data. Tests cover:
  *   - Azure credential propagation to executors via broadcast variables
  *   - Azure path normalization (wasbs:// → az:// conversion)
  *   - Distributed vs non-distributed path equivalence on real Azure storage
@@ -35,8 +35,8 @@ import io.indextables.spark.CloudAzureTestBase
  *   - Fallback behavior when distributed scan fails
  *
  * These tests require:
- *   1. Azure credentials (via ~/.azure/credentials, system properties, or environment variables)
- *   2. An Azure Blob Storage container for test data
+ *   1. Azure credentials (via ~/.azure/credentials, system properties, or environment variables) 2. An Azure Blob
+ *      Storage container for test data
  *
  * Tests are automatically skipped if credentials are not available.
  */
@@ -135,23 +135,26 @@ class CloudAzureDistributedSyncTest extends CloudAzureTestBase {
     df.repartition(3).write.format("delta").mode("overwrite").save(deltaPath)
 
     // Build with distributed enabled (default)
-    val distResult = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$distPath'"
-    ).collect()
+    val distResult = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$distPath'"
+      )
+      .collect()
 
     // Build with distributed disabled
     spark.conf.set("spark.indextables.companion.sync.distributedLogRead.enabled", "false")
     try {
-      val nonDistResult = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$nonDistPath'"
-      ).collect()
+      val nonDistResult = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$nonDistPath'"
+        )
+        .collect()
 
       distResult(0).getString(2) shouldBe "success"
       nonDistResult(0).getString(2) shouldBe "success"
       distResult(0).getInt(6) shouldBe nonDistResult(0).getInt(6)
-    } finally {
+    } finally
       spark.conf.unset("spark.indextables.companion.sync.distributedLogRead.enabled")
-    }
   }
 
   // ─── Delta: Distributed Sync on Azure ───
@@ -167,14 +170,17 @@ class CloudAzureDistributedSyncTest extends CloudAzureTestBase {
 
     val _spark = spark
     import _spark.implicits._
-    val df = (0 until 50).map(i => (i.toLong, s"name_$i", i * 1.5, i % 2 == 0))
+    val df = (0 until 50)
+      .map(i => (i.toLong, s"name_$i", i * 1.5, i % 2 == 0))
       .toDF("id", "name", "score", "active")
 
     df.repartition(5).write.format("delta").mode("overwrite").save(deltaPath)
 
-    val result = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
 
     result(0).getString(2) shouldBe "success"
     result(0).getInt(4) should be > 0
@@ -194,26 +200,38 @@ class CloudAzureDistributedSyncTest extends CloudAzureTestBase {
     import _spark.implicits._
 
     // Initial write
-    (0 until 20).map(i => (i.toLong, s"name_$i", i * 1.5))
+    (0 until 20)
+      .map(i => (i.toLong, s"name_$i", i * 1.5))
       .toDF("id", "name", "score")
       .repartition(2)
-      .write.format("delta").mode("overwrite").save(deltaPath)
+      .write
+      .format("delta")
+      .mode("overwrite")
+      .save(deltaPath)
 
-    val result1 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result1 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result1(0).getString(2) shouldBe "success"
 
     // Append more data
-    (100 until 110).map(i => (i.toLong, s"name_$i", i * 1.5))
+    (100 until 110)
+      .map(i => (i.toLong, s"name_$i", i * 1.5))
       .toDF("id", "name", "score")
       .repartition(1)
-      .write.format("delta").mode("append").save(deltaPath)
+      .write
+      .format("delta")
+      .mode("append")
+      .save(deltaPath)
 
     // Incremental sync
-    val result2 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result2 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result2(0).getString(2) shouldBe "success"
     result2(0).getInt(6) shouldBe 1
   }
@@ -239,9 +257,11 @@ class CloudAzureDistributedSyncTest extends CloudAzureTestBase {
 
     df.write.format("delta").partitionBy("region").mode("overwrite").save(deltaPath)
 
-    val result = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
 
     result(0).getString(2) shouldBe "success"
 
@@ -272,14 +292,17 @@ class CloudAzureDistributedSyncTest extends CloudAzureTestBase {
 
     val _spark = spark
     import _spark.implicits._
-    val df = (0 until 30).map(i => (i.toLong, s"name_$i", i * 1.5))
+    val df = (0 until 30)
+      .map(i => (i.toLong, s"name_$i", i * 1.5))
       .toDF("id", "name", "score")
 
     df.repartition(3).write.parquet(parquetPath)
 
-    val result = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
 
     result(0).getString(2) shouldBe "success"
     result(0).getInt(6) shouldBe 3
@@ -299,24 +322,28 @@ class CloudAzureDistributedSyncTest extends CloudAzureTestBase {
     import _spark.implicits._
     Seq((1, "hello world", 100.0), (2, "foo bar", 200.0), (3, "test data", 300.0))
       .toDF("id", "content", "score")
-      .write.parquet(parquetPath)
+      .write
+      .parquet(parquetPath)
 
-    val distResult = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$distPath'"
-    ).collect()
+    val distResult = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$distPath'"
+      )
+      .collect()
 
     spark.conf.set("spark.indextables.companion.sync.distributedLogRead.enabled", "false")
     try {
-      val nonDistResult = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$nonDistPath'"
-      ).collect()
+      val nonDistResult = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$nonDistPath'"
+        )
+        .collect()
 
       distResult(0).getString(2) shouldBe "success"
       nonDistResult(0).getString(2) shouldBe "success"
       distResult(0).getInt(6) shouldBe nonDistResult(0).getInt(6)
-    } finally {
+    } finally
       spark.conf.unset("spark.indextables.companion.sync.distributedLogRead.enabled")
-    }
   }
 
   // ─── Column Mapping: WHERE filter via distributed path on Azure ───
@@ -339,19 +366,24 @@ class CloudAzureDistributedSyncTest extends CloudAzureTestBase {
       (4L, "dave", "2026-02-08", "10"),
       (5L, "eve", "2026-02-08", "12")
     ).toDF("id", "name", "kdate", "khour")
-      .write.format("delta").partitionBy("kdate", "khour")
+      .write
+      .format("delta")
+      .partitionBy("kdate", "khour")
       .option("delta.columnMapping.mode", "name")
       .option("delta.minReaderVersion", "2")
       .option("delta.minWriterVersion", "5")
-      .mode("overwrite").save(deltaPath)
+      .mode("overwrite")
+      .save(deltaPath)
 
     // Force checkpoint so distributed path (readCheckpointPart with snapshotInfo) runs
     val deltaLog = org.apache.spark.sql.delta.DeltaLog.forTable(spark, deltaPath)
     deltaLog.checkpoint()
 
-    val result = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
-    ).collect()
+    val result = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
+      )
+      .collect()
 
     result(0).getString(2) shouldBe "success"
 
@@ -380,22 +412,30 @@ class CloudAzureDistributedSyncTest extends CloudAzureTestBase {
 
     val _spark = spark
     import _spark.implicits._
-    (0 until 20).map(i => (i.toLong, s"name_$i", i * 1.5))
+    (0 until 20)
+      .map(i => (i.toLong, s"name_$i", i * 1.5))
       .toDF("id", "name", "score")
       .repartition(2)
-      .write.format("delta").mode("overwrite").save(deltaPath)
+      .write
+      .format("delta")
+      .mode("overwrite")
+      .save(deltaPath)
 
     // First sync — should succeed
-    val result1 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result1 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result1(0).getString(2) shouldBe "success"
     result1(0).getInt(6) should be > 0
 
     // Second sync with no changes — should return no_action
-    val result2 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result2 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result2(0).getString(2) shouldBe "no_action"
     result2(0).getInt(6) shouldBe 0
   }
@@ -411,22 +451,28 @@ class CloudAzureDistributedSyncTest extends CloudAzureTestBase {
 
     val _spark = spark
     import _spark.implicits._
-    (0 until 15).map(i => (i.toLong, s"name_$i"))
+    (0 until 15)
+      .map(i => (i.toLong, s"name_$i"))
       .toDF("id", "name")
       .repartition(2)
-      .write.parquet(parquetPath)
+      .write
+      .parquet(parquetPath)
 
     // First sync — should succeed
-    val result1 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result1 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result1(0).getString(2) shouldBe "success"
     result1(0).getInt(6) should be > 0
 
     // Second sync with no changes — should return no_action
-    val result2 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result2 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result2(0).getString(2) shouldBe "no_action"
     result2(0).getInt(6) shouldBe 0
   }
@@ -444,12 +490,13 @@ class CloudAzureDistributedSyncTest extends CloudAzureTestBase {
 
     val _spark = spark
     import _spark.implicits._
-    Seq((1, "single row")).toDF("id", "content")
-      .write.format("delta").mode("overwrite").save(deltaPath)
+    Seq((1, "single row")).toDF("id", "content").write.format("delta").mode("overwrite").save(deltaPath)
 
-    val result = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
 
     result(0).getString(2) shouldBe "success"
     result(0).getInt(6) should be > 0

--- a/src/test/scala/io/indextables/spark/sync/CloudS3DistributedSyncTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CloudS3DistributedSyncTest.scala
@@ -29,8 +29,8 @@ import io.indextables.spark.CloudS3TestBase
 /**
  * Real S3 integration tests for the distributed log read feature of BUILD INDEXTABLES COMPANION.
  *
- * Validates that the distributed transaction log scanning (DistributedSourceScanner) works correctly
- * with real S3 paths, credentials, and Delta/Parquet data. Tests cover:
+ * Validates that the distributed transaction log scanning (DistributedSourceScanner) works correctly with real S3
+ * paths, credentials, and Delta/Parquet data. Tests cover:
  *   - S3 credential propagation to executors via broadcast variables
  *   - S3 path format handling (s3a:// scheme normalization)
  *   - Distributed vs non-distributed path equivalence on real cloud storage
@@ -38,8 +38,7 @@ import io.indextables.spark.CloudS3TestBase
  *   - Fallback behavior when distributed scan fails
  *
  * These tests require:
- *   1. AWS credentials in ~/.aws/credentials
- *   2. An S3 bucket for test data (configured via S3_BUCKET constant)
+ *   1. AWS credentials in ~/.aws/credentials 2. An S3 bucket for test data (configured via S3_BUCKET constant)
  *
  * Tests are automatically skipped if credentials are not available.
  */
@@ -154,23 +153,26 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
     df.repartition(3).write.format("delta").mode("overwrite").save(deltaPath)
 
     // Build with distributed enabled (default)
-    val distResult = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$distPath'"
-    ).collect()
+    val distResult = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$distPath'"
+      )
+      .collect()
 
     // Build with distributed disabled
     spark.conf.set("spark.indextables.companion.sync.distributedLogRead.enabled", "false")
     try {
-      val nonDistResult = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$nonDistPath'"
-      ).collect()
+      val nonDistResult = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$nonDistPath'"
+        )
+        .collect()
 
       distResult(0).getString(2) shouldBe "success"
       nonDistResult(0).getString(2) shouldBe "success"
       distResult(0).getInt(6) shouldBe nonDistResult(0).getInt(6) // same parquet_files_indexed
-    } finally {
+    } finally
       spark.conf.unset("spark.indextables.companion.sync.distributedLogRead.enabled")
-    }
   }
 
   // ─── Delta: Distributed Sync on S3 ───
@@ -186,14 +188,17 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
 
     val _spark = spark
     import _spark.implicits._
-    val df = (0 until 50).map(i => (i.toLong, s"name_$i", i * 1.5, i % 2 == 0))
+    val df = (0 until 50)
+      .map(i => (i.toLong, s"name_$i", i * 1.5, i % 2 == 0))
       .toDF("id", "name", "score", "active")
 
     df.repartition(5).write.format("delta").mode("overwrite").save(deltaPath)
 
-    val result = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
 
     result(0).getString(2) shouldBe "success"
     result(0).getInt(4) should be > 0 // splits_created
@@ -213,26 +218,38 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
     import _spark.implicits._
 
     // Initial write
-    (0 until 20).map(i => (i.toLong, s"name_$i", i * 1.5))
+    (0 until 20)
+      .map(i => (i.toLong, s"name_$i", i * 1.5))
       .toDF("id", "name", "score")
       .repartition(2)
-      .write.format("delta").mode("overwrite").save(deltaPath)
+      .write
+      .format("delta")
+      .mode("overwrite")
+      .save(deltaPath)
 
-    val result1 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result1 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result1(0).getString(2) shouldBe "success"
 
     // Append more data
-    (100 until 110).map(i => (i.toLong, s"name_$i", i * 1.5))
+    (100 until 110)
+      .map(i => (i.toLong, s"name_$i", i * 1.5))
       .toDF("id", "name", "score")
       .repartition(1)
-      .write.format("delta").mode("append").save(deltaPath)
+      .write
+      .format("delta")
+      .mode("append")
+      .save(deltaPath)
 
     // Incremental sync should detect the new file
-    val result2 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result2 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result2(0).getString(2) shouldBe "success"
     result2(0).getInt(6) shouldBe 1 // only the new file
   }
@@ -258,9 +275,11 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
 
     df.write.format("delta").partitionBy("region").mode("overwrite").save(deltaPath)
 
-    val result = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
 
     result(0).getString(2) shouldBe "success"
     result(0).getInt(6) should be > 0
@@ -292,14 +311,17 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
 
     val _spark = spark
     import _spark.implicits._
-    val df = (0 until 30).map(i => (i.toLong, s"name_$i", i * 1.5))
+    val df = (0 until 30)
+      .map(i => (i.toLong, s"name_$i", i * 1.5))
       .toDF("id", "name", "score")
 
     df.repartition(3).write.parquet(parquetPath)
 
-    val result = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
 
     result(0).getString(2) shouldBe "success"
     result(0).getInt(6) shouldBe 3
@@ -323,23 +345,26 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
     df.write.parquet(parquetPath)
 
     // Distributed (default)
-    val distResult = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$distPath'"
-    ).collect()
+    val distResult = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$distPath'"
+      )
+      .collect()
 
     // Non-distributed
     spark.conf.set("spark.indextables.companion.sync.distributedLogRead.enabled", "false")
     try {
-      val nonDistResult = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$nonDistPath'"
-      ).collect()
+      val nonDistResult = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$nonDistPath'"
+        )
+        .collect()
 
       distResult(0).getString(2) shouldBe "success"
       nonDistResult(0).getString(2) shouldBe "success"
       distResult(0).getInt(6) shouldBe nonDistResult(0).getInt(6)
-    } finally {
+    } finally
       spark.conf.unset("spark.indextables.companion.sync.distributedLogRead.enabled")
-    }
   }
 
   // NOTE: Partitioned Parquet companion sync on S3 has a pre-existing issue also present
@@ -363,9 +388,11 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
 
     df.write.partitionBy("date").parquet(parquetPath)
 
-    val result = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
 
     result(0).getString(2) shouldBe "success"
     result(0).getInt(6) should be > 0
@@ -395,9 +422,9 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
     files should not be empty
     // Paths should be relative (no s3a:// prefix, no bucket name)
     files.foreach { f =>
-      f.path should not startWith ("s3")
-      f.path should not startWith ("/")
-      f.path should endWith (".parquet")
+      f.path should not startWith "s3"
+      f.path should not startWith "/"
+      f.path should endWith(".parquet")
       f.size should be > 0L
     }
   }
@@ -412,10 +439,14 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
 
     val _spark = spark
     import _spark.implicits._
-    (0 until 10).map(i => (i.toLong, s"name_$i"))
+    (0 until 10)
+      .map(i => (i.toLong, s"name_$i"))
       .toDF("id", "name")
       .repartition(2)
-      .write.format("delta").mode("overwrite").save(deltaPath)
+      .write
+      .format("delta")
+      .mode("overwrite")
+      .save(deltaPath)
 
     // Force a checkpoint so the distributed scanner (which requires _last_checkpoint) can work
     val deltaLog = org.apache.spark.sql.delta.DeltaLog.forTable(spark, deltaPath)
@@ -460,19 +491,24 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
       (4L, "dave", "2026-02-08", "10"),
       (5L, "eve", "2026-02-08", "12")
     ).toDF("id", "name", "kdate", "khour")
-      .write.format("delta").partitionBy("kdate", "khour")
+      .write
+      .format("delta")
+      .partitionBy("kdate", "khour")
       .option("delta.columnMapping.mode", "name")
       .option("delta.minReaderVersion", "2")
       .option("delta.minWriterVersion", "5")
-      .mode("overwrite").save(deltaPath)
+      .mode("overwrite")
+      .save(deltaPath)
 
     // Force checkpoint so distributed path (readCheckpointPart with snapshotInfo) runs
     val deltaLog = org.apache.spark.sql.delta.DeltaLog.forTable(spark, deltaPath)
     deltaLog.checkpoint()
 
-    val result = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
-    ).collect()
+    val result = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
+      )
+      .collect()
 
     result(0).getString(2) shouldBe "success"
 
@@ -506,27 +542,34 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
       (4L, "dave", "2026-02-08", "10"),
       (5L, "eve", "2026-02-08", "12")
     ).toDF("id", "name", "kdate", "khour")
-      .write.format("delta").partitionBy("kdate", "khour")
+      .write
+      .format("delta")
+      .partitionBy("kdate", "khour")
       .option("delta.columnMapping.mode", "name")
       .option("delta.minReaderVersion", "2")
       .option("delta.minWriterVersion", "5")
-      .mode("overwrite").save(deltaPath)
+      .mode("overwrite")
+      .save(deltaPath)
 
     // Force checkpoint so distributed path runs
     val deltaLog = org.apache.spark.sql.delta.DeltaLog.forTable(spark, deltaPath)
     deltaLog.checkpoint()
 
     // First sync — should succeed
-    val result1 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
-    ).collect()
+    val result1 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result1(0).getString(2) shouldBe "success"
     result1(0).getInt(6) should be > 0
 
     // Second sync against same unchanged partition — should return no_action
-    val result2 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
-    ).collect()
+    val result2 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result2(0).getString(2) shouldBe "no_action"
     result2(0).getInt(4) shouldBe 0 // splits_created
     result2(0).getInt(6) shouldBe 0 // parquet_files_indexed
@@ -545,22 +588,30 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
 
     val _spark = spark
     import _spark.implicits._
-    (0 until 20).map(i => (i.toLong, s"name_$i", i * 1.5))
+    (0 until 20)
+      .map(i => (i.toLong, s"name_$i", i * 1.5))
       .toDF("id", "name", "score")
       .repartition(2)
-      .write.format("delta").mode("overwrite").save(deltaPath)
+      .write
+      .format("delta")
+      .mode("overwrite")
+      .save(deltaPath)
 
     // First sync — should succeed
-    val result1 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result1 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result1(0).getString(2) shouldBe "success"
     result1(0).getInt(6) should be > 0
 
     // Second sync with no changes — should return no_action
-    val result2 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result2 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result2(0).getString(2) shouldBe "no_action"
     result2(0).getInt(6) shouldBe 0 // no new files indexed
   }
@@ -573,22 +624,28 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
 
     val _spark = spark
     import _spark.implicits._
-    (0 until 15).map(i => (i.toLong, s"name_$i"))
+    (0 until 15)
+      .map(i => (i.toLong, s"name_$i"))
       .toDF("id", "name")
       .repartition(2)
-      .write.parquet(parquetPath)
+      .write
+      .parquet(parquetPath)
 
     // First sync — should succeed
-    val result1 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result1 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result1(0).getString(2) shouldBe "success"
     result1(0).getInt(6) should be > 0
 
     // Second sync with no changes — should return no_action
-    val result2 = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result2 = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
     result2(0).getString(2) shouldBe "no_action"
     result2(0).getInt(6) shouldBe 0
   }
@@ -608,13 +665,14 @@ class CloudS3DistributedSyncTest extends CloudS3TestBase {
 
     val _spark = spark
     import _spark.implicits._
-    Seq((1, "single row")).toDF("id", "content")
-      .write.format("delta").mode("overwrite").save(deltaPath)
+    Seq((1, "single row")).toDF("id", "content").write.format("delta").mode("overwrite").save(deltaPath)
 
     // This should succeed via fallback even without a checkpoint
-    val result = spark.sql(
-      s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-    ).collect()
+    val result = spark
+      .sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      .collect()
 
     result(0).getString(2) shouldBe "success"
     result(0).getInt(6) should be > 0

--- a/src/test/scala/io/indextables/spark/sync/CompanionColumnarReadTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionColumnarReadTest.scala
@@ -526,13 +526,14 @@ class CompanionColumnarReadTest extends AnyFunSuite with Matchers with BeforeAnd
       sourceById.keySet shouldBe companionById.keySet
 
       for ((id, src) <- sourceById) {
-        val comp           = companionById(id)
-        val srcContacts    = src.getAs[Seq[Row]]("contacts")
-        val compContacts   = comp.getAs[Seq[Row]]("contacts")
+        val comp         = companionById(id)
+        val srcContacts  = src.getAs[Seq[Row]]("contacts")
+        val compContacts = comp.getAs[Seq[Row]]("contacts")
         srcContacts.length shouldBe compContacts.length
-        srcContacts.zip(compContacts).foreach { case (s, c) =>
-          c.getAs[String]("name") shouldBe s.getAs[String]("name")
-          c.getAs[String]("phone") shouldBe s.getAs[String]("phone")
+        srcContacts.zip(compContacts).foreach {
+          case (s, c) =>
+            c.getAs[String]("name") shouldBe s.getAs[String]("name")
+            c.getAs[String]("phone") shouldBe s.getAs[String]("phone")
         }
       }
     }
@@ -1334,10 +1335,12 @@ class CompanionColumnarReadTest extends AnyFunSuite with Matchers with BeforeAnd
 
       val df = buildAndReadColumnar(deltaPath, indexPath)
 
-      val midYear = df.filter(
-        col("event_date") >= java.sql.Date.valueOf("2024-06-01") &&
-          col("event_date") < java.sql.Date.valueOf("2024-10-01")
-      ).collect()
+      val midYear = df
+        .filter(
+          col("event_date") >= java.sql.Date.valueOf("2024-06-01") &&
+            col("event_date") < java.sql.Date.valueOf("2024-10-01")
+        )
+        .collect()
       midYear.length shouldBe 2
       midYear.map(_.getAs[String]("name")).toSet shouldBe Set("Bob", "Charlie")
     }
@@ -1368,10 +1371,12 @@ class CompanionColumnarReadTest extends AnyFunSuite with Matchers with BeforeAnd
       afterJune.length shouldBe 3
       afterJune.map(_.getAs[String]("name")).toSet shouldBe Set("Bob", "Charlie", "Dave")
 
-      val q3q4 = df.filter(
-        col("event_date") >= java.sql.Date.valueOf("2024-07-01") &&
-          col("event_date") <= java.sql.Date.valueOf("2024-12-31")
-      ).collect()
+      val q3q4 = df
+        .filter(
+          col("event_date") >= java.sql.Date.valueOf("2024-07-01") &&
+            col("event_date") <= java.sql.Date.valueOf("2024-12-31")
+        )
+        .collect()
       q3q4.length shouldBe 2
       q3q4.map(_.getAs[String]("name")).toSet shouldBe Set("Charlie", "Dave")
     }
@@ -1423,10 +1428,12 @@ class CompanionColumnarReadTest extends AnyFunSuite with Matchers with BeforeAnd
 
       val df = buildAndReadColumnar(deltaPath, indexPath)
 
-      val midYear = df.filter(
-        col("created_at") >= java.sql.Timestamp.valueOf("2024-06-01 00:00:00") &&
-          col("created_at") < java.sql.Timestamp.valueOf("2024-10-01 00:00:00")
-      ).collect()
+      val midYear = df
+        .filter(
+          col("created_at") >= java.sql.Timestamp.valueOf("2024-06-01 00:00:00") &&
+            col("created_at") < java.sql.Timestamp.valueOf("2024-10-01 00:00:00")
+        )
+        .collect()
       midYear.length shouldBe 2
       midYear.map(_.getAs[String]("name")).toSet shouldBe Set("Bob", "Charlie")
     }

--- a/src/test/scala/io/indextables/spark/sync/CompanionSplitTypeComprehensiveTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionSplitTypeComprehensiveTest.scala
@@ -1195,10 +1195,12 @@ class CompanionSplitTypeComprehensiveTest extends AnyFunSuite with Matchers with
 
       val df = buildAndReadCompanion(deltaPath, indexPath)
 
-      val midYear = df.filter(
-        col("event_date") >= java.sql.Date.valueOf("2024-06-01") &&
-          col("event_date") < java.sql.Date.valueOf("2024-10-01")
-      ).collect()
+      val midYear = df
+        .filter(
+          col("event_date") >= java.sql.Date.valueOf("2024-06-01") &&
+            col("event_date") < java.sql.Date.valueOf("2024-10-01")
+        )
+        .collect()
       midYear.length shouldBe 2
       midYear.map(_.getAs[String]("name")).toSet shouldBe Set("Bob", "Charlie")
     }
@@ -1250,10 +1252,12 @@ class CompanionSplitTypeComprehensiveTest extends AnyFunSuite with Matchers with
 
       val df = buildAndReadCompanion(deltaPath, indexPath)
 
-      val midYear = df.filter(
-        col("created_at") >= java.sql.Timestamp.valueOf("2024-06-01 00:00:00") &&
-          col("created_at") < java.sql.Timestamp.valueOf("2024-10-01 00:00:00")
-      ).collect()
+      val midYear = df
+        .filter(
+          col("created_at") >= java.sql.Timestamp.valueOf("2024-06-01 00:00:00") &&
+            col("created_at") < java.sql.Timestamp.valueOf("2024-10-01 00:00:00")
+        )
+        .collect()
       midYear.length shouldBe 2
       midYear.map(_.getAs[String]("name")).toSet shouldBe Set("Bob", "Charlie")
     }
@@ -1286,10 +1290,12 @@ class CompanionSplitTypeComprehensiveTest extends AnyFunSuite with Matchers with
       afterJune.map(_.getAs[String]("name")).toSet shouldBe Set("Bob", "Charlie", "Dave")
 
       // Between on partition column
-      val q3q4 = df.filter(
-        col("event_date") >= java.sql.Date.valueOf("2024-07-01") &&
-          col("event_date") <= java.sql.Date.valueOf("2024-12-31")
-      ).collect()
+      val q3q4 = df
+        .filter(
+          col("event_date") >= java.sql.Date.valueOf("2024-07-01") &&
+            col("event_date") <= java.sql.Date.valueOf("2024-12-31")
+        )
+        .collect()
       q3q4.length shouldBe 2
       q3q4.map(_.getAs[String]("name")).toSet shouldBe Set("Charlie", "Dave")
     }

--- a/src/test/scala/io/indextables/spark/sync/DistributedAntiJoinTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/DistributedAntiJoinTest.scala
@@ -27,8 +27,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 
 /**
- * Tests for DistributedAntiJoin — verifies distributed anti-join logic for initial sync,
- * incremental sync, invalidation, and remaining-from-invalidated.
+ * Tests for DistributedAntiJoin — verifies distributed anti-join logic for initial sync, incremental sync,
+ * invalidation, and remaining-from-invalidated.
  */
 class DistributedAntiJoinTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
 
@@ -57,7 +57,11 @@ class DistributedAntiJoinTest extends AnyFunSuite with Matchers with BeforeAndAf
       spark.stop()
     }
 
-  private def makeSourceFile(path: String, size: Long = 1000L, partVals: Map[String, String] = Map.empty) =
+  private def makeSourceFile(
+    path: String,
+    size: Long = 1000L,
+    partVals: Map[String, String] = Map.empty
+  ) =
     CompanionSourceFile(path, partVals, size)
 
   private def makeAddAction(
@@ -77,7 +81,7 @@ class DistributedAntiJoinTest extends AnyFunSuite with Matchers with BeforeAndAf
   // ─── Initial Sync ───
 
   test("initial sync should return all source files") {
-    val sc          = spark.sparkContext
+    val sc = spark.sparkContext
     val sourceFiles = Seq(
       makeSourceFile("file1.parquet"),
       makeSourceFile("file2.parquet"),
@@ -95,7 +99,7 @@ class DistributedAntiJoinTest extends AnyFunSuite with Matchers with BeforeAndAf
   // ─── Incremental Sync: New Files ───
 
   test("incremental sync should detect new files") {
-    val sc          = spark.sparkContext
+    val sc = spark.sparkContext
     val sourceFiles = Seq(
       makeSourceFile("file1.parquet"),
       makeSourceFile("file2.parquet"),
@@ -116,7 +120,7 @@ class DistributedAntiJoinTest extends AnyFunSuite with Matchers with BeforeAndAf
   }
 
   test("incremental sync with no changes should return empty") {
-    val sc          = spark.sparkContext
+    val sc = spark.sparkContext
     val sourceFiles = Seq(
       makeSourceFile("file1.parquet"),
       makeSourceFile("file2.parquet")
@@ -137,7 +141,7 @@ class DistributedAntiJoinTest extends AnyFunSuite with Matchers with BeforeAndAf
   // ─── Incremental Sync: Invalidation ───
 
   test("incremental sync should detect gone files and invalidate splits") {
-    val sc          = spark.sparkContext
+    val sc = spark.sparkContext
     val sourceFiles = Seq(
       makeSourceFile("file1.parquet") // file2 is gone from source
     )
@@ -178,7 +182,7 @@ class DistributedAntiJoinTest extends AnyFunSuite with Matchers with BeforeAndAf
   }
 
   test("incremental sync should look up accurate file sizes from source") {
-    val sc          = spark.sparkContext
+    val sc = spark.sparkContext
     val sourceFiles = Seq(
       makeSourceFile("file1.parquet", size = 42000L)
     )
@@ -197,7 +201,7 @@ class DistributedAntiJoinTest extends AnyFunSuite with Matchers with BeforeAndAf
   // ─── Deduplication ───
 
   test("should dedup files by path, preferring largest size") {
-    val sc          = spark.sparkContext
+    val sc = spark.sparkContext
     val sourceFiles = Seq(
       makeSourceFile("new_file.parquet", size = 5000L),
       makeSourceFile("file1.parquet", size = 10000L) // also in source, still valid
@@ -223,7 +227,7 @@ class DistributedAntiJoinTest extends AnyFunSuite with Matchers with BeforeAndAf
   // ─── URL-encoded paths ───
 
   test("should handle URL-encoded paths in anti-join") {
-    val sc          = spark.sparkContext
+    val sc = spark.sparkContext
     val sourceFiles = Seq(
       makeSourceFile("path%20with%20spaces/file1.parquet"),
       makeSourceFile("normal/file2.parquet") // new
@@ -245,7 +249,7 @@ class DistributedAntiJoinTest extends AnyFunSuite with Matchers with BeforeAndAf
   // ─── Multiple splits ───
 
   test("should handle multiple companion splits correctly") {
-    val sc          = spark.sparkContext
+    val sc = spark.sparkContext
     val sourceFiles = Seq(
       makeSourceFile("file1.parquet"),
       makeSourceFile("file2.parquet"),

--- a/src/test/scala/io/indextables/spark/sync/DistributedDeltaSyncIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/DistributedDeltaSyncIntegrationTest.scala
@@ -20,21 +20,21 @@ package io.indextables.spark.sync
 import java.io.File
 import java.nio.file.Files
 
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.SparkSession
 
 import org.apache.hadoop.fs.Path
 
 import io.indextables.spark.transaction.TransactionLogFactory
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 
-import scala.jdk.CollectionConverters._
-
 /**
- * End-to-end integration tests for distributed log read in BUILD INDEXTABLES COMPANION.
- * Tests the full pipeline with distributed enabled vs disabled, verifying identical results.
+ * End-to-end integration tests for distributed log read in BUILD INDEXTABLES COMPANION. Tests the full pipeline with
+ * distributed enabled vs disabled, verifying identical results.
  */
 class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
 
@@ -130,9 +130,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createDeltaTable(deltaPath, numFiles = 1, rowsPerFile = 10)
 
-      spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-      ).collect()
+      spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       val txLog = TransactionLogFactory.create(
         new Path(indexPath),
@@ -164,9 +166,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       // Initial write: 2 files
       createDeltaTable(deltaPath, numFiles = 2, rowsPerFile = 10)
-      val result1 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-      ).collect()
+      val result1 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+        )
+        .collect()
       result1(0).getString(2) shouldBe "success"
       val initialFiles = result1(0).getInt(6) // parquet_files_indexed
 
@@ -183,9 +187,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
         .save(deltaPath)
 
       // Incremental sync: should detect the new file
-      val result2 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-      ).collect()
+      val result2 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result2(0).getString(2) shouldBe "success"
       result2(0).getInt(6) shouldBe 1 // only the new file
@@ -199,13 +205,17 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createDeltaTable(deltaPath, numFiles = 1, rowsPerFile = 10)
 
-      spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-      ).collect()
+      spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
-      val result2 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-      ).collect()
+      val result2 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+        )
+        .collect()
       result2(0).getString(2) shouldBe "no_action"
     }
   }
@@ -222,15 +232,16 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       // Disable distributed log read
       spark.conf.set("spark.indextables.companion.sync.distributedLogRead.enabled", "false")
       try {
-        val result = spark.sql(
-          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-        ).collect()
+        val result = spark
+          .sql(
+            s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+          )
+          .collect()
 
         result(0).getString(2) shouldBe "success"
         result(0).getInt(6) shouldBe 2
-      } finally {
+      } finally
         spark.conf.unset("spark.indextables.companion.sync.distributedLogRead.enabled")
-      }
     }
   }
 
@@ -238,31 +249,34 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
   test("distributed and non-distributed paths should produce identical companion indexes") {
     withTempPath { tempDir =>
-      val deltaPath    = new File(tempDir, "delta_compare").getAbsolutePath
-      val distPath     = new File(tempDir, "companion_dist").getAbsolutePath
-      val nonDistPath  = new File(tempDir, "companion_nondist").getAbsolutePath
+      val deltaPath   = new File(tempDir, "delta_compare").getAbsolutePath
+      val distPath    = new File(tempDir, "companion_dist").getAbsolutePath
+      val nonDistPath = new File(tempDir, "companion_nondist").getAbsolutePath
 
       createDeltaTable(deltaPath, numFiles = 3, rowsPerFile = 10)
 
       // Build with distributed enabled (default)
-      val distResult = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$distPath'"
-      ).collect()
+      val distResult = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$distPath'"
+        )
+        .collect()
 
       // Build with distributed disabled
       spark.conf.set("spark.indextables.companion.sync.distributedLogRead.enabled", "false")
       try {
-        val nonDistResult = spark.sql(
-          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$nonDistPath'"
-        ).collect()
+        val nonDistResult = spark
+          .sql(
+            s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$nonDistPath'"
+          )
+          .collect()
 
         // Both should succeed with same file count
         distResult(0).getString(2) shouldBe "success"
         nonDistResult(0).getString(2) shouldBe "success"
         distResult(0).getInt(6) shouldBe nonDistResult(0).getInt(6) // same parquet_files_indexed
-      } finally {
+      } finally
         spark.conf.unset("spark.indextables.companion.sync.distributedLogRead.enabled")
-      }
     }
   }
 
@@ -275,9 +289,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createParquetData(parquetPath, numFiles = 2)
 
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       result(0).getInt(6) shouldBe 2
@@ -295,9 +311,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       createPartitionedDeltaTable(deltaPath, Seq("2024-01-01", "2024-02-01", "2024-03-01"))
 
       // Initial sync (all partitions)
-      val result1 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-      ).collect()
+      val result1 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+        )
+        .collect()
       result1(0).getString(2) shouldBe "success"
 
       // Verify all partitions are indexed
@@ -317,9 +335,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       createPartitionedDeltaTable(deltaPath, Seq("2024-02-01", "2024-03-01"))
 
       // Incremental sync with WHERE date >= '2024-02-01' (default: scoped invalidation)
-      val result2 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date >= '2024-02-01' AT LOCATION '$indexPath'"
-      ).collect()
+      val result2 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date >= '2024-02-01' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       // Verify: splits for date=2024-01-01 should NOT be invalidated
       val txLog2 = TransactionLogFactory.create(
@@ -348,9 +368,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       createPartitionedDeltaTable(deltaPath, Seq("2024-01-01", "2024-02-01", "2024-03-01"))
 
       // Initial sync (all partitions)
-      val result1 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-      ).collect()
+      val result1 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+        )
+        .collect()
       result1(0).getString(2) shouldBe "success"
 
       // Delete source files for date=2024-01-01 and recreate without that partition
@@ -358,9 +380,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       createPartitionedDeltaTable(deltaPath, Seq("2024-02-01", "2024-03-01"))
 
       // Incremental sync with WHERE + INVALIDATE ALL PARTITIONS
-      val result2 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date >= '2024-02-01' INVALIDATE ALL PARTITIONS AT LOCATION '$indexPath'"
-      ).collect()
+      val result2 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date >= '2024-02-01' INVALIDATE ALL PARTITIONS AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       // Verify: splits for date=2024-01-01 SHOULD be invalidated
       val txLog = TransactionLogFactory.create(
@@ -372,7 +396,7 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       )
       try {
         val remainingFiles = txLog.listFiles()
-        val jan01Splits = remainingFiles.filter(_.partitionValues.get("date").contains("2024-01-01"))
+        val jan01Splits    = remainingFiles.filter(_.partitionValues.get("date").contains("2024-01-01"))
         jan01Splits shouldBe empty
       } finally
         txLog.close()
@@ -388,9 +412,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       createPartitionedDeltaTable(deltaPath, Seq("2024-01-01", "2024-02-01", "2024-03-01"))
 
       // Initial sync (all partitions)
-      val result1 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-      ).collect()
+      val result1 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+        )
+        .collect()
       result1(0).getString(2) shouldBe "success"
 
       // Delete source files for date=2024-02-01 (within WHERE range) and recreate without it
@@ -398,9 +424,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       createPartitionedDeltaTable(deltaPath, Seq("2024-01-01", "2024-03-01"))
 
       // Incremental sync with WHERE date >= '2024-02-01' (scoped invalidation)
-      val result2 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date >= '2024-02-01' AT LOCATION '$indexPath'"
-      ).collect()
+      val result2 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date >= '2024-02-01' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       // Verify: splits for date=2024-02-01 SHOULD be invalidated (within scope)
       // Verify: splits for date=2024-01-01 should NOT be invalidated (outside scope)
@@ -413,7 +441,7 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       )
       try {
         val remainingFiles = txLog.listFiles()
-        val feb01Splits = remainingFiles.filter(_.partitionValues.get("date").contains("2024-02-01"))
+        val feb01Splits    = remainingFiles.filter(_.partitionValues.get("date").contains("2024-02-01"))
         feb01Splits shouldBe empty // invalidated (within WHERE scope)
 
         val jan01Splits = remainingFiles.filter(_.partitionValues.get("date").contains("2024-01-01"))
@@ -432,21 +460,23 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createPartitionedDeltaTable(deltaPath, Seq("2024-01-01", "2024-02-01", "2024-03-01"))
 
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date = '2024-02-01' AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date = '2024-02-01' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       // Only files from the date=2024-02-01 partition should be indexed
       val txLog = TransactionLogFactory.create(
-        new Path(indexPath), spark,
-        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava))
+        new Path(indexPath),
+        spark,
+        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava)
+      )
       try {
         val files = txLog.listFiles()
         files should not be empty
-        files.foreach { f =>
-          f.partitionValues.get("date") shouldBe Some("2024-02-01")
-        }
+        files.foreach(f => f.partitionValues.get("date") shouldBe Some("2024-02-01"))
       } finally txLog.close()
     }
   }
@@ -458,14 +488,18 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createPartitionedDeltaTable(deltaPath, Seq("2024-01-01", "2024-02-01", "2024-03-01"))
 
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date IN ('2024-01-01', '2024-03-01') AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date IN ('2024-01-01', '2024-03-01') AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       val txLog = TransactionLogFactory.create(
-        new Path(indexPath), spark,
-        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava))
+        new Path(indexPath),
+        spark,
+        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava)
+      )
       try {
         val files    = txLog.listFiles()
         val dateVals = files.flatMap(_.partitionValues.get("date")).toSet
@@ -483,19 +517,23 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createMultiPartDeltaTable(deltaPath)
 
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE year >= 2024 AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE year >= 2024 AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       val txLog = TransactionLogFactory.create(
-        new Path(indexPath), spark,
-        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava))
+        new Path(indexPath),
+        spark,
+        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava)
+      )
       try {
-        val files     = txLog.listFiles()
-        val yearVals  = files.flatMap(_.partitionValues.get("year")).map(_.toInt).toSet
+        val files    = txLog.listFiles()
+        val yearVals = files.flatMap(_.partitionValues.get("year")).map(_.toInt).toSet
         yearVals.foreach(_ should be >= 2024)
-        yearVals should not contain 2023  // assert exclusion
+        yearVals should not contain 2023 // assert exclusion
       } finally txLog.close()
     }
   }
@@ -507,14 +545,18 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createMultiPartDeltaTable(deltaPath)
 
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE year = 2024 AND region = 'east' AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE year = 2024 AND region = 'east' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       val txLog = TransactionLogFactory.create(
-        new Path(indexPath), spark,
-        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava))
+        new Path(indexPath),
+        spark,
+        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava)
+      )
       try {
         val files = txLog.listFiles()
         files should not be empty
@@ -533,14 +575,18 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createPartitionedDeltaTable(deltaPath, Seq("2024-01-01", "2024-02-01", "2024-03-01"))
 
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date = '2024-01-01' OR date = '2024-03-01' AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date = '2024-01-01' OR date = '2024-03-01' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       val txLog = TransactionLogFactory.create(
-        new Path(indexPath), spark,
-        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava))
+        new Path(indexPath),
+        spark,
+        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava)
+      )
       try {
         val dateVals = txLog.listFiles().flatMap(_.partitionValues.get("date")).toSet
         dateVals should contain("2024-01-01")
@@ -557,19 +603,23 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createMultiPartDeltaTable(deltaPath)
 
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE year > 2023 AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE year > 2023 AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       val txLog = TransactionLogFactory.create(
-        new Path(indexPath), spark,
-        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava))
+        new Path(indexPath),
+        spark,
+        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava)
+      )
       try {
         val files    = txLog.listFiles()
         val yearVals = files.flatMap(_.partitionValues.get("year")).map(_.toInt).toSet
         yearVals.foreach(_ should be > 2023)
-        yearVals should not contain 2023  // strictly excluded
+        yearVals should not contain 2023 // strictly excluded
         yearVals should contain(2024)
         yearVals should contain(2025)
       } finally txLog.close()
@@ -583,14 +633,18 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createMultiPartDeltaTable(deltaPath)
 
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE year >= 2024 AND year <= 2024 AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE year >= 2024 AND year <= 2024 AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       val txLog = TransactionLogFactory.create(
-        new Path(indexPath), spark,
-        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava))
+        new Path(indexPath),
+        spark,
+        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava)
+      )
       try {
         val files    = txLog.listFiles()
         val yearVals = files.flatMap(_.partitionValues.get("year")).map(_.toInt).toSet
@@ -606,14 +660,18 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createDatePartitionedDeltaTable(deltaPath)
 
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE dt >= '2025-01-01' AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE dt >= '2025-01-01' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       val txLog = TransactionLogFactory.create(
-        new Path(indexPath), spark,
-        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava))
+        new Path(indexPath),
+        spark,
+        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava)
+      )
       try {
         val files  = txLog.listFiles()
         val dtVals = files.flatMap(_.partitionValues.get("dt")).toSet
@@ -631,14 +689,18 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
       createPartitionedDeltaTable(deltaPath, Seq("2024-01-01", "2024-02-01", "2024-03-01"))
 
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date != '2024-02-01' AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date != '2024-02-01' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       val txLog = TransactionLogFactory.create(
-        new Path(indexPath), spark,
-        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava))
+        new Path(indexPath),
+        spark,
+        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava)
+      )
       try {
         val dateVals = txLog.listFiles().flatMap(_.partitionValues.get("date")).toSet
         dateVals should contain("2024-01-01")
@@ -652,31 +714,34 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
   test("Arrow FFI disabled should produce same results as Arrow FFI enabled") {
     withTempPath { tempDir =>
-      val deltaPath    = new File(tempDir, "delta_ffi_compare").getAbsolutePath
-      val ffiPath      = new File(tempDir, "companion_ffi").getAbsolutePath
-      val tantPath     = new File(tempDir, "companion_tant").getAbsolutePath
+      val deltaPath = new File(tempDir, "delta_ffi_compare").getAbsolutePath
+      val ffiPath   = new File(tempDir, "companion_ffi").getAbsolutePath
+      val tantPath  = new File(tempDir, "companion_tant").getAbsolutePath
 
       createPartitionedDeltaTable(deltaPath, Seq("2024-01-01", "2024-02-01", "2024-03-01"))
 
       // Build with Arrow FFI enabled (default)
-      val ffiResult = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date >= '2024-02-01' AT LOCATION '$ffiPath'"
-      ).collect()
+      val ffiResult = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date >= '2024-02-01' AT LOCATION '$ffiPath'"
+        )
+        .collect()
 
       // Build with Arrow FFI disabled
       spark.conf.set("spark.indextables.companion.sync.arrowFfi.enabled", "false")
       try {
-        val tantResult = spark.sql(
-          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date >= '2024-02-01' AT LOCATION '$tantPath'"
-        ).collect()
+        val tantResult = spark
+          .sql(
+            s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE date >= '2024-02-01' AT LOCATION '$tantPath'"
+          )
+          .collect()
 
         // Both should succeed with same file count
         ffiResult(0).getString(2) shouldBe "success"
         tantResult(0).getString(2) shouldBe "success"
         ffiResult(0).getInt(6) shouldBe tantResult(0).getInt(6) // same parquet_files_indexed
-      } finally {
+      } finally
         spark.conf.unset("spark.indextables.companion.sync.arrowFfi.enabled")
-      }
     }
   }
 
@@ -690,14 +755,18 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       createColumnMappingDeltaTable(deltaPath)
 
       // WHERE on both string partition columns
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       val txLog = TransactionLogFactory.create(
-        new Path(indexPath), spark,
-        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava))
+        new Path(indexPath),
+        spark,
+        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava)
+      )
       try {
         val files = txLog.listFiles()
         files should not be empty
@@ -717,9 +786,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       createColumnMappingDeltaTable(deltaPath)
 
       // No WHERE filter — should index all files
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       result(0).getInt(6) should be >= 4 // at least 4 partition combos
@@ -734,16 +805,20 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       createColumnMappingDeltaTable(deltaPath)
 
       // Initial sync
-      val result1 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
-      ).collect()
+      val result1 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
+        )
+        .collect()
       result1(0).getString(2) shouldBe "success"
       result1(0).getInt(6) should be > 0
 
       // Re-sync: no changes, should return no_action
-      val result2 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
-      ).collect()
+      val result2 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
+        )
+        .collect()
       result2(0).getString(2) shouldBe "no_action"
       result2(0).getInt(4) shouldBe 0 // splits_created
     }
@@ -751,30 +826,33 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
 
   test("column mapping table distributed vs non-distributed should produce same results") {
     withTempPath { tempDir =>
-      val deltaPath    = new File(tempDir, "delta_colmap_cmp").getAbsolutePath
-      val distPath     = new File(tempDir, "companion_colmap_dist").getAbsolutePath
-      val nonDistPath  = new File(tempDir, "companion_colmap_nondist").getAbsolutePath
+      val deltaPath   = new File(tempDir, "delta_colmap_cmp").getAbsolutePath
+      val distPath    = new File(tempDir, "companion_colmap_dist").getAbsolutePath
+      val nonDistPath = new File(tempDir, "companion_colmap_nondist").getAbsolutePath
 
       createColumnMappingDeltaTable(deltaPath)
 
       // Build with distributed enabled (default)
-      val distResult = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AT LOCATION '$distPath'"
-      ).collect()
+      val distResult = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AT LOCATION '$distPath'"
+        )
+        .collect()
 
       // Build with distributed disabled
       spark.conf.set("spark.indextables.companion.sync.distributedLogRead.enabled", "false")
       try {
-        val nonDistResult = spark.sql(
-          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AT LOCATION '$nonDistPath'"
-        ).collect()
+        val nonDistResult = spark
+          .sql(
+            s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AT LOCATION '$nonDistPath'"
+          )
+          .collect()
 
         distResult(0).getString(2) shouldBe "success"
         nonDistResult(0).getString(2) shouldBe "success"
         distResult(0).getInt(6) shouldBe nonDistResult(0).getInt(6)
-      } finally {
+      } finally
         spark.conf.unset("spark.indextables.companion.sync.distributedLogRead.enabled")
-      }
     }
   }
 
@@ -789,14 +867,18 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       val deltaLog = org.apache.spark.sql.delta.DeltaLog.forTable(spark, deltaPath)
       deltaLog.checkpoint()
 
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
+        )
+        .collect()
 
       result(0).getString(2) shouldBe "success"
       val txLog = TransactionLogFactory.create(
-        new Path(indexPath), spark,
-        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava))
+        new Path(indexPath),
+        spark,
+        new CaseInsensitiveStringMap(Map("spark.indextables.transaction.allowDirectUsage" -> "true").asJava)
+      )
       try {
         val files = txLog.listFiles()
         files should not be empty
@@ -821,16 +903,20 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       deltaLog.checkpoint()
 
       // First sync — should succeed
-      val result1 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
-      ).collect()
+      val result1 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
+        )
+        .collect()
       result1(0).getString(2) shouldBe "success"
       result1(0).getInt(6) should be > 0
 
       // Second sync against same unchanged partition — should return no_action
-      val result2 = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
-      ).collect()
+      val result2 = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WHERE kdate = '2026-02-07' AND khour = '12' AT LOCATION '$indexPath'"
+        )
+        .collect()
       result2(0).getString(2) shouldBe "no_action"
       result2(0).getInt(4) shouldBe 0 // splits_created
       result2(0).getInt(6) shouldBe 0 // parquet_files_indexed
@@ -863,9 +949,7 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
   private def createPartitionedDeltaTable(path: String, dates: Seq[String]): Unit = {
     val ss = spark
     import ss.implicits._
-    val data = dates.flatMap { date =>
-      (0 until 5).map(i => (i.toLong, s"name_$i", date))
-    }
+    val data = dates.flatMap(date => (0 until 5).map(i => (i.toLong, s"name_$i", date)))
     data
       .toDF("id", "name", "date")
       .repartition(dates.size)
@@ -911,7 +995,11 @@ class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with
       .save(path)
   }
 
-  private def createDeltaTable(path: String, numFiles: Int, rowsPerFile: Int): Unit = {
+  private def createDeltaTable(
+    path: String,
+    numFiles: Int,
+    rowsPerFile: Int
+  ): Unit = {
     val ss = spark
     import ss.implicits._
     val data = (0 until numFiles * rowsPerFile).map(i => (i.toLong, s"name_$i", i * 1.5, i % 2 == 0))

--- a/src/test/scala/io/indextables/spark/sync/DistributedSourceScannerTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/DistributedSourceScannerTest.scala
@@ -27,8 +27,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 
 /**
- * Tests for DistributedSourceScanner — verifies that distributed Delta and Parquet scans
- * produce the same file set as the existing single-call readers.
+ * Tests for DistributedSourceScanner — verifies that distributed Delta and Parquet scans produce the same file set as
+ * the existing single-call readers.
  */
 class DistributedSourceScannerTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
 
@@ -110,12 +110,12 @@ class DistributedSourceScannerTest extends AnyFunSuite with Matchers with Before
       val deltaPath = new File(tempDir, "delta_paths").getAbsolutePath
       createDeltaTable(deltaPath, numFiles = 2, rowsPerFile = 5)
 
-      val reader         = new DeltaLogReader(deltaPath, emptyCredentials)
-      val singlePaths    = reader.getAllFiles().map(_.path).toSet
+      val reader      = new DeltaLogReader(deltaPath, emptyCredentials)
+      val singlePaths = reader.getAllFiles().map(_.path).toSet
 
-      val scanner        = new DistributedSourceScanner(spark)
-      val distResult     = scanner.scanDeltaTable(deltaPath, emptyCredentials)
-      val distPaths      = distResult.filesRDD.map(_.path).collect().toSet
+      val scanner    = new DistributedSourceScanner(spark)
+      val distResult = scanner.scanDeltaTable(deltaPath, emptyCredentials)
+      val distPaths  = distResult.filesRDD.map(_.path).collect().toSet
 
       distPaths shouldBe singlePaths
     }
@@ -126,7 +126,7 @@ class DistributedSourceScannerTest extends AnyFunSuite with Matchers with Before
       val deltaPath = new File(tempDir, "delta_version").getAbsolutePath
       createDeltaTable(deltaPath, numFiles = 1, rowsPerFile = 5)
 
-      val reader      = new DeltaLogReader(deltaPath, emptyCredentials)
+      val reader        = new DeltaLogReader(deltaPath, emptyCredentials)
       val readerVersion = reader.currentVersion()
 
       val scanner    = new DistributedSourceScanner(spark)
@@ -160,7 +160,7 @@ class DistributedSourceScannerTest extends AnyFunSuite with Matchers with Before
       val reader      = new DeltaLogReader(deltaPath, emptyCredentials)
       val singleFiles = reader.getAllFiles()
 
-      val scanner   = new DistributedSourceScanner(spark)
+      val scanner    = new DistributedSourceScanner(spark)
       val distResult = scanner.scanDeltaTable(deltaPath, emptyCredentials)
       val distFiles  = distResult.filesRDD.collect().toSeq
 
@@ -226,12 +226,12 @@ class DistributedSourceScannerTest extends AnyFunSuite with Matchers with Before
       val deltaPath = new File(tempDir, "delta_nofilter").getAbsolutePath
       createDeltaTable(deltaPath, numFiles = 2, rowsPerFile = 10)
 
-      val scanner      = new DistributedSourceScanner(spark)
+      val scanner        = new DistributedSourceScanner(spark)
       val resultNoFilter = scanner.scanDeltaTable(deltaPath, emptyCredentials, partitionFilter = None)
       val filesNoFilter  = resultNoFilter.filesRDD.collect().toSeq
 
-      val resultDefault  = scanner.scanDeltaTable(deltaPath, emptyCredentials)
-      val filesDefault   = resultDefault.filesRDD.collect().toSeq
+      val resultDefault = scanner.scanDeltaTable(deltaPath, emptyCredentials)
+      val filesDefault  = resultDefault.filesRDD.collect().toSeq
 
       filesNoFilter.size shouldBe filesDefault.size
       filesNoFilter.map(_.path).toSet shouldBe filesDefault.map(_.path).toSet
@@ -268,7 +268,11 @@ class DistributedSourceScannerTest extends AnyFunSuite with Matchers with Before
 
   // ─── Helpers ───
 
-  private def createDeltaTable(path: String, numFiles: Int, rowsPerFile: Int): Unit = {
+  private def createDeltaTable(
+    path: String,
+    numFiles: Int,
+    rowsPerFile: Int
+  ): Unit = {
     val ss = spark
     import ss.implicits._
     val data = (0 until numFiles * rowsPerFile).map(i => (i.toLong, s"name_$i", i * 1.5, i % 2 == 0))

--- a/src/test/scala/io/indextables/spark/sync/SparkPredicateToPartitionFilterTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/SparkPredicateToPartitionFilterTest.scala
@@ -19,8 +19,8 @@ package io.indextables.spark.sync
 
 import java.nio.file.Files
 
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
+import org.apache.spark.sql.SparkSession
 
 import io.indextables.tantivy4java.filter.PartitionFilter
 import org.scalatest.funsuite.AnyFunSuite
@@ -28,8 +28,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 
 /**
- * Unit tests for SparkPredicateToPartitionFilter — verifies conversion of Spark SQL WHERE
- * predicate strings into tantivy4java PartitionFilter objects.
+ * Unit tests for SparkPredicateToPartitionFilter — verifies conversion of Spark SQL WHERE predicate strings into
+ * tantivy4java PartitionFilter objects.
  */
 class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with BeforeAndAfterAll {
 
@@ -55,36 +55,44 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
     if (spark != null) spark.stop()
 
   private val stringPartCols = Seq("date", "region")
-  private val stringSchema = StructType(Seq(
-    StructField("id", LongType),
-    StructField("date", StringType),
-    StructField("region", StringType)
-  ))
+  private val stringSchema = StructType(
+    Seq(
+      StructField("id", LongType),
+      StructField("date", StringType),
+      StructField("region", StringType)
+    )
+  )
 
   private val intPartCols = Seq("year", "month")
-  private val intSchema = StructType(Seq(
-    StructField("id", LongType),
-    StructField("year", IntegerType),
-    StructField("month", IntegerType)
-  ))
+  private val intSchema = StructType(
+    Seq(
+      StructField("id", LongType),
+      StructField("year", IntegerType),
+      StructField("month", IntegerType)
+    )
+  )
 
   private val longPartCols = Seq("event_ts")
-  private val longSchema = StructType(Seq(
-    StructField("id", LongType),
-    StructField("event_ts", LongType)
-  ))
+  private val longSchema = StructType(
+    Seq(
+      StructField("id", LongType),
+      StructField("event_ts", LongType)
+    )
+  )
 
   private val datePartCols = Seq("dt")
-  private val dateSchema = StructType(Seq(
-    StructField("id", LongType),
-    StructField("dt", DateType)
-  ))
+  private val dateSchema = StructType(
+    Seq(
+      StructField("id", LongType),
+      StructField("dt", DateType)
+    )
+  )
 
   // ─── Basic Equality ───
 
   test("simple equality on string partition column") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("date = '2024-01-01'"), stringPartCols, spark, Some(stringSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("date = '2024-01-01'"), stringPartCols, spark, Some(stringSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"eq\"")
@@ -93,8 +101,8 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   }
 
   test("equality with reversed operands") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("'us-east' = region"), stringPartCols, spark, Some(stringSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("'us-east' = region"), stringPartCols, spark, Some(stringSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"column\":\"region\"")
@@ -104,8 +112,7 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   // ─── Range Comparisons ───
 
   test("greater than on integer partition column should include withType long") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("year > 2024"), intPartCols, spark, Some(intSchema))
+    val result = SparkPredicateToPartitionFilter.convert(Seq("year > 2024"), intPartCols, spark, Some(intSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"gt\"")
@@ -114,37 +121,33 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   }
 
   test("greater than or equal") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("year >= 2024"), intPartCols, spark, Some(intSchema))
+    val result = SparkPredicateToPartitionFilter.convert(Seq("year >= 2024"), intPartCols, spark, Some(intSchema))
     result shouldBe defined
     result.get.toJson should include("\"op\":\"gte\"")
   }
 
   test("less than") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("year < 2025"), intPartCols, spark, Some(intSchema))
+    val result = SparkPredicateToPartitionFilter.convert(Seq("year < 2025"), intPartCols, spark, Some(intSchema))
     result shouldBe defined
     result.get.toJson should include("\"op\":\"lt\"")
   }
 
   test("less than or equal") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("year <= 2025"), intPartCols, spark, Some(intSchema))
+    val result = SparkPredicateToPartitionFilter.convert(Seq("year <= 2025"), intPartCols, spark, Some(intSchema))
     result shouldBe defined
     result.get.toJson should include("\"op\":\"lte\"")
   }
 
   test("reversed comparison: literal > column → lt on column") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("2025 > year"), intPartCols, spark, Some(intSchema))
+    val result = SparkPredicateToPartitionFilter.convert(Seq("2025 > year"), intPartCols, spark, Some(intSchema))
     result shouldBe defined
     result.get.toJson should include("\"op\":\"lt\"")
     result.get.toJson should include("\"column\":\"year\"")
   }
 
   test("range on string partition column should NOT include withType") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("date >= '2024-01-01'"), stringPartCols, spark, Some(stringSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("date >= '2024-01-01'"), stringPartCols, spark, Some(stringSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"gte\"")
@@ -155,7 +158,11 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
 
   test("IN with multiple values") {
     val result = SparkPredicateToPartitionFilter.convert(
-      Seq("region IN ('us-east', 'us-west', 'eu-west')"), stringPartCols, spark, Some(stringSchema))
+      Seq("region IN ('us-east', 'us-west', 'eu-west')"),
+      stringPartCols,
+      spark,
+      Some(stringSchema)
+    )
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"in\"")
@@ -167,15 +174,15 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   // ─── IS NULL / IS NOT NULL ───
 
   test("IS NULL") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("region IS NULL"), stringPartCols, spark, Some(stringSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("region IS NULL"), stringPartCols, spark, Some(stringSchema))
     result shouldBe defined
     result.get.toJson should include("\"op\":\"is_null\"")
   }
 
   test("IS NOT NULL") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("region IS NOT NULL"), stringPartCols, spark, Some(stringSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("region IS NOT NULL"), stringPartCols, spark, Some(stringSchema))
     result shouldBe defined
     result.get.toJson should include("\"op\":\"is_not_null\"")
   }
@@ -183,8 +190,8 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   // ─── Compound: AND / OR / NOT ───
 
   test("AND of two predicates") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("year >= 2024 AND month <= 6"), intPartCols, spark, Some(intSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("year >= 2024 AND month <= 6"), intPartCols, spark, Some(intSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"and\"")
@@ -192,22 +199,29 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
 
   test("OR of two predicates") {
     val result = SparkPredicateToPartitionFilter.convert(
-      Seq("region = 'us-east' OR region = 'eu-west'"), stringPartCols, spark, Some(stringSchema))
+      Seq("region = 'us-east' OR region = 'eu-west'"),
+      stringPartCols,
+      spark,
+      Some(stringSchema)
+    )
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"or\"")
   }
 
   test("NOT on non-equality expression uses general NOT handler") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("NOT (year >= 2024)"), intPartCols, spark, Some(intSchema))
+    val result = SparkPredicateToPartitionFilter.convert(Seq("NOT (year >= 2024)"), intPartCols, spark, Some(intSchema))
     result shouldBe defined
     result.get.toJson should include("\"op\":\"not\"")
   }
 
   test("multiple predicate strings are AND-combined") {
     val result = SparkPredicateToPartitionFilter.convert(
-      Seq("date = '2024-01-01'", "region = 'us-east'"), stringPartCols, spark, Some(stringSchema))
+      Seq("date = '2024-01-01'", "region = 'us-east'"),
+      stringPartCols,
+      spark,
+      Some(stringSchema)
+    )
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"and\"")
@@ -216,8 +230,8 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   // ─── Not Equal (!=) ───
 
   test("NOT equality should produce neq filter") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("NOT region = 'us-east'"), stringPartCols, spark, Some(stringSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("NOT region = 'us-east'"), stringPartCols, spark, Some(stringSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"neq\"")
@@ -227,8 +241,8 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
 
   test("!= operator should produce neq filter") {
     // Spark parses != as Not(EqualTo(...))
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("region != 'us-east'"), stringPartCols, spark, Some(stringSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("region != 'us-east'"), stringPartCols, spark, Some(stringSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"neq\"")
@@ -236,15 +250,15 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   }
 
   test("<> operator should produce neq filter") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("region <> 'us-east'"), stringPartCols, spark, Some(stringSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("region <> 'us-east'"), stringPartCols, spark, Some(stringSchema))
     result shouldBe defined
     result.get.toJson should include("\"op\":\"neq\"")
   }
 
   test("NOT equality with reversed operands") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("NOT 'us-east' = region"), stringPartCols, spark, Some(stringSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("NOT 'us-east' = region"), stringPartCols, spark, Some(stringSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"neq\"")
@@ -254,8 +268,8 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   // ─── LongType Partition Columns ───
 
   test("range on LongType partition column should include withType long") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("event_ts > 1700000000"), longPartCols, spark, Some(longSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("event_ts > 1700000000"), longPartCols, spark, Some(longSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"gt\"")
@@ -264,8 +278,8 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   }
 
   test("equality on LongType partition column") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("event_ts = 1700000000"), longPartCols, spark, Some(longSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("event_ts = 1700000000"), longPartCols, spark, Some(longSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"eq\"")
@@ -275,8 +289,7 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   // ─── DateType Partition Columns ───
 
   test("equality on DateType partition column") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("dt = '2024-01-15'"), datePartCols, spark, Some(dateSchema))
+    val result = SparkPredicateToPartitionFilter.convert(Seq("dt = '2024-01-15'"), datePartCols, spark, Some(dateSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"eq\"")
@@ -284,8 +297,8 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   }
 
   test("range on DateType partition column should not include withType long") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("dt >= '2024-01-01'"), datePartCols, spark, Some(dateSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("dt >= '2024-01-01'"), datePartCols, spark, Some(dateSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"gte\"")
@@ -296,12 +309,13 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
 
   test("equality on date-format string like '2025/01/01'") {
     val dtPartCols = Seq("dt")
-    val dtSchema = StructType(Seq(
-      StructField("id", LongType),
-      StructField("dt", StringType)
-    ))
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("dt = '2025/01/01'"), dtPartCols, spark, Some(dtSchema))
+    val dtSchema = StructType(
+      Seq(
+        StructField("id", LongType),
+        StructField("dt", StringType)
+      )
+    )
+    val result = SparkPredicateToPartitionFilter.convert(Seq("dt = '2025/01/01'"), dtPartCols, spark, Some(dtSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"eq\"")
@@ -310,24 +324,25 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
 
   test("range on date-format string like dt >= '2025/01/01'") {
     val dtPartCols = Seq("dt")
-    val dtSchema = StructType(Seq(
-      StructField("id", LongType),
-      StructField("dt", StringType)
-    ))
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("dt >= '2025/01/01'"), dtPartCols, spark, Some(dtSchema))
+    val dtSchema = StructType(
+      Seq(
+        StructField("id", LongType),
+        StructField("dt", StringType)
+      )
+    )
+    val result = SparkPredicateToPartitionFilter.convert(Seq("dt >= '2025/01/01'"), dtPartCols, spark, Some(dtSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"gte\"")
     json should include("\"value\":\"2025/01/01\"")
-    json should not include "\"type\":"  // string, not long
+    json should not include "\"type\":" // string, not long
   }
 
   // ─── BETWEEN (AND composition) ───
 
   test("BETWEEN-equivalent filter via AND should produce and(gte, lte)") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("year >= 2023 AND year <= 2025"), intPartCols, spark, Some(intSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("year >= 2023 AND year <= 2025"), intPartCols, spark, Some(intSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"and\"")
@@ -339,8 +354,8 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   }
 
   test("BETWEEN-equivalent as separate predicates") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("year >= 2023", "year <= 2025"), intPartCols, spark, Some(intSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("year >= 2023", "year <= 2025"), intPartCols, spark, Some(intSchema))
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"and\"")
@@ -351,32 +366,38 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   // ─── Graceful Degradation ───
 
   test("empty predicates returns None") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq.empty, stringPartCols, spark, Some(stringSchema))
+    val result = SparkPredicateToPartitionFilter.convert(Seq.empty, stringPartCols, spark, Some(stringSchema))
     result shouldBe None
   }
 
   test("empty partition columns returns None") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("date = '2024-01-01'"), Seq.empty, spark, Some(stringSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("date = '2024-01-01'"), Seq.empty, spark, Some(stringSchema))
     result shouldBe None
   }
 
   test("predicate on non-partition column returns None") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("id = 42"), stringPartCols, spark, Some(stringSchema))
+    val result = SparkPredicateToPartitionFilter.convert(Seq("id = 42"), stringPartCols, spark, Some(stringSchema))
     result shouldBe None
   }
 
   test("OR with one non-convertible side returns None") {
     val result = SparkPredicateToPartitionFilter.convert(
-      Seq("region = 'us-east' OR id > 10"), stringPartCols, spark, Some(stringSchema))
+      Seq("region = 'us-east' OR id > 10"),
+      stringPartCols,
+      spark,
+      Some(stringSchema)
+    )
     result shouldBe None
   }
 
   test("AND with one non-convertible side keeps the convertible part") {
     val result = SparkPredicateToPartitionFilter.convert(
-      Seq("region = 'us-east' AND id > 10"), stringPartCols, spark, Some(stringSchema))
+      Seq("region = 'us-east' AND id > 10"),
+      stringPartCols,
+      spark,
+      Some(stringSchema)
+    )
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"column\":\"region\"")
@@ -384,16 +405,15 @@ class SparkPredicateToPartitionFilterTest extends AnyFunSuite with Matchers with
   }
 
   test("unsupported expression type returns None") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("region LIKE 'us-%'"), stringPartCols, spark, Some(stringSchema))
+    val result =
+      SparkPredicateToPartitionFilter.convert(Seq("region LIKE 'us-%'"), stringPartCols, spark, Some(stringSchema))
     result shouldBe None
   }
 
   // ─── Without Schema (defaults to StringType) ───
 
   test("range on partition column without schema does not include withType") {
-    val result = SparkPredicateToPartitionFilter.convert(
-      Seq("year >= 2024"), Seq("year"), spark, None)
+    val result = SparkPredicateToPartitionFilter.convert(Seq("year >= 2024"), Seq("year"), spark, None)
     result shouldBe defined
     val json = result.get.toJson
     json should include("\"op\":\"gte\"")


### PR DESCRIPTION
## Summary

- Run `mvn spotless:apply` to fix formatting across 20 files (import ordering, line wrapping in new Arrow FFI and distributed sync code)
- Update README Maven JAR link from 0.5.1 to 0.5.3

## Test plan

- [ ] Verify `mvn spotless:check` passes
- [ ] Verify README link points to correct 0.5.3 artifact
- [ ] No functional changes — formatting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)