### PR TITLE
Fix Claude review: remove broken claude_args

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -50,4 +50,3 @@ jobs:
             - Hypothetical future improvements unrelated to the PR
 
             Use inline comments for specific issues. Use a top-level summary for overall assessment.
-          claude_args: "--allowedTools mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary
- Root cause found: `--allowedTools` splits `Bash(gh pr comment:*)` on spaces, producing invalid tool names (`"Bash"`, `"gh"`, `"pr"`)
- Fix: Remove `claude_args` entirely — the action's default tool set already includes inline comments, git ops, and MCP tools