### PR TITLE
Pin claude-code-action to v1.0.51 (AJV crash workaround)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 1
 
       - name: Claude Code Review
-        uses: anthropics/claude-code-action@v1.0.70
+        uses: anthropics/claude-code-action@v1.0.51
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true


### PR DESCRIPTION
## Summary
- Known SDK bug: v1.0.69+ crashes with AJV schema validation error on startup (exit code 1, $0 cost)
- See anthropics/claude-code-action#1013
- Pin to v1.0.51, a confirmed working version per anthropics/claude-code-action#947