### PR TITLE
Bump tantivy4java to 0.32.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <dependency>
             <groupId>io.indextables</groupId>
             <artifactId>tantivy4java</artifactId>
-            <version>0.32.6</version>
+            <version>0.32.7</version>
             <classifier>${platform.classifier}</classifier>
         </dependency>
 


### PR DESCRIPTION
## Summary

- Bumps tantivy4java dependency from 0.32.6 to 0.32.7

## Test plan

- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)