### PR TITLE
Add CI workflow for self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: [self-hosted, macOS, ARM64]
+    environment: self-hosted
+    env:
+      JAVA_HOME: /opt/homebrew/opt/openjdk@11
+      PATH: /opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup dependencies
+        run: ./scripts/setup.sh
+
+      - name: Build
+        run: make compile
+
+      - name: Test
+        run: make test


### PR DESCRIPTION
Runs build and test on pull requests and pushes to main using the org-level self-hosted macOS ARM64 runner with environment approval gate.