### PR TITLE
Pin claude-code-action to v1.0.70, fix tool config

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 1
 
       - name: Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@v1.0.70
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
@@ -50,8 +50,4 @@ jobs:
             - Hypothetical future improvements unrelated to the PR
 
             Use inline comments for specific issues. Use a top-level summary for overall assessment.
-          allowed_tools: |
-            mcp__github_inline_comment__create_inline_comment
-            Bash(gh pr comment:*)
-            Bash(gh pr diff:*)
-            Bash(gh pr view:*)
+          claude_args: "--allowedTools mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Pin `anthropics/claude-code-action` from stale `@v1` (Aug 2025) to `@v1.0.70` (Mar 6 2026)
- Fix tool config: `allowed_tools` is not a valid action input — use `claude_args` with `--allowedTools`

## Context
The review workflow crashes with SDK exit code 1 on init (175ms, $0 cost). Root cause: `@v1` points to an outdated release. The `allowed_tools` input was silently ignored.

## Test plan
- [ ] This PR itself will trigger the review workflow (will fail due to workflow validation mismatch — expected)
- [ ] After merge, trigger review on PR #215 to verify