### PR TITLE
Fix Claude review workflow SDK crash

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -50,5 +50,8 @@ jobs:
             - Hypothetical future improvements unrelated to the PR
 
             Use inline comments for specific issues. Use a top-level summary for overall assessment.
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+          allowed_tools: |
+            mcp__github_inline_comment__create_inline_comment
+            Bash(gh pr comment:*)
+            Bash(gh pr diff:*)
+            Bash(gh pr view:*)


### PR DESCRIPTION
## Summary
- Fixes SDK crash (exit code 1) in `claude-review.yml` ([failed run](https://github.com/indextables/indextables_spark/actions/runs/22780936827))
- Root cause: `claude_args: --allowedTools` conflicts with the action's internal tool configuration
- Fix: Use the action's native `allowed_tools` parameter instead

## Test plan
- [ ] Verify this PR triggers the review workflow successfully