### PR TITLE
Replace PR trigger with workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build-and-test-macos:


### PR DESCRIPTION
## Summary
- Removes automatic `pull_request` trigger to avoid running on every PR
- Adds `workflow_dispatch` for on-demand runs from the Actions UI or `gh workflow run`
- CI still runs automatically on push to main

## Usage
```bash
gh workflow run ci.yml --ref <branch-name>
```