### PR TITLE
Add Claude Code automatic PR review and @claude workflows

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,55 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          show_full_output: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are reviewing a pull request for IndexTables4Spark, a high-performance
+            Spark DataSource implementing full-text search using Tantivy via tantivy4java.
+
+            Review the PR diff and provide feedback focusing on:
+
+            1. **Correctness** - Logic errors, off-by-one bugs, race conditions, null safety
+            2. **Resource management** - Unclosed resources, memory leaks (especially Arrow FFI
+               struct lifecycles: ArrowArray/ArrowSchema must be closed on error paths)
+            3. **Performance** - Unnecessary allocations, O(n^2) patterns, excessive JNI crossings,
+               serialization overhead in Spark closures
+            4. **Thread safety** - Concurrent access to mutable state, unsafe lazy vals in
+               executor-side code, Spark driver vs executor assumptions
+            5. **Error handling** - Swallowed exceptions, missing context in error messages,
+               exception-based control flow where schema-driven dispatch is possible
+            6. **API design** - Breaking changes, visibility too broad (prefer private[package]),
+               log levels (use debug for hot paths, info for lifecycle events)
+
+            Do NOT comment on:
+            - Style preferences, formatting, or import ordering
+            - Adding documentation to unchanged code
+            - Hypothetical future improvements unrelated to the PR
+
+            Use inline comments for specific issues. Use a top-level summary for overall assessment.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,33 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Add `claude-review.yml`: automatically reviews every non-draft PR for correctness, resource leaks, performance, thread safety, and error handling
- Add `claude.yml`: interactive `@claude` mentions in PR/issue comments
- `show_full_output: true` enabled to diagnose startup crash (AJV/auth issue)

## Test plan
- [ ] Verify ANTHROPIC_API_KEY has credits at https://console.anthropic.com/settings/billing
- [ ] Merge and open a test PR to trigger the review workflow
- [ ] Verify `@claude` mention triggers the interactive workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)