### PR TITLE
Apply spotless formatting to all Scala source files

### DIFF
--- a/src/main/scala/io/indextables/spark/core/CompanionColumnarMultiSplitPartitionReader.scala
+++ b/src/main/scala/io/indextables/spark/core/CompanionColumnarMultiSplitPartitionReader.scala
@@ -25,7 +25,14 @@ import org.apache.spark.sql.vectorized.ColumnarBatch
 
 import org.apache.hadoop.fs.Path
 
-import io.indextables.spark.metrics.{ReadPipelineMetrics, TaskSplitEngineCreationTime, TaskQueryBuildTime, TaskStreamingSessionStartTime, TaskNextBatchTime, TaskBatchAssemblyTime}
+import io.indextables.spark.metrics.{
+  ReadPipelineMetrics,
+  TaskBatchAssemblyTime,
+  TaskNextBatchTime,
+  TaskQueryBuildTime,
+  TaskSplitEngineCreationTime,
+  TaskStreamingSessionStartTime
+}
 import io.indextables.spark.transaction.AddAction
 import org.slf4j.LoggerFactory
 

--- a/src/main/scala/io/indextables/spark/core/CompanionColumnarPartitionReader.scala
+++ b/src/main/scala/io/indextables/spark/core/CompanionColumnarPartitionReader.scala
@@ -34,9 +34,16 @@ import org.apache.spark.unsafe.types.UTF8String
 import org.apache.hadoop.fs.Path
 
 import io.indextables.spark.arrow.ArrowFfiBridge
-import io.indextables.spark.metrics.{ReadPipelineMetrics, TaskSplitEngineCreationTime, TaskQueryBuildTime, TaskStreamingSessionStartTime, TaskNextBatchTime, TaskBatchAssemblyTime}
-import io.indextables.spark.sync.DistributedSourceScanner
+import io.indextables.spark.metrics.{
+  ReadPipelineMetrics,
+  TaskBatchAssemblyTime,
+  TaskNextBatchTime,
+  TaskQueryBuildTime,
+  TaskSplitEngineCreationTime,
+  TaskStreamingSessionStartTime
+}
 import io.indextables.spark.search.SplitSearchEngine
+import io.indextables.spark.sync.DistributedSourceScanner
 import io.indextables.spark.transaction.AddAction
 import io.indextables.tantivy4java.split.SplitSearcher
 import org.slf4j.LoggerFactory
@@ -164,8 +171,8 @@ class ColumnarPartitionReader(
     // Start streaming session on first call
     if (streamingSession == null) {
       val queryBuildT0 = System.nanoTime()
-      val splitQuery    = ctx.buildSplitQuery(splitSearchEngine)
-      val queryAstJson  = splitQuery.toQueryAstJson()
+      val splitQuery   = ctx.buildSplitQuery(splitSearchEngine)
+      val queryAstJson = splitQuery.toQueryAstJson()
       pipelineMetrics.queryBuildNs = System.nanoTime() - queryBuildT0
 
       val typeHints     = buildTypeHints()
@@ -219,7 +226,7 @@ class ColumnarPartitionReader(
     }
 
     val assemblyT0 = System.nanoTime()
-    val dataBatch = bridge.importAsColumnarBatchStreaming(arrays, schemas, rows)
+    val dataBatch  = bridge.importAsColumnarBatchStreaming(arrays, schemas, rows)
     currentBatch = assembleColumnarBatch(dataBatch, rows)
     pipelineMetrics.batchAssemblyTotalNs += System.nanoTime() - assemblyT0
 
@@ -227,7 +234,7 @@ class ColumnarPartitionReader(
     pipelineMetrics.totalRows = totalRowsReturned
     logger.debug(
       s"Streaming: batch with $rows rows for ${addAction.path}, totalRowsReturned=$totalRowsReturned" +
-      f", nextBatch=${nextBatchElapsed / 1e6}%.1f ms"
+        f", nextBatch=${nextBatchElapsed / 1e6}%.1f ms"
     )
     true
   }
@@ -435,26 +442,32 @@ class ColumnarPartitionReader(
         case BooleanType => vec.setBoolean(value.toBoolean)
         case ShortType   => vec.setShort(value.toShort)
         case ByteType    => vec.setByte(value.toByte)
-        case DateType =>
+        case DateType    =>
           // Handle both ISO date strings (e.g., "2026-03-22") and epoch-day numbers
           // (e.g., "20527" from older companion indexes). The build-side fix in
           // DistributedSourceScanner normalizes to ISO, so try that first to avoid
           // exception allocation on the common path.
-          val epochDay = try {
-            val dateStr = if (value.contains("T")) value.substring(0, 10) else value
-            java.time.LocalDate.parse(dateStr).toEpochDay.toInt // ISO date string (common case)
-          } catch {
-            case _: Exception =>
-              val n = try { value.toInt } catch {
-                case e: NumberFormatException =>
+          val epochDay =
+            try {
+              val dateStr = if (value.contains("T")) value.substring(0, 10) else value
+              java.time.LocalDate.parse(dateStr).toEpochDay.toInt // ISO date string (common case)
+            } catch {
+              case _: Exception =>
+                val n =
+                  try value.toInt
+                  catch {
+                    case e: NumberFormatException =>
+                      throw new IllegalArgumentException(
+                        s"Cannot convert partition value '$value' to DateType: ${e.getMessage}",
+                        e
+                      )
+                  }
+                if (!DistributedSourceScanner.isPlausibleEpochDay(n))
                   throw new IllegalArgumentException(
-                    s"Cannot convert partition value '$value' to DateType: ${e.getMessage}", e)
-              }
-              if (!DistributedSourceScanner.isPlausibleEpochDay(n))
-                throw new IllegalArgumentException(
-                  s"Partition value '$value' is numeric but not a plausible epoch day (range: -100000..100000)")
-              n
-          }
+                    s"Partition value '$value' is numeric but not a plausible epoch day (range: -100000..100000)"
+                  )
+                n
+            }
           vec.setInt(epochDay)
         case TimestampType =>
           val instant = if (value.contains("T")) {

--- a/src/main/scala/io/indextables/spark/core/GroupByAggregateColumnarReader.scala
+++ b/src/main/scala/io/indextables/spark/core/GroupByAggregateColumnarReader.scala
@@ -271,8 +271,16 @@ class GroupByAggregateColumnarReader(
 
     try {
       val dataGroupByCols = partition.groupByColumns.filterNot(partition.partitionColumns.contains)
-      val isRange = bucketConfig.isInstanceOf[RangeConfig]
-      U.assembleBucketBatch(ffiBatch, columnNames, aggExprs, dataGroupByCols, schema, columnTypes, isRangeAggregation = isRange)
+      val isRange         = bucketConfig.isInstanceOf[RangeConfig]
+      U.assembleBucketBatch(
+        ffiBatch,
+        columnNames,
+        aggExprs,
+        dataGroupByCols,
+        schema,
+        columnTypes,
+        isRangeAggregation = isRange
+      )
     } finally
       ffiBatch.close()
   }
@@ -563,8 +571,16 @@ class MultiSplitGroupByAggregateColumnarReader(
 
     try {
       val dataGroupByCols = partition.groupByColumns.filterNot(partition.partitionColumns.contains)
-      val isRange = bucketConfig.isInstanceOf[RangeConfig]
-      U.assembleBucketBatch(ffiBatch, columnNames, aggExprs, dataGroupByCols, schema, columnTypes, isRangeAggregation = isRange)
+      val isRange         = bucketConfig.isInstanceOf[RangeConfig]
+      U.assembleBucketBatch(
+        ffiBatch,
+        columnNames,
+        aggExprs,
+        dataGroupByCols,
+        schema,
+        columnTypes,
+        isRangeAggregation = isRange
+      )
     } finally
       ffiBatch.close()
   }

--- a/src/main/scala/io/indextables/spark/core/GroupByColumnarReaderUtils.scala
+++ b/src/main/scala/io/indextables/spark/core/GroupByColumnarReaderUtils.scala
@@ -361,7 +361,7 @@ object GroupByColumnarReaderUtils {
 
     ffiKeyIndices.zipWithIndex.foreach {
       case (ffiIdx, outIdx) =>
-        val keyColName  = if (outIdx < dataGroupByCols.length) dataGroupByCols(outIdx) else "key"
+        val keyColName   = if (outIdx < dataGroupByCols.length) dataGroupByCols(outIdx) else "key"
         val keyArrowType = arrowTypeAt(columnTypes, ffiIdx)
         val keyTargetType =
           // If the Arrow column is Utf8 the key is a string value (e.g. Range bucket labels in
@@ -369,8 +369,7 @@ object GroupByColumnarReaderUtils {
           if (keyArrowType == ARROW_UTF8) StringType
           else if (outIdx == 0 && isRange) StringType
           else schema.fields.find(_.name == keyColName).map(_.dataType).getOrElse(StringType)
-        vectors(outIdx) =
-          castColumnSafe(ffiBatch.column(ffiIdx), keyTargetType, numRows, keyArrowType)
+        vectors(outIdx) = castColumnSafe(ffiBatch.column(ffiIdx), keyTargetType, numRows, keyArrowType)
     }
 
     val docCountIdx   = columnNames.indexOf("doc_count")

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkDataSource.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkDataSource.scala
@@ -266,8 +266,9 @@ class IndexTables4SparkTable(
 
 }
 
-class IndexTables4SparkTableProvider extends org.apache.spark.sql.connector.catalog.TableProvider
-  with org.apache.spark.sql.sources.DataSourceRegister {
+class IndexTables4SparkTableProvider
+    extends org.apache.spark.sql.connector.catalog.TableProvider
+    with org.apache.spark.sql.sources.DataSourceRegister {
 
   override def shortName(): String = "indextables"
 

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkPartitions.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkPartitions.scala
@@ -234,4 +234,3 @@ class IndexTables4SparkWriterFactory(
     )
   }
 }
-

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkScan.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkScan.scala
@@ -35,7 +35,15 @@ import io.indextables.spark.metrics._
 import io.indextables.spark.prewarm.{IndexComponentMapping, PreWarmManager}
 import io.indextables.spark.stats.DataSkippingMetrics
 import io.indextables.spark.storage.DriverSplitLocalityManager
-import io.indextables.spark.transaction.{AddAction, NativeFilteringMetrics, NativeListFilesResult, NativeTransactionLog, PartitionPredicateUtils, SparkFilterToNativeFilter, TransactionLogInterface}
+import io.indextables.spark.transaction.{
+  AddAction,
+  NativeFilteringMetrics,
+  NativeListFilesResult,
+  NativeTransactionLog,
+  PartitionPredicateUtils,
+  SparkFilterToNativeFilter,
+  TransactionLogInterface
+}
 import io.indextables.spark.util.{PartitionUtils, SplitsPerTaskCalculator, TimestampUtils}
 // Removed unused imports
 import org.slf4j.LoggerFactory
@@ -81,7 +89,7 @@ class IndexTables4SparkScan(
   // Replaces: getPartitionColumns + listFilesWithPartitionFilters + applyDataSkipping + getSchema
   private lazy val cachedListFilesResult: NativeListFilesResult = {
     // Separate partition vs data filters using shared utility
-    val partitionColumns = transactionLog.getPartitionColumns()
+    val partitionColumns                = transactionLog.getPartitionColumns()
     val (partitionFilters, dataFilters) = SparkFilterToNativeFilter.splitFilters(pushedFilters, partitionColumns)
 
     // Single native call: partition pruning + data skipping + cooldown filtering + metadata
@@ -120,9 +128,9 @@ class IndexTables4SparkScan(
 
     logger.debug(
       s"Native filtering: ${m.totalFilesBeforeFiltering} total → " +
-      s"${m.filesAfterPartitionPruning} after partition → " +
-      s"${m.filesAfterDataSkipping} after data skip → " +
-      s"${result.files.size} final (${m.manifestsPruned}/${m.manifestsTotal} manifests pruned)"
+        s"${m.filesAfterPartitionPruning} after partition → " +
+        s"${m.filesAfterDataSkipping} after data skip → " +
+        s"${result.files.size} final (${m.manifestsPruned}/${m.manifestsTotal} manifests pruned)"
     )
 
     result
@@ -179,7 +187,7 @@ class IndexTables4SparkScan(
     // Time this call to capture native filtering cost within the planInputPartitions window.
     // If estimateStatistics() already triggered the lazy val, this returns instantly (0 ns).
     val nativeFilterStart = System.nanoTime()
-    val filteredActions = getFilteredActions()
+    val filteredActions   = getFilteredActions()
     planningMetrics.nativeFilteringNs = System.nanoTime() - nativeFilterStart
     planningMetrics.totalFilesBeforeFiltering = cachedListFilesResult.metrics.totalFilesBeforeFiltering
     planningMetrics.resultFiles = filteredActions.size
@@ -306,8 +314,8 @@ class IndexTables4SparkScan(
 
     // Batch-assign all splits for this query using per-query load balancing
     val localityStart = System.nanoTime()
-    val splitPaths  = filteredActions.map(_.path)
-    val assignments = DriverSplitLocalityManager.assignSplitsForQuery(splitPaths, availableHosts)
+    val splitPaths    = filteredActions.map(_.path)
+    val assignments   = DriverSplitLocalityManager.assignSplitsForQuery(splitPaths, availableHosts)
     planningMetrics.localityAssignmentNs = System.nanoTime() - localityStart
     logger.debug(s"Assigned ${assignments.size} splits to hosts")
 
@@ -487,8 +495,6 @@ class IndexTables4SparkScan(
         // Return unknown statistics rather than failing the query
         IndexTables4SparkStatistics.unknown()
     }
-
-
 
   // ============================================================================
   // Filter utilities

--- a/src/main/scala/io/indextables/spark/core/SplitReaderContext.scala
+++ b/src/main/scala/io/indextables/spark/core/SplitReaderContext.scala
@@ -390,10 +390,9 @@ class SplitReaderContext(
 
   /**
    * Check if a range filter is redundant based on min/max statistics. A filter is redundant if the split's entire data
-   * Redundant range filter elimination is now handled natively (FR4).
-   * The native split search engine automatically uses per-file stats
-   * cached during listFilesArrowFfi() to eliminate redundant range filters.
-   * See: TANTIVY4JAVA_FR4_API_GAP.md (resolved)
+   * Redundant range filter elimination is now handled natively (FR4). The native split search engine automatically uses
+   * per-file stats cached during listFilesArrowFfi() to eliminate redundant range filters. See:
+   * TANTIVY4JAVA_FR4_API_GAP.md (resolved)
    */
 }
 

--- a/src/main/scala/io/indextables/spark/core/TransactionLogCountScan.scala
+++ b/src/main/scala/io/indextables/spark/core/TransactionLogCountScan.scala
@@ -122,7 +122,8 @@ class TransactionLogCountBatch(
     }
 
   /** Compute the count from transaction log on the driver side. */
-  private def computeCountFromTransactionLog(transactionLog: TransactionLogInterface, pushedFilters: Array[Filter]): Long =
+  private def computeCountFromTransactionLog(transactionLog: TransactionLogInterface, pushedFilters: Array[Filter])
+    : Long =
     if (pushedFilters.isEmpty) {
       // No filters - return total count from transaction log
       transactionLog.getTotalRowCount()
@@ -341,16 +342,19 @@ class TransactionLogGroupByCountPartitionReader(
           localDate.toEpochDay.toInt
         } catch {
           case _: Exception =>
-            val n = try { value.toInt } catch {
-              case e: NumberFormatException =>
-                throw new IllegalArgumentException(
-                  s"Cannot convert partition value '$value' for column '$columnName' to DateType: ${e.getMessage}",
-                  e
-                )
-            }
+            val n =
+              try value.toInt
+              catch {
+                case e: NumberFormatException =>
+                  throw new IllegalArgumentException(
+                    s"Cannot convert partition value '$value' for column '$columnName' to DateType: ${e.getMessage}",
+                    e
+                  )
+              }
             if (!DistributedSourceScanner.isPlausibleEpochDay(n))
               throw new IllegalArgumentException(
-                s"Partition value '$value' for column '$columnName' is numeric but not a plausible epoch day (range: -100000..100000)")
+                s"Partition value '$value' for column '$columnName' is numeric but not a plausible epoch day (range: -100000..100000)"
+              )
             n
         }
 

--- a/src/main/scala/io/indextables/spark/io/merge/MergeIOConfig.scala
+++ b/src/main/scala/io/indextables/spark/io/merge/MergeIOConfig.scala
@@ -83,12 +83,17 @@ object MergeIOConfig {
   /** Create configuration from a case-insensitive string map (Spark options). */
   def fromOptions(options: CaseInsensitiveStringMap): MergeIOConfig =
     MergeIOConfig(
-      maxConcurrencyPerCore = io.indextables.spark.util.ConfigParsingUtils.getIntOption(options, KEY_MAX_CONCURRENCY_PER_CORE, DEFAULT_MAX_CONCURRENCY_PER_CORE),
+      maxConcurrencyPerCore = io.indextables.spark.util.ConfigParsingUtils
+        .getIntOption(options, KEY_MAX_CONCURRENCY_PER_CORE, DEFAULT_MAX_CONCURRENCY_PER_CORE),
       memoryBudgetBytes = parseBytes(options.getOrDefault(KEY_MEMORY_BUDGET, formatBytes(DEFAULT_MEMORY_BUDGET_BYTES))),
-      downloadRetries = io.indextables.spark.util.ConfigParsingUtils.getIntOption(options, KEY_DOWNLOAD_RETRIES, DEFAULT_DOWNLOAD_RETRIES),
-      uploadMaxConcurrency = io.indextables.spark.util.ConfigParsingUtils.getIntOption(options, KEY_UPLOAD_MAX_CONCURRENCY, DEFAULT_UPLOAD_MAX_CONCURRENCY),
-      retryBaseDelayMs = io.indextables.spark.util.ConfigParsingUtils.getLongOption(options, KEY_RETRY_BASE_DELAY_MS, DEFAULT_RETRY_BASE_DELAY_MS),
-      retryMaxDelayMs = io.indextables.spark.util.ConfigParsingUtils.getLongOption(options, KEY_RETRY_MAX_DELAY_MS, DEFAULT_RETRY_MAX_DELAY_MS)
+      downloadRetries = io.indextables.spark.util.ConfigParsingUtils
+        .getIntOption(options, KEY_DOWNLOAD_RETRIES, DEFAULT_DOWNLOAD_RETRIES),
+      uploadMaxConcurrency = io.indextables.spark.util.ConfigParsingUtils
+        .getIntOption(options, KEY_UPLOAD_MAX_CONCURRENCY, DEFAULT_UPLOAD_MAX_CONCURRENCY),
+      retryBaseDelayMs = io.indextables.spark.util.ConfigParsingUtils
+        .getLongOption(options, KEY_RETRY_BASE_DELAY_MS, DEFAULT_RETRY_BASE_DELAY_MS),
+      retryMaxDelayMs = io.indextables.spark.util.ConfigParsingUtils
+        .getLongOption(options, KEY_RETRY_MAX_DELAY_MS, DEFAULT_RETRY_MAX_DELAY_MS)
     ).validate()
 
   /**

--- a/src/main/scala/io/indextables/spark/io/merge/MergeUploader.scala
+++ b/src/main/scala/io/indextables/spark/io/merge/MergeUploader.scala
@@ -282,7 +282,6 @@ object MergeUploader {
     }
   }
 
-
   /**
    * Upload a local file to Azure Blob Storage.
    *

--- a/src/main/scala/io/indextables/spark/merge/AsyncMergeOnWriteConfig.scala
+++ b/src/main/scala/io/indextables/spark/merge/AsyncMergeOnWriteConfig.scala
@@ -17,8 +17,9 @@
 
 package io.indextables.spark.merge
 
-import io.indextables.spark.util.{ConfigParsingUtils, SizeParser}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import io.indextables.spark.util.{ConfigParsingUtils, SizeParser}
 import org.slf4j.LoggerFactory
 
 /**
@@ -163,13 +164,35 @@ object AsyncMergeOnWriteConfig {
    *   Parsed configuration
    */
   def fromOptions(options: CaseInsensitiveStringMap): AsyncMergeOnWriteConfig = {
-    val enabled              = ConfigParsingUtils.getBooleanOption(options, KEY_ENABLED, DEFAULT_ENABLED)
-    val asyncEnabled         = ConfigParsingUtils.getBooleanOption(options, KEY_ASYNC_ENABLED, DEFAULT_ASYNC_ENABLED)
-    val batchCpuFraction     = ConfigParsingUtils.getDoubleOption(options, KEY_BATCH_CPU_FRACTION, DEFAULT_BATCH_CPU_FRACTION, minExclusive = Some(0.0), maxInclusive = Some(1.0))
-    val maxConcurrentBatches = ConfigParsingUtils.getIntOption(options, KEY_MAX_CONCURRENT_BATCHES, DEFAULT_MAX_CONCURRENT_BATCHES, mustBePositive = true)
-    val minBatchesToTrigger  = ConfigParsingUtils.getIntOption(options, KEY_MIN_BATCHES_TO_TRIGGER, DEFAULT_MIN_BATCHES_TO_TRIGGER, mustBePositive = true)
-    val targetSizeBytes      = SizeParser.parseSize(options.getOrDefault(KEY_TARGET_SIZE, SizeParser.formatBytes(DEFAULT_TARGET_SIZE_BYTES)))
-    val shutdownTimeoutMs    = ConfigParsingUtils.getLongOption(options, KEY_SHUTDOWN_TIMEOUT_MS, DEFAULT_SHUTDOWN_TIMEOUT_MS, mustBePositive = true)
+    val enabled      = ConfigParsingUtils.getBooleanOption(options, KEY_ENABLED, DEFAULT_ENABLED)
+    val asyncEnabled = ConfigParsingUtils.getBooleanOption(options, KEY_ASYNC_ENABLED, DEFAULT_ASYNC_ENABLED)
+    val batchCpuFraction = ConfigParsingUtils.getDoubleOption(
+      options,
+      KEY_BATCH_CPU_FRACTION,
+      DEFAULT_BATCH_CPU_FRACTION,
+      minExclusive = Some(0.0),
+      maxInclusive = Some(1.0)
+    )
+    val maxConcurrentBatches = ConfigParsingUtils.getIntOption(
+      options,
+      KEY_MAX_CONCURRENT_BATCHES,
+      DEFAULT_MAX_CONCURRENT_BATCHES,
+      mustBePositive = true
+    )
+    val minBatchesToTrigger = ConfigParsingUtils.getIntOption(
+      options,
+      KEY_MIN_BATCHES_TO_TRIGGER,
+      DEFAULT_MIN_BATCHES_TO_TRIGGER,
+      mustBePositive = true
+    )
+    val targetSizeBytes =
+      SizeParser.parseSize(options.getOrDefault(KEY_TARGET_SIZE, SizeParser.formatBytes(DEFAULT_TARGET_SIZE_BYTES)))
+    val shutdownTimeoutMs = ConfigParsingUtils.getLongOption(
+      options,
+      KEY_SHUTDOWN_TIMEOUT_MS,
+      DEFAULT_SHUTDOWN_TIMEOUT_MS,
+      mustBePositive = true
+    )
 
     val config = AsyncMergeOnWriteConfig(
       enabled = enabled,
@@ -216,6 +239,5 @@ object AsyncMergeOnWriteConfig {
       shutdownTimeoutMs = get(KEY_SHUTDOWN_TIMEOUT_MS).map(_.toLong).getOrElse(DEFAULT_SHUTDOWN_TIMEOUT_MS)
     ).validate()
   }
-
 
 }

--- a/src/main/scala/io/indextables/spark/metrics/ReadPipelineMetrics.scala
+++ b/src/main/scala/io/indextables/spark/metrics/ReadPipelineMetrics.scala
@@ -29,18 +29,18 @@ import org.slf4j.LoggerFactory
  *   - Per-batch retrieval (nextBatch FFI calls — S3 GETs + parquet decode)
  *   - Arrow batch assembly (FFI import + partition column interleave)
  *
- * All durations are in nanoseconds for precision, converted to milliseconds for logging.
- * Callers are responsible for logging the `summary` string — this class does not log directly.
+ * All durations are in nanoseconds for precision, converted to milliseconds for logging. Callers are responsible for
+ * logging the `summary` string — this class does not log directly.
  */
 class ReadPipelineMetrics(val splitPath: String) {
 
-  var splitEngineCreationNs: Long = 0L
-  var queryBuildNs: Long = 0L
+  var splitEngineCreationNs: Long   = 0L
+  var queryBuildNs: Long            = 0L
   var streamingSessionStartNs: Long = 0L
-  var nextBatchTotalNs: Long = 0L
-  var nextBatchCount: Int = 0
-  var batchAssemblyTotalNs: Long = 0L
-  var totalRows: Long = 0L
+  var nextBatchTotalNs: Long        = 0L
+  var nextBatchCount: Int           = 0
+  var batchAssemblyTotalNs: Long    = 0L
+  var totalRows: Long               = 0L
 
   /** Merge another instance's timings into this one (for multi-split aggregation). */
   def mergeFrom(other: ReadPipelineMetrics): Unit = {
@@ -53,11 +53,11 @@ class ReadPipelineMetrics(val splitPath: String) {
     totalRows += other.totalRows
   }
 
-  def splitEngineCreationMs: Double = splitEngineCreationNs / 1e6
-  def queryBuildMs: Double = queryBuildNs / 1e6
+  def splitEngineCreationMs: Double   = splitEngineCreationNs / 1e6
+  def queryBuildMs: Double            = queryBuildNs / 1e6
   def streamingSessionStartMs: Double = streamingSessionStartNs / 1e6
-  def nextBatchTotalMs: Double = nextBatchTotalNs / 1e6
-  def batchAssemblyTotalMs: Double = batchAssemblyTotalNs / 1e6
+  def nextBatchTotalMs: Double        = nextBatchTotalNs / 1e6
+  def batchAssemblyTotalMs: Double    = batchAssemblyTotalNs / 1e6
 
   def totalTrackedMs: Double =
     splitEngineCreationMs + queryBuildMs + streamingSessionStartMs +
@@ -65,9 +65,9 @@ class ReadPipelineMetrics(val splitPath: String) {
 
   def summary: String = {
     val avg = if (nextBatchCount > 0) f" avgBatch=${nextBatchTotalMs / nextBatchCount}%.1fms" else ""
-    f"ReadPipelineMetrics path=$splitPath engineCreation=${splitEngineCreationMs}%.1fms queryBuild=${queryBuildMs}%.1fms " +
-      f"streamingStart=${streamingSessionStartMs}%.1fms nextBatch=${nextBatchTotalMs}%.1fms(${nextBatchCount}batches$avg) " +
-      f"batchAssembly=${batchAssemblyTotalMs}%.1fms total=${totalTrackedMs}%.1fms rows=$totalRows"
+    f"ReadPipelineMetrics path=$splitPath engineCreation=$splitEngineCreationMs%.1fms queryBuild=$queryBuildMs%.1fms " +
+      f"streamingStart=$streamingSessionStartMs%.1fms nextBatch=$nextBatchTotalMs%.1fms(${nextBatchCount}batches$avg) " +
+      f"batchAssembly=$batchAssemblyTotalMs%.1fms total=$totalTrackedMs%.1fms rows=$totalRows"
   }
 }
 
@@ -83,22 +83,21 @@ class ScanPlanningMetrics(val tablePath: String) {
 
   private val logger = LoggerFactory.getLogger(classOf[ScanPlanningMetrics])
 
-  var nativeFilteringNs: Long = 0L
+  var nativeFilteringNs: Long    = 0L
   var localityAssignmentNs: Long = 0L
-  var totalPlanNs: Long = 0L
+  var totalPlanNs: Long          = 0L
 
   var totalFilesBeforeFiltering: Long = 0L
-  var resultFiles: Long = 0L
-  var resultPartitions: Int = 0
+  var resultFiles: Long               = 0L
+  var resultPartitions: Int           = 0
 
-  def nativeFilteringMs: Double = nativeFilteringNs / 1e6
+  def nativeFilteringMs: Double    = nativeFilteringNs / 1e6
   def localityAssignmentMs: Double = localityAssignmentNs / 1e6
-  def totalPlanMs: Double = totalPlanNs / 1e6
+  def totalPlanMs: Double          = totalPlanNs / 1e6
 
-  def logSummary(): Unit = {
+  def logSummary(): Unit =
     logger.info(
-      f"ScanPlanningMetrics table=$tablePath nativeFiltering=${nativeFilteringMs}%.1fms($totalFilesBeforeFiltering->${resultFiles}files) " +
-        f"locality=${localityAssignmentMs}%.1fms totalPlan=${totalPlanMs}%.1fms partitions=$resultPartitions"
+      f"ScanPlanningMetrics table=$tablePath nativeFiltering=$nativeFilteringMs%.1fms($totalFilesBeforeFiltering->${resultFiles}files) " +
+        f"locality=$localityAssignmentMs%.1fms totalPlan=$totalPlanMs%.1fms partitions=$resultPartitions"
     )
-  }
 }

--- a/src/main/scala/io/indextables/spark/metrics/ReadPipelineSparkUIMetrics.scala
+++ b/src/main/scala/io/indextables/spark/metrics/ReadPipelineSparkUIMetrics.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.connector.metric.{CustomMetric, CustomSumMetric, Cus
 abstract class CustomMaxMillisMetric extends CustomMetric {
   override def aggregateTaskMetrics(taskMetrics: Array[Long]): String = {
     val maxVal = if (taskMetrics.nonEmpty) taskMetrics.max else 0L
-    s"${maxVal} ms"
+    s"$maxVal ms"
   }
 }
 
@@ -81,10 +81,20 @@ object BatchAssemblyTime { val NAME = "batchAssemblyTimeMs" }
 // TaskMetric wrappers
 // ============================================================================
 
-class TaskNativeFilteringTime(val value: Long)         extends CustomTaskMetric { override def name(): String = NativeFilteringTime.NAME }
-class TaskScanPlanTotalTime(val value: Long)           extends CustomTaskMetric { override def name(): String = ScanPlanTotalTime.NAME }
-class TaskSplitEngineCreationTime(val value: Long)     extends CustomTaskMetric { override def name(): String = SplitEngineCreationTime.NAME }
-class TaskQueryBuildTime(val value: Long)              extends CustomTaskMetric { override def name(): String = QueryBuildTime.NAME }
-class TaskStreamingSessionStartTime(val value: Long)   extends CustomTaskMetric { override def name(): String = StreamingSessionStartTime.NAME }
-class TaskNextBatchTime(val value: Long)               extends CustomTaskMetric { override def name(): String = NextBatchTime.NAME }
-class TaskBatchAssemblyTime(val value: Long)           extends CustomTaskMetric { override def name(): String = BatchAssemblyTime.NAME }
+class TaskNativeFilteringTime(val value: Long) extends CustomTaskMetric {
+  override def name(): String = NativeFilteringTime.NAME
+}
+class TaskScanPlanTotalTime(val value: Long) extends CustomTaskMetric {
+  override def name(): String = ScanPlanTotalTime.NAME
+}
+class TaskSplitEngineCreationTime(val value: Long) extends CustomTaskMetric {
+  override def name(): String = SplitEngineCreationTime.NAME
+}
+class TaskQueryBuildTime(val value: Long) extends CustomTaskMetric { override def name(): String = QueryBuildTime.NAME }
+class TaskStreamingSessionStartTime(val value: Long) extends CustomTaskMetric {
+  override def name(): String = StreamingSessionStartTime.NAME
+}
+class TaskNextBatchTime(val value: Long) extends CustomTaskMetric { override def name(): String = NextBatchTime.NAME }
+class TaskBatchAssemblyTime(val value: Long) extends CustomTaskMetric {
+  override def name(): String = BatchAssemblyTime.NAME
+}

--- a/src/main/scala/io/indextables/spark/sql/CheckpointCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/CheckpointCommand.scala
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory
  *   - CHECKPOINT TANTIVY4SPARK '/path/to/table'
  *
  * This command:
- *   1. Reads the current transaction log state 2. Delegates checkpoint creation to the native
- *      tantivy4java implementation 3. Returns status information about the checkpoint
+ *   1. Reads the current transaction log state 2. Delegates checkpoint creation to the native tantivy4java
+ *      implementation 3. Returns status information about the checkpoint
  *
  * Use this command to:
  *   - Force checkpoint creation at a specific point in time

--- a/src/main/scala/io/indextables/spark/sql/FfiProfilerCommands.scala
+++ b/src/main/scala/io/indextables/spark/sql/FfiProfilerCommands.scala
@@ -20,11 +20,11 @@ package io.indextables.spark.sql
 import scala.jdk.CollectionConverters._
 import scala.reflect.ClassTag
 
-import org.apache.spark.SparkContext
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
 import org.apache.spark.sql.execution.command.LeafRunnableCommand
 import org.apache.spark.sql.types.{DoubleType, IntegerType, LongType, StringType}
+import org.apache.spark.SparkContext
 
 import io.indextables.spark.storage.DriverSplitLocalityManager
 import io.indextables.tantivy4java.split.FfiProfiler
@@ -46,8 +46,7 @@ case class EnableFfiProfilerCommand() extends LeafRunnableCommand {
   override def run(sparkSession: SparkSession): Seq[Row] = {
     FfiProfiler.enable() // driver host
     val hostCount = FfiProfilerExecutorHelper.broadcastToHosts(sparkSession.sparkContext, enable = true)
-    Seq(Row("enabled", hostCount,
-      s"FFI profiler enabled on driver + $hostCount executor host(s) (counters auto-reset)"))
+    Seq(Row("enabled", hostCount, s"FFI profiler enabled on driver + $hostCount executor host(s) (counters auto-reset)"))
   }
 }
 
@@ -67,17 +66,17 @@ case class DisableFfiProfilerCommand() extends LeafRunnableCommand {
   override def run(sparkSession: SparkSession): Seq[Row] = {
     FfiProfiler.disable() // driver host
     val hostCount = FfiProfilerExecutorHelper.broadcastToHosts(sparkSession.sparkContext, enable = false)
-    Seq(Row("disabled", hostCount,
-      s"FFI profiler disabled on driver + $hostCount executor host(s) (counters preserved)"))
+    Seq(
+      Row("disabled", hostCount, s"FFI profiler disabled on driver + $hostCount executor host(s) (counters preserved)")
+    )
   }
 }
 
 /**
  * SQL command to read FFI profiler counters from all hosts as a DataFrame.
  *
- * Syntax:
- *   DESCRIBE INDEXTABLES PROFILER        -- section timings
- *   DESCRIBE INDEXTABLES PROFILER CACHE  -- cache hit/miss counters
+ * Syntax: DESCRIBE INDEXTABLES PROFILER -- section timings DESCRIBE INDEXTABLES PROFILER CACHE -- cache hit/miss
+ * counters
  */
 case class DescribeFfiProfilerCommand(cacheOnly: Boolean = false) extends LeafRunnableCommand {
 
@@ -96,12 +95,10 @@ case class DescribeFfiProfilerCommand(cacheOnly: Boolean = false) extends LeafRu
 /**
  * SQL command to read and reset FFI profiler counters from all hosts.
  *
- * Reset is atomic per-host (native CAS), but not cluster-atomic. Events recorded on executors
- * between their reset and the driver reset are not captured in the returned snapshot.
+ * Reset is atomic per-host (native CAS), but not cluster-atomic. Events recorded on executors between their reset and
+ * the driver reset are not captured in the returned snapshot.
  *
- * Syntax:
- *   RESET INDEXTABLES PROFILER        -- section timings
- *   RESET INDEXTABLES PROFILER CACHE  -- cache hit/miss counters
+ * Syntax: RESET INDEXTABLES PROFILER -- section timings RESET INDEXTABLES PROFILER CACHE -- cache hit/miss counters
  */
 case class ResetFfiProfilerCommand(cacheOnly: Boolean = false) extends LeafRunnableCommand {
 
@@ -144,12 +141,13 @@ private[sql] object FfiProfilerCommands {
     sections.toSeq
       .filter { case (_, (count, _, _, _)) => count > 0 }
       .sortBy { case (name, _) => name }
-      .map { case (name, (count, totalNanos, minNanos, maxNanos)) =>
-        val totalMs = totalNanos / 1000000.0
-        val avgUs   = if (count > 0) totalNanos.toDouble / count / 1000.0 else 0.0
-        val minUs   = minNanos / 1000.0
-        val maxUs   = maxNanos / 1000.0
-        Row(name, categoryFor(name), count, totalMs, avgUs, minUs, maxUs)
+      .map {
+        case (name, (count, totalNanos, minNanos, maxNanos)) =>
+          val totalMs = totalNanos / 1000000.0
+          val avgUs   = if (count > 0) totalNanos.toDouble / count / 1000.0 else 0.0
+          val minUs   = minNanos / 1000.0
+          val maxUs   = maxNanos / 1000.0
+          Row(name, categoryFor(name), count, totalMs, avgUs, minUs, maxUs)
       }
 
   def buildCacheRows(counters: Map[String, Long]): Seq[Row] = {
@@ -157,14 +155,16 @@ private[sql] object FfiProfilerCommands {
     // added in tantivy4java are automatically picked up without code changes.
     val cacheNames = counters.keys
       .map(k => k.replaceAll("_(hit|miss)$", ""))
-      .toSeq.distinct.sorted
+      .toSeq
+      .distinct
+      .sorted
 
     cacheNames.flatMap { name =>
       val hits   = counters.getOrElse(s"${name}_hit", 0L)
       val misses = counters.getOrElse(s"${name}_miss", 0L)
       if (hits == 0 && misses == 0) None
       else {
-        val total = hits + misses
+        val total                     = hits + misses
         val hitRate: java.lang.Double = if (total > 0) hits.toDouble / total else null
         Some(Row(name, hits, misses, hitRate))
       }
@@ -188,9 +188,9 @@ private[sql] object FfiProfilerCommands {
 /**
  * Helper for running profiler operations on each unique executor host.
  *
- * Uses `DriverSplitLocalityManager.getAvailableHosts` for host discovery and
- * `sc.makeRDD` with preferred locations — the same pattern as `PrewarmCacheCommand`.
- * Since profiler counters are global per host, one collect per unique host is correct.
+ * Uses `DriverSplitLocalityManager.getAvailableHosts` for host discovery and `sc.makeRDD` with preferred locations —
+ * the same pattern as `PrewarmCacheCommand`. Since profiler counters are global per host, one collect per unique host
+ * is correct.
  */
 private[sql] object FfiProfilerExecutorHelper {
 
@@ -199,11 +199,11 @@ private[sql] object FfiProfilerExecutorHelper {
   import FfiProfilerCommands.SectionData
 
   /**
-   * Run a function once on each unique executor host using preferred locations.
-   * In local mode (no executors), returns empty — caller handles driver separately.
+   * Run a function once on each unique executor host using preferred locations. In local mode (no executors), returns
+   * empty — caller handles driver separately.
    *
-   * Note: preferred locations are hints, not guarantees. Under heavy load, Spark may
-   * schedule a task on a different host. This is best-effort, same as PrewarmCacheCommand.
+   * Note: preferred locations are hints, not guarantees. Under heavy load, Spark may schedule a task on a different
+   * host. This is best-effort, same as PrewarmCacheCommand.
    */
   private def runOnEachHost[T: ClassTag](
     sc: SparkContext,
@@ -227,25 +227,28 @@ private[sql] object FfiProfilerExecutorHelper {
 
   /** Broadcast enable/disable to all executor hosts. Returns number of hosts reached. */
   def broadcastToHosts(sc: SparkContext, enable: Boolean): Int = {
-    val results = runOnEachHost(sc, () => {
-      if (enable) FfiProfiler.enable() else FfiProfiler.disable()
-    })
+    val results = runOnEachHost(sc, () => if (enable) FfiProfiler.enable() else FfiProfiler.disable())
     results.size
   }
 
   /** Collect and merge section counters from all hosts (executors + driver). */
   def collectSectionCounters(sc: SparkContext, reset: Boolean): Map[String, SectionData] = {
-    val hostResults = runOnEachHost[Map[String, SectionData]](sc, () => {
-      val entries = if (reset) FfiProfiler.reset() else FfiProfiler.snapshot()
-      entries.asScala.map { case (name, pe) =>
-        name -> (pe.getCount, pe.getTotalNanos, pe.getMinNanos, pe.getMaxNanos)
-      }.toMap
-    })
+    val hostResults = runOnEachHost[Map[String, SectionData]](
+      sc,
+      () => {
+        val entries = if (reset) FfiProfiler.reset() else FfiProfiler.snapshot()
+        entries.asScala.map {
+          case (name, pe) =>
+            name -> (pe.getCount, pe.getTotalNanos, pe.getMinNanos, pe.getMaxNanos)
+        }.toMap
+      }
+    )
 
     // Driver-host counters
     val driverEntries = if (reset) FfiProfiler.reset() else FfiProfiler.snapshot()
-    val driverMap = driverEntries.asScala.map { case (name, pe) =>
-      name -> (pe.getCount, pe.getTotalNanos, pe.getMinNanos, pe.getMaxNanos)
+    val driverMap = driverEntries.asScala.map {
+      case (name, pe) =>
+        name -> (pe.getCount, pe.getTotalNanos, pe.getMinNanos, pe.getMaxNanos)
     }.toMap
 
     mergeProfiles(hostResults :+ driverMap)
@@ -253,29 +256,34 @@ private[sql] object FfiProfilerExecutorHelper {
 
   /** Collect and merge cache counters from all hosts (executors + driver). */
   def collectCacheCounters(sc: SparkContext, reset: Boolean): Map[String, Long] = {
-    val hostResults = runOnEachHost[Map[String, Long]](sc, () => {
-      val counters = if (reset) FfiProfiler.resetCacheCounters() else FfiProfiler.cacheCounters()
-      counters.asScala.map { case (k, v) => k -> v.longValue() }.toMap
-    })
+    val hostResults = runOnEachHost[Map[String, Long]](
+      sc,
+      () => {
+        val counters = if (reset) FfiProfiler.resetCacheCounters() else FfiProfiler.cacheCounters()
+        counters.asScala.map { case (k, v) => k -> v.longValue() }.toMap
+      }
+    )
 
     // Driver-host counters
     val driverCounters = if (reset) FfiProfiler.resetCacheCounters() else FfiProfiler.cacheCounters()
-    val driverMap = driverCounters.asScala.map { case (k, v) => k -> v.longValue() }.toMap
+    val driverMap      = driverCounters.asScala.map { case (k, v) => k -> v.longValue() }.toMap
 
     val allMaps = hostResults :+ driverMap
-    allMaps.flatten.groupBy(_._1).map { case (key, entries) =>
-      key -> entries.map(_._2).sum
+    allMaps.flatten.groupBy(_._1).map {
+      case (key, entries) =>
+        key -> entries.map(_._2).sum
     }
   }
 
   private def mergeProfiles(profiles: Seq[Map[String, SectionData]]): Map[String, SectionData] =
-    profiles.flatten.groupBy(_._1).map { case (section, entries) =>
-      val values = entries.map(_._2)
-      section -> (
-        values.map(_._1).sum,       // sum counts
-        values.map(_._2).sum,       // sum totalNanos
-        values.map(_._3).min,       // min of mins
-        values.map(_._4).max        // max of maxes
-      )
+    profiles.flatten.groupBy(_._1).map {
+      case (section, entries) =>
+        val values = entries.map(_._2)
+        section -> (
+          values.map(_._1).sum, // sum counts
+          values.map(_._2).sum, // sum totalNanos
+          values.map(_._3).min, // min of mins
+          values.map(_._4).max  // max of maxes
+        )
     }
 }

--- a/src/main/scala/io/indextables/spark/sql/MergeSplitsCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/MergeSplitsCommand.scala
@@ -33,8 +33,8 @@ import io.indextables.spark.transaction.{
   AddAction,
   PartitionPredicateUtils,
   RemoveAction,
-  TransactionLogInterface,
-  TransactionLogFactory
+  TransactionLogFactory,
+  TransactionLogInterface
 }
 import io.indextables.spark.util.{ConfigNormalization, ConfigUtils}
 import io.indextables.tantivy4java.split.merge.QuickwitSplit

--- a/src/main/scala/io/indextables/spark/sql/PurgeOrphanedSplitsExecutor.scala
+++ b/src/main/scala/io/indextables/spark/sql/PurgeOrphanedSplitsExecutor.scala
@@ -105,50 +105,67 @@ class PurgeOrphanedSplitsExecutor(
     // The native layer evaluates version retention and returns all split file paths
     // referenced by any non-expired version. This is the "known files" set.
     val retainedFilePaths = {
-      val paths   = scala.collection.mutable.Set[String]()
-      val cursor  = TransactionLogReader.openRetainedFilesCursor(nativeTablePath, nativeConfig, txLogRetentionMs)
+      val paths  = scala.collection.mutable.Set[String]()
+      val cursor = TransactionLogReader.openRetainedFilesCursor(nativeTablePath, nativeConfig, txLogRetentionMs)
       try {
         val numCols = 20 // base schema including partition_values (no dynamic partitions for purge)
-        val bridge = new io.indextables.spark.arrow.ArrowFfiBridge()
+        val bridge  = new io.indextables.spark.arrow.ArrowFfiBridge()
         try {
           var continue = true
           while (continue) {
             val (arrays, schemas, arrayAddrs, schemaAddrs) = bridge.allocateStructs(numCols)
             try {
               val rowCount = TransactionLogReader.readNextRetainedFilesBatchArrowFfi(
-                cursor, 10000, arrayAddrs, schemaAddrs
+                cursor,
+                10000,
+                arrayAddrs,
+                schemaAddrs
               )
               if (rowCount > 0) {
                 // importAsColumnarBatchStreaming transfers ownership of all structs
                 val batch = bridge.importAsColumnarBatchStreaming(arrays.take(numCols), schemas.take(numCols), rowCount)
                 try {
-                  val pathVec = batch.column(0).asInstanceOf[
-                    org.apache.spark.sql.vectorized.ArrowColumnVector
-                  ].getValueVector.asInstanceOf[org.apache.arrow.vector.VarCharVector]
+                  val pathVec = batch
+                    .column(0)
+                    .asInstanceOf[
+                      org.apache.spark.sql.vectorized.ArrowColumnVector
+                    ]
+                    .getValueVector
+                    .asInstanceOf[org.apache.arrow.vector.VarCharVector]
                   var i = 0
                   while (i < rowCount) {
                     if (!pathVec.isNull(i)) paths += new String(pathVec.get(i), java.nio.charset.StandardCharsets.UTF_8)
                     i += 1
                   }
-                } finally {
+                } finally
                   batch.close()
-                }
               } else {
                 continue = false
                 // Close unused structs — native didn't fill them
-                arrays.foreach(a => try a.close() catch { case _: Exception => })
-                schemas.foreach(s => try s.close() catch { case _: Exception => })
+                arrays.foreach(a =>
+                  try a.close()
+                  catch { case _: Exception => }
+                )
+                schemas.foreach(s =>
+                  try s.close()
+                  catch { case _: Exception => }
+                )
               }
             } catch {
               case e: Exception =>
-                arrays.foreach(a => try a.close() catch { case _: Exception => })
-                schemas.foreach(s => try s.close() catch { case _: Exception => })
+                arrays.foreach(a =>
+                  try a.close()
+                  catch { case _: Exception => }
+                )
+                schemas.foreach(s =>
+                  try s.close()
+                  catch { case _: Exception => }
+                )
                 throw e
             }
           }
-        } finally {
+        } finally
           bridge.close()
-        }
       } finally
         TransactionLogReader.closeRetainedFilesCursor(cursor)
       paths.toSet
@@ -158,8 +175,10 @@ class PurgeOrphanedSplitsExecutor(
     // --- Step 2: Native cleanup of expired states and versions ---
     // For dry run, use dryRun=true to get counts. Guard deleted counts in Scala as a
     // safety net until native dryRun is fully verified. For real runs, delete with dryRun=false.
-    val stateResultJson   = TransactionLogWriter.deleteExpiredStates(nativeTablePath, nativeConfig, txLogRetentionMs, dryRun)
-    val versionResultJson = TransactionLogWriter.deleteExpiredVersions(nativeTablePath, nativeConfig, txLogRetentionMs, dryRun)
+    val stateResultJson =
+      TransactionLogWriter.deleteExpiredStates(nativeTablePath, nativeConfig, txLogRetentionMs, dryRun)
+    val versionResultJson =
+      TransactionLogWriter.deleteExpiredVersions(nativeTablePath, nativeConfig, txLogRetentionMs, dryRun)
 
     // Invalidate cache after deletion so subsequent reads rebuild from current state.
     // Invalidate both the normalized path (used by this txlog instance) and the raw path
@@ -198,10 +217,15 @@ class PurgeOrphanedSplitsExecutor(
       val durationMs = System.currentTimeMillis() - startTime
       return PurgeResult(
         status = if (dryRun) "DRY_RUN" else "SUCCESS",
-        orphanedFilesFound = 0, orphanedFilesDeleted = 0, sizeMBDeleted = 0.0,
-        txLogFilesDeleted = versionFilesDeleted, retentionHours = retentionHours,
-        expiredStatesFound = stateCleanupResult.found, expiredStatesDeleted = stateCleanupResult.deleted,
-        dryRun = dryRun, durationMs = durationMs,
+        orphanedFilesFound = 0,
+        orphanedFilesDeleted = 0,
+        sizeMBDeleted = 0.0,
+        txLogFilesDeleted = versionFilesDeleted,
+        retentionHours = retentionHours,
+        expiredStatesFound = stateCleanupResult.found,
+        expiredStatesDeleted = stateCleanupResult.deleted,
+        dryRun = dryRun,
+        durationMs = durationMs,
         message = Some(s"No split files found in table directory.$stateMessage")
       )
     }
@@ -220,10 +244,15 @@ class PurgeOrphanedSplitsExecutor(
       val durationMs = System.currentTimeMillis() - startTime
       return PurgeResult(
         status = if (dryRun) "DRY_RUN" else "SUCCESS",
-        orphanedFilesFound = 0, orphanedFilesDeleted = 0, sizeMBDeleted = 0.0,
-        txLogFilesDeleted = versionFilesDeleted, retentionHours = retentionHours,
-        expiredStatesFound = stateCleanupResult.found, expiredStatesDeleted = stateCleanupResult.deleted,
-        dryRun = dryRun, durationMs = durationMs,
+        orphanedFilesFound = 0,
+        orphanedFilesDeleted = 0,
+        sizeMBDeleted = 0.0,
+        txLogFilesDeleted = versionFilesDeleted,
+        retentionHours = retentionHours,
+        expiredStatesFound = stateCleanupResult.found,
+        expiredStatesDeleted = stateCleanupResult.deleted,
+        dryRun = dryRun,
+        durationMs = durationMs,
         message = Some(s"No orphaned files found.$stateMessage")
       )
     }
@@ -232,17 +261,25 @@ class PurgeOrphanedSplitsExecutor(
     val retentionTimestamp  = System.currentTimeMillis() - (retentionHours * 3600 * 1000)
     val eligibleForDeletion = orphanedFiles.filter(col("modificationTime") < retentionTimestamp)
     val eligibleCount       = eligibleForDeletion.count()
-    logger.info(s"Orphaned files eligible for deletion: $eligibleCount (skipped ${orphanedCount - eligibleCount} too recent)")
+    logger.info(
+      s"Orphaned files eligible for deletion: $eligibleCount (skipped ${orphanedCount - eligibleCount} too recent)"
+    )
 
     if (eligibleCount == 0) {
       val durationMs = System.currentTimeMillis() - startTime
       return PurgeResult(
         status = if (dryRun) "DRY_RUN" else "SUCCESS",
-        orphanedFilesFound = orphanedCount, orphanedFilesDeleted = 0, sizeMBDeleted = 0.0,
-        txLogFilesDeleted = versionFilesDeleted, retentionHours = retentionHours,
-        expiredStatesFound = stateCleanupResult.found, expiredStatesDeleted = stateCleanupResult.deleted,
-        dryRun = dryRun, durationMs = durationMs,
-        message = Some(s"$orphanedCount orphaned files found, but all are newer than retention period ($retentionHours hours).$stateMessage")
+        orphanedFilesFound = orphanedCount,
+        orphanedFilesDeleted = 0,
+        sizeMBDeleted = 0.0,
+        txLogFilesDeleted = versionFilesDeleted,
+        retentionHours = retentionHours,
+        expiredStatesFound = stateCleanupResult.found,
+        expiredStatesDeleted = stateCleanupResult.deleted,
+        dryRun = dryRun,
+        durationMs = durationMs,
+        message =
+          Some(s"$orphanedCount orphaned files found, but all are newer than retention period ($retentionHours hours).$stateMessage")
       )
     }
 
@@ -943,8 +980,7 @@ class PurgeOrphanedSplitsExecutor(
    *   The specific versions to scan (typically versions that will remain after cleanup) Returns: Seq[AddAction]
    *   containing all files that appear in any of the specified versions
    */
-  private def getAllFilesFromVersions(txLog: TransactionLogInterface, versionsToScan: Seq[Long])
-    : Seq[AddAction] = {
+  private def getAllFilesFromVersions(txLog: TransactionLogInterface, versionsToScan: Seq[Long]): Seq[AddAction] = {
     logger.info(s"Scanning ${versionsToScan.size} transaction log versions for file references (time travel support)")
 
     // Collect all unique file paths that appear in ANY of the specified versions
@@ -1021,9 +1057,9 @@ class PurgeOrphanedSplitsExecutor(
     // scanning them would over-protect files that have since been removed (e.g., by MERGE
     // or DROP PARTITIONS). Only post-checkpoint versions may contain state changes not yet
     // reflected in a checkpoint.
-    val checkpointVersion = txLog.getLastCheckpointVersion().getOrElse(-1L)
+    val checkpointVersion      = txLog.getLastCheckpointVersion().getOrElse(-1L)
     val postCheckpointVersions = versionsToKeep.filter(_ > checkpointVersion)
-    val versionFiles = getAllFilesFromVersions(txLog, postCheckpointVersions)
+    val versionFiles           = getAllFilesFromVersions(txLog, postCheckpointVersions)
     versionFiles.foreach { add =>
       allFilePaths += add.path
       // Keep the most recent AddAction for each path (for metadata like size)
@@ -1223,9 +1259,9 @@ class PurgeOrphanedSplitsExecutor(
   private def parseActionsFromStream(provider: CloudStorageProvider, filePath: String): Seq[Action] = {
     import io.indextables.spark.util.JsonUtil
 
-    val rawStream           = provider.openInputStream(filePath)
-    val reader              = new BufferedReader(new InputStreamReader(rawStream, "UTF-8"))
-    val actions             = ListBuffer[Action]()
+    val rawStream = provider.openInputStream(filePath)
+    val reader    = new BufferedReader(new InputStreamReader(rawStream, "UTF-8"))
+    val actions   = ListBuffer[Action]()
 
     try {
       var line = reader.readLine()
@@ -1252,9 +1288,11 @@ class PurgeOrphanedSplitsExecutor(
       .map { line =>
         EnhancedTransactionLogCache.incrementGlobalJsonParseCounter()
         val jsonNode = JsonUtil.mapper.readTree(line)
-        ActionJsonSerializer.parseActionFromJsonNode(jsonNode).getOrElse(
-          throw new IllegalArgumentException(s"Unknown action type in line: $line")
-        )
+        ActionJsonSerializer
+          .parseActionFromJsonNode(jsonNode)
+          .getOrElse(
+            throw new IllegalArgumentException(s"Unknown action type in line: $line")
+          )
       }
       .toSeq
   }
@@ -1425,9 +1463,7 @@ class PurgeOrphanedSplitsExecutor(
     spark.createDataset(addedFiles)
   }
 
-  /**
-   * Convert retained file paths from the native layer into a Dataset of filenames for anti-join.
-   */
+  /** Convert retained file paths from the native layer into a Dataset of filenames for anti-join. */
   private def getValidSplitFilesFromRetainedPaths(retainedPaths: Set[String]): Dataset[String] = {
     import spark.implicits._
     val filenames = retainedPaths.map(_.split('/').last).toSeq

--- a/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
@@ -469,7 +469,9 @@ case class SyncToExternalCommand(
             .map { json =>
               import com.fasterxml.jackson.core.`type`.TypeReference
               io.indextables.spark.util.JsonUtil.mapper
-                .readValue(json, new TypeReference[java.util.Map[String, String]]() {}).asScala.toMap
+                .readValue(json, new TypeReference[java.util.Map[String, String]]() {})
+                .asScala
+                .toMap
             }
             .getOrElse(Map.empty)
         } catch {
@@ -558,12 +560,14 @@ case class SyncToExternalCommand(
       // When no HASHED FASTFIELDS clause is specified, tantivy4java hashes ALL string columns by default,
       // which can produce oversized splits with many useless hashed columns.
       if (effectiveHfInclude.isEmpty && effectiveHfExclude.isEmpty) {
-        val textFields = effectiveIndexingModes.collect { case (f, m) if m.toLowerCase == "text" => f.toLowerCase }.toSet
+        val textFields = effectiveIndexingModes.collect {
+          case (f, m) if m.toLowerCase == "text" => f.toLowerCase
+        }.toSet
         val partitionFieldsLower = partitionColumns.map(_.toLowerCase).toSet
         val hashableStringColumns = sourceSchema.fields.count { field =>
           field.dataType == StringType &&
-            !textFields.contains(field.name.toLowerCase) &&
-            !partitionFieldsLower.contains(field.name.toLowerCase)
+          !textFields.contains(field.name.toLowerCase) &&
+          !partitionFieldsLower.contains(field.name.toLowerCase)
         }
         val maxAutomaticHashedFastfields = mergedConfigs
           .get("spark.indextables.companion.maxAutomaticHashedFastfields")
@@ -1093,9 +1097,10 @@ case class SyncToExternalCommand(
             )
           } else Map.empty) ++ (if (effectiveIndexingModes.nonEmpty) {
                                   Map(
-                                    "indextables.companion.indexingModes" -> io.indextables.spark.util.JsonUtil.mapper.writeValueAsString(
-                                      effectiveIndexingModes.asJava
-                                    )
+                                    "indextables.companion.indexingModes" -> io.indextables.spark.util.JsonUtil.mapper
+                                      .writeValueAsString(
+                                        effectiveIndexingModes.asJava
+                                      )
                                   )
                                 } else Map.empty) ++ (if (effectiveWherePredicates.nonEmpty) {
                                                         Map(

--- a/src/main/scala/io/indextables/spark/sql/TruncateTimeTravelCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/TruncateTimeTravelCommand.scala
@@ -147,7 +147,7 @@ case class TruncateTimeTravelCommand(
           val versionFiles    = scala.collection.mutable.ListBuffer[(Long, String)]()
           val checkpointFiles = scala.collection.mutable.ListBuffer[(Long, String)]()
           val partFiles       = scala.collection.mutable.ListBuffer[(Long, String, String)]() // (version, uuid, path)
-          val avroStateFiles  = scala.collection.mutable.ListBuffer[(Long, String)]() // (version, file path)
+          val avroStateFiles  = scala.collection.mutable.ListBuffer[(Long, String)]()         // (version, file path)
 
           allFiles.foreach { f =>
             val filePath = new Path(f.path)
@@ -170,8 +170,10 @@ case class TruncateTimeTravelCommand(
             }
           }
 
-          logger.info(s"Found ${versionFiles.size} version files, ${checkpointFiles.size} JSON checkpoints, " +
-            s"${partFiles.size} checkpoint parts, ${avroStateFiles.map(_._1).toSet.size} Avro state checkpoints")
+          logger.info(
+            s"Found ${versionFiles.size} version files, ${checkpointFiles.size} JSON checkpoints, " +
+              s"${partFiles.size} checkpoint parts, ${avroStateFiles.map(_._1).toSet.size} Avro state checkpoints"
+          )
 
           // Identify files to delete:
           // - Version files with version < checkpointVersion
@@ -183,10 +185,13 @@ case class TruncateTimeTravelCommand(
           val partsToDelete       = partFiles.filter(_._1 < checkpointVersion)
           val avroStateToDelete   = avroStateFiles.filter(_._1 < checkpointVersion)
 
-          val totalFilesToDelete = versionsToDelete.size + checkpointsToDelete.size + partsToDelete.size + avroStateToDelete.size
+          val totalFilesToDelete =
+            versionsToDelete.size + checkpointsToDelete.size + partsToDelete.size + avroStateToDelete.size
 
-          logger.info(s"Files to delete: ${versionsToDelete.size} versions, ${checkpointsToDelete.size} checkpoints, " +
-            s"${partsToDelete.size} parts, ${avroStateToDelete.size} Avro state files")
+          logger.info(
+            s"Files to delete: ${versionsToDelete.size} versions, ${checkpointsToDelete.size} checkpoints, " +
+              s"${partsToDelete.size} parts, ${avroStateToDelete.size} Avro state files"
+          )
 
           if (totalFilesToDelete == 0) {
             return Seq(

--- a/src/main/scala/io/indextables/spark/sync/DistributedSourceScanner.scala
+++ b/src/main/scala/io/indextables/spark/sync/DistributedSourceScanner.scala
@@ -17,9 +17,9 @@
 
 package io.indextables.spark.sync
 
-import scala.jdk.CollectionConverters._
-
 import java.time.LocalDate
+
+import scala.jdk.CollectionConverters._
 
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.{DataType, DateType, StructType}
@@ -189,26 +189,29 @@ object DistributedSourceScanner {
     dateColumns: Set[String]
   ): Map[String, String] = {
     if (dateColumns.isEmpty) return partitionValues
-    partitionValues.map { case (key, value) =>
-      if (dateColumns.contains(key)) {
-        try {
-          val epochDay = value.toLong
-          if (isPlausibleEpochDay(epochDay)) {
-            key -> LocalDate.ofEpochDay(epochDay).toString
-          } else {
-            key -> value // implausibly large — likely a compact ISO date, pass through
+    partitionValues.map {
+      case (key, value) =>
+        if (dateColumns.contains(key)) {
+          try {
+            val epochDay = value.toLong
+            if (isPlausibleEpochDay(epochDay)) {
+              key -> LocalDate.ofEpochDay(epochDay).toString
+            } else {
+              key -> value // implausibly large — likely a compact ISO date, pass through
+            }
+          } catch {
+            case _: NumberFormatException => key -> value
           }
-        } catch {
-          case _: NumberFormatException => key -> value
+        } else {
+          key -> value
         }
-      } else {
-        key -> value
-      }
     }
   }
 
-  /** Plausibility check: epoch days outside -100000..100000 (~year -304 to ~2243) are likely
-    * compact ISO dates (e.g., 20260322) rather than real epoch days. */
+  /**
+   * Plausibility check: epoch days outside -100000..100000 (~year -304 to ~2243) are likely compact ISO dates (e.g.,
+   * 20260322) rather than real epoch days.
+   */
   private[spark] def isPlausibleEpochDay(n: Long): Boolean = n >= -100000 && n <= 100000
 
   /** Extract the set of DATE column names from a Spark StructType schema. */
@@ -387,7 +390,8 @@ object DistributedSourceScanner {
                 case None => absolutePath
               }
 
-              val effectivePartitionValues = resolvePartitionValues(partitionValues, absolutePath, storageRoot, dateColumns)
+              val effectivePartitionValues =
+                resolvePartitionValues(partitionValues, absolutePath, storageRoot, dateColumns)
 
               results += CompanionSourceFile(
                 path = relativePath,

--- a/src/main/scala/io/indextables/spark/sync/IcebergSourceReader.scala
+++ b/src/main/scala/io/indextables/spark/sync/IcebergSourceReader.scala
@@ -48,17 +48,15 @@ object IcebergSourceReader {
     config
   }
 
-  private val logger = LoggerFactory.getLogger(getClass)
+  private val logger         = LoggerFactory.getLogger(getClass)
   private val decimalPattern = """decimal\((\d+),\s*(\d+)\)""".r
-  private val fixedPattern = """fixed\[(\d+)\]""".r
+  private val fixedPattern   = """fixed\[(\d+)\]""".r
 
-  /**
-   * Parse schema JSON to Spark StructType, trying Spark format first and falling back to Iceberg format conversion.
-   */
+  /** Parse schema JSON to Spark StructType, trying Spark format first and falling back to Iceberg format conversion. */
   def parseSchemaJson(schemaJson: String): StructType =
-    try {
+    try
       DataType.fromJson(schemaJson).asInstanceOf[StructType]
-    } catch {
+    catch {
       case _: Exception =>
         logger.info("Schema JSON is not Spark-compatible, converting from Iceberg format")
         convertIcebergSchemaToSpark(schemaJson)
@@ -70,7 +68,7 @@ object IcebergSourceReader {
    * "fields":[{"name":"...", "type":"long", "nullable":true, "metadata":{}}]}
    */
   def convertIcebergSchemaToSpark(schemaJson: String): StructType = {
-    val root = JsonUtil.mapper.readTree(schemaJson)
+    val root   = JsonUtil.mapper.readTree(schemaJson)
     val fields = root.get("fields")
 
     val sparkFields = (0 until fields.size()).map { i =>
@@ -127,10 +125,10 @@ object IcebergSourceReader {
     case "binary" | "fixed"                                              => BinaryType
     case "date"                                                          => DateType
     case "timestamp" | "timestamptz" | "timestamp_ns" | "timestamptz_ns" => TimestampType
-    case "time"                           => LongType
-    case "uuid"                           => StringType
-    case fixedPattern(_)                  => BinaryType
-    case decimalPattern(precision, scale) => DecimalType(precision.toInt, scale.toInt)
+    case "time"                                                          => LongType
+    case "uuid"                                                          => StringType
+    case fixedPattern(_)                                                 => BinaryType
+    case decimalPattern(precision, scale)                                => DecimalType(precision.toInt, scale.toInt)
     case other =>
       logger.warn(s"Unknown Iceberg type '$other', defaulting to StringType")
       StringType
@@ -227,7 +225,9 @@ class IcebergSourceReader(
 
     // Extract DATE column names so we can convert Iceberg epoch-day partition
     // values to ISO format (e.g., "20527" -> "2026-03-22").
-    val schemaOpt = try Some(parsedSchema) catch { case _: Exception => None }
+    val schemaOpt =
+      try Some(parsedSchema)
+      catch { case _: Exception => None }
     val dateColumns = DistributedSourceScanner.extractDateColumns(schemaOpt)
 
     // Build files with absolute paths first (needed for partition value extraction).
@@ -235,8 +235,8 @@ class IcebergSourceReader(
     val absoluteFiles = parquetFiles.map { entry =>
       CompanionSourceFile(
         path = entry.getPath,
-        partitionValues = DistributedSourceScanner.normalizeIcebergDatePartitions(
-          entry.getPartitionValues.asScala.toMap, dateColumns),
+        partitionValues =
+          DistributedSourceScanner.normalizeIcebergDatePartitions(entry.getPartitionValues.asScala.toMap, dateColumns),
         size = entry.getFileSizeBytes
       )
     }

--- a/src/main/scala/io/indextables/spark/sync/SyncTaskExecutor.scala
+++ b/src/main/scala/io/indextables/spark/sync/SyncTaskExecutor.scala
@@ -292,7 +292,7 @@ object SyncTaskExecutor {
       downloadFromAzure(sourcePath, destFile, storageConfig)
     } else {
       // Local filesystem copy — path may be a plain path or a file:// URI (Iceberg uses file:// URIs)
-      val localPath = CloudPathUtils.stripFileScheme(sourcePath)
+      val localPath  = CloudPathUtils.stripFileScheme(sourcePath)
       val sourceFile = new File(localPath)
       Files.copy(sourceFile.toPath, destFile.toPath, StandardCopyOption.REPLACE_EXISTING)
       sourceFile.length()
@@ -404,7 +404,6 @@ object SyncTaskExecutor {
       ("spark.indextables.databricks.credential.operation" -> "PATH_READ_WRITE")
     io.indextables.spark.io.merge.MergeUploader.uploadWithRetry(localPath, destPath, uploadConfig, tablePath)
   }
-
 
   /**
    * Extract the table base path from a full file path by stripping the filename and any trailing Hive-style partition

--- a/src/main/scala/io/indextables/spark/transaction/ActionJsonSerializer.scala
+++ b/src/main/scala/io/indextables/spark/transaction/ActionJsonSerializer.scala
@@ -17,44 +17,36 @@
 
 package io.indextables.spark.transaction
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.{ArrayNode, ObjectNode}
+import com.fasterxml.jackson.databind.JsonNode
 import io.indextables.spark.util.JsonUtil
 
 /**
- * Serializes Scala Action types to JSON formats expected by the native tantivy4java transaction log
- * API.
+ * Serializes Scala Action types to JSON formats expected by the native tantivy4java transaction log API.
  *
  * Two output formats:
- *   - JSON-lines for `writeVersion()` (GAP-1): one JSON object per line with action type
- *     discriminator
+ *   - JSON-lines for `writeVersion()` (GAP-1): one JSON object per line with action type discriminator
  *   - JSON array for `addFiles()`: array of AddAction objects
  */
 object ActionJsonSerializer {
 
   private val mapper = JsonUtil.mapper
 
-  /**
-   * Serialize a sequence of AddActions to a JSON array string for `TransactionLogWriter.addFiles()`.
-   */
+  /** Serialize a sequence of AddActions to a JSON array string for `TransactionLogWriter.addFiles()`. */
   def addActionsToJson(addActions: Seq[AddAction]): String = {
     val arrayNode = mapper.createArrayNode()
-    addActions.foreach { a => arrayNode.add(addActionToObjectNode(a)) }
+    addActions.foreach(a => arrayNode.add(addActionToObjectNode(a)))
     mapper.writeValueAsString(arrayNode)
   }
 
-  /**
-   * Serialize a ProtocolAction to a JSON-lines entry: `{"protocol":{...}}`.
-   */
+  /** Serialize a ProtocolAction to a JSON-lines entry: `{"protocol":{...}}`. */
   def protocolToJsonLine(protocol: ProtocolAction): String = {
     val wrapper = mapper.createObjectNode()
     wrapper.set[ObjectNode]("protocol", protocolToObjectNode(protocol))
     mapper.writeValueAsString(wrapper)
   }
 
-  /**
-   * Serialize a MetadataAction to a JSON-lines entry: `{"metaData":{...}}`.
-   */
+  /** Serialize a MetadataAction to a JSON-lines entry: `{"metaData":{...}}`. */
   def metadataToJsonLine(metadata: MetadataAction): String = {
     val wrapper = mapper.createObjectNode()
     wrapper.set[ObjectNode]("metaData", metadataToObjectNode(metadata))
@@ -105,9 +97,7 @@ object ActionJsonSerializer {
     node
   }
 
-  /**
-   * Serialize a RemoveAction to a JSON-lines entry: `{"remove":{...}}`.
-   */
+  /** Serialize a RemoveAction to a JSON-lines entry: `{"remove":{...}}`. */
   def removeToJsonLine(remove: RemoveAction): String = {
     val wrapper = mapper.createObjectNode()
     val node    = mapper.createObjectNode()
@@ -130,18 +120,14 @@ object ActionJsonSerializer {
     mapper.writeValueAsString(wrapper)
   }
 
-  /**
-   * Serialize an AddAction to a JSON-lines entry: `{"add":{...}}`.
-   */
+  /** Serialize an AddAction to a JSON-lines entry: `{"add":{...}}`. */
   def addToJsonLine(add: AddAction): String = {
     val wrapper = mapper.createObjectNode()
     wrapper.set[ObjectNode]("add", addActionToObjectNode(add))
     mapper.writeValueAsString(wrapper)
   }
 
-  /**
-   * Serialize a SkipAction to a JSON string for `TransactionLogWriter.skipFile()`.
-   */
+  /** Serialize a SkipAction to a JSON string for `TransactionLogWriter.skipFile()`. */
   def skipActionToJson(skip: SkipAction): String = {
     val node = mapper.createObjectNode()
     node.put("path", skip.path)
@@ -164,35 +150,32 @@ object ActionJsonSerializer {
    *
    * Each action is serialized as a single JSON line with an action type discriminator.
    */
-  def actionsToJsonLines(actions: Seq[Action]): String = {
-    actions.map {
-      case p: ProtocolAction => protocolToJsonLine(p)
-      case m: MetadataAction => metadataToJsonLine(m)
-      case a: AddAction      => addToJsonLine(a)
-      case r: RemoveAction   => removeToJsonLine(r)
-      case s: SkipAction =>
-        val wrapper = mapper.createObjectNode()
-        val skipNode = mapper.createObjectNode()
-        skipNode.put("path", s.path)
-        skipNode.put("skipTimestamp", s.skipTimestamp)
-        skipNode.put("reason", s.reason)
-        skipNode.put("operation", s.operation)
-        s.retryAfter.foreach(skipNode.put("retryAfter", _))
-        skipNode.put("skipCount", s.skipCount)
-        wrapper.set[ObjectNode]("skip", skipNode)
-        mapper.writeValueAsString(wrapper)
-    }.mkString("\n")
-  }
+  def actionsToJsonLines(actions: Seq[Action]): String =
+    actions
+      .map {
+        case p: ProtocolAction => protocolToJsonLine(p)
+        case m: MetadataAction => metadataToJsonLine(m)
+        case a: AddAction      => addToJsonLine(a)
+        case r: RemoveAction   => removeToJsonLine(r)
+        case s: SkipAction =>
+          val wrapper  = mapper.createObjectNode()
+          val skipNode = mapper.createObjectNode()
+          skipNode.put("path", s.path)
+          skipNode.put("skipTimestamp", s.skipTimestamp)
+          skipNode.put("reason", s.reason)
+          skipNode.put("operation", s.operation)
+          s.retryAfter.foreach(skipNode.put("retryAfter", _))
+          skipNode.put("skipCount", s.skipCount)
+          wrapper.set[ObjectNode]("skip", skipNode)
+          mapper.writeValueAsString(wrapper)
+      }
+      .mkString("\n")
 
-  /**
-   * Serialize a ProtocolAction to a standalone JSON string (no wrapper).
-   */
+  /** Serialize a ProtocolAction to a standalone JSON string (no wrapper). */
   def protocolToJson(protocol: ProtocolAction): String =
     mapper.writeValueAsString(protocolToObjectNode(protocol))
 
-  /**
-   * Serialize a MetadataAction to a standalone JSON string (no wrapper).
-   */
+  /** Serialize a MetadataAction to a standalone JSON string (no wrapper). */
   def metadataToJson(metadata: MetadataAction): String =
     mapper.writeValueAsString(metadataToObjectNode(metadata))
 

--- a/src/main/scala/io/indextables/spark/transaction/ActionsToArrowConverter.scala
+++ b/src/main/scala/io/indextables/spark/transaction/ActionsToArrowConverter.scala
@@ -19,41 +19,42 @@ package io.indextables.spark.transaction
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.arrow.c.{ArrowArray, ArrowSchema, Data}
-import org.slf4j.LoggerFactory
-import org.apache.arrow.memory.BufferAllocator
-import org.apache.arrow.vector._
-import org.apache.arrow.vector.complex.ListVector
-import org.apache.arrow.vector.complex.impl.UnionListWriter
-import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
-
 import io.indextables.spark.arrow.ArrowFfiBridge
 import io.indextables.spark.util.JsonUtil
+import org.apache.arrow.c.{ArrowArray, ArrowSchema, Data}
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector._
+import org.apache.arrow.vector.complex.impl.UnionListWriter
+import org.apache.arrow.vector.complex.ListVector
+import org.apache.arrow.vector.types.pojo.{ArrowType, Field, FieldType, Schema}
+import org.slf4j.LoggerFactory
 
 /**
  * Converts Scala Action objects to an Arrow RecordBatch for the FR2 write path.
  *
- * Uses a unified schema with an `action_type` discriminator column.
- * Non-applicable columns are null for each action type.
+ * Uses a unified schema with an `action_type` discriminator column. Non-applicable columns are null for each action
+ * type.
  *
- * The Arrow batch is exported via Arrow C Data Interface (FFI) and passed
- * to TransactionLogWriter.writeVersionArrowFfi().
+ * The Arrow batch is exported via Arrow C Data Interface (FFI) and passed to
+ * TransactionLogWriter.writeVersionArrowFfi().
  */
 object ActionsToArrowConverter {
 
-  private val logger = LoggerFactory.getLogger(ActionsToArrowConverter.getClass)
-  private val mapper = JsonUtil.mapper
+  private val logger                     = LoggerFactory.getLogger(ActionsToArrowConverter.getClass)
+  private val mapper                     = JsonUtil.mapper
   private val allocator: BufferAllocator = ArrowFfiBridge.allocator
 
   /**
    * Export actions as Arrow FFI structs for writeVersionArrowFfi.
    *
-   * @param actions Seq of Action (AddAction, RemoveAction, SkipAction, ProtocolAction, MetadataAction)
-   * @return (arrayAddr, schemaAddr) — caller passes these to writeVersionArrowFfi, then must close the ArrowArray/ArrowSchema
+   * @param actions
+   *   Seq of Action (AddAction, RemoveAction, SkipAction, ProtocolAction, MetadataAction)
+   * @return
+   *   (arrayAddr, schemaAddr) — caller passes these to writeVersionArrowFfi, then must close the ArrowArray/ArrowSchema
    */
   def exportAsFfi(actions: Seq[Action]): (ArrowArray, ArrowSchema, Long, Long) = {
-    val root = buildVectorSchemaRoot(actions)
-    val arrowArray = ArrowArray.allocateNew(allocator)
+    val root        = buildVectorSchemaRoot(actions)
+    val arrowArray  = ArrowArray.allocateNew(allocator)
     val arrowSchema = ArrowSchema.allocateNew(allocator)
     try {
       Data.exportVectorSchemaRoot(allocator, root, null, arrowArray, arrowSchema)
@@ -63,162 +64,173 @@ object ActionsToArrowConverter {
         arrowArray.close()
         arrowSchema.close()
         throw e
-    } finally {
+    } finally
       root.close() // always close root; caller owns arrowArray/arrowSchema on success
-    }
   }
 
   private def buildVectorSchemaRoot(actions: Seq[Action]): VectorSchemaRoot = {
     val schema = buildSchema()
-    val root = VectorSchemaRoot.create(schema, allocator)
+    val root   = VectorSchemaRoot.create(schema, allocator)
 
-    val actionTypeVec = root.getVector("action_type").asInstanceOf[VarCharVector]
-    val pathVec = root.getVector("path").asInstanceOf[VarCharVector]
-    val sizeVec = root.getVector("size").asInstanceOf[BigIntVector]
-    val modTimeVec = root.getVector("modification_time").asInstanceOf[BigIntVector]
-    val dataChangeVec = root.getVector("data_change").asInstanceOf[BitVector]
-    val partitionValuesVec = root.getVector("partition_values").asInstanceOf[VarCharVector]
-    val numRecordsVec = root.getVector("num_records").asInstanceOf[BigIntVector]
-    val minValuesVec = root.getVector("min_values").asInstanceOf[VarCharVector]
-    val maxValuesVec = root.getVector("max_values").asInstanceOf[VarCharVector]
-    val statsVec = root.getVector("stats").asInstanceOf[VarCharVector]
-    val footerStartVec = root.getVector("footer_start_offset").asInstanceOf[BigIntVector]
-    val footerEndVec = root.getVector("footer_end_offset").asInstanceOf[BigIntVector]
-    val docMappingJsonVec = root.getVector("doc_mapping_json").asInstanceOf[VarCharVector]
-    val docMappingRefVec = root.getVector("doc_mapping_ref").asInstanceOf[VarCharVector]
-    val uncompressedSizeVec = root.getVector("uncompressed_size_bytes").asInstanceOf[BigIntVector]
-    val timeRangeStartVec = root.getVector("time_range_start").asInstanceOf[BigIntVector]
-    val timeRangeEndVec = root.getVector("time_range_end").asInstanceOf[BigIntVector]
-    val companionDeltaVersionVec = root.getVector("companion_delta_version").asInstanceOf[BigIntVector]
+    val actionTypeVec             = root.getVector("action_type").asInstanceOf[VarCharVector]
+    val pathVec                   = root.getVector("path").asInstanceOf[VarCharVector]
+    val sizeVec                   = root.getVector("size").asInstanceOf[BigIntVector]
+    val modTimeVec                = root.getVector("modification_time").asInstanceOf[BigIntVector]
+    val dataChangeVec             = root.getVector("data_change").asInstanceOf[BitVector]
+    val partitionValuesVec        = root.getVector("partition_values").asInstanceOf[VarCharVector]
+    val numRecordsVec             = root.getVector("num_records").asInstanceOf[BigIntVector]
+    val minValuesVec              = root.getVector("min_values").asInstanceOf[VarCharVector]
+    val maxValuesVec              = root.getVector("max_values").asInstanceOf[VarCharVector]
+    val statsVec                  = root.getVector("stats").asInstanceOf[VarCharVector]
+    val footerStartVec            = root.getVector("footer_start_offset").asInstanceOf[BigIntVector]
+    val footerEndVec              = root.getVector("footer_end_offset").asInstanceOf[BigIntVector]
+    val docMappingJsonVec         = root.getVector("doc_mapping_json").asInstanceOf[VarCharVector]
+    val docMappingRefVec          = root.getVector("doc_mapping_ref").asInstanceOf[VarCharVector]
+    val uncompressedSizeVec       = root.getVector("uncompressed_size_bytes").asInstanceOf[BigIntVector]
+    val timeRangeStartVec         = root.getVector("time_range_start").asInstanceOf[BigIntVector]
+    val timeRangeEndVec           = root.getVector("time_range_end").asInstanceOf[BigIntVector]
+    val companionDeltaVersionVec  = root.getVector("companion_delta_version").asInstanceOf[BigIntVector]
     val companionFastFieldModeVec = root.getVector("companion_fast_field_mode").asInstanceOf[VarCharVector]
-    val deletionTimestampVec = root.getVector("deletion_timestamp").asInstanceOf[BigIntVector]
-    val skipTimestampVec = root.getVector("skip_timestamp").asInstanceOf[BigIntVector]
-    val reasonVec = root.getVector("reason").asInstanceOf[VarCharVector]
-    val operationVec = root.getVector("operation").asInstanceOf[VarCharVector]
-    val retryAfterVec = root.getVector("retry_after").asInstanceOf[BigIntVector]
-    val skipCountVec = root.getVector("skip_count").asInstanceOf[IntVector]
-    val minReaderVersionVec = root.getVector("min_reader_version").asInstanceOf[IntVector]
-    val minWriterVersionVec = root.getVector("min_writer_version").asInstanceOf[IntVector]
-    val metadataIdVec = root.getVector("id").asInstanceOf[VarCharVector]
-    val metadataNameVec = root.getVector("metadata_name").asInstanceOf[VarCharVector]
-    val metadataDescriptionVec = root.getVector("metadata_description").asInstanceOf[VarCharVector]
-    val schemaStringVec = root.getVector("schema_string").asInstanceOf[VarCharVector]
-    val configurationVec = root.getVector("configuration").asInstanceOf[VarCharVector]
-    val createdTimeVec = root.getVector("created_time").asInstanceOf[BigIntVector]
-    val formatProviderVec = root.getVector("format_provider").asInstanceOf[VarCharVector]
-    val formatOptionsVec = root.getVector("format_options").asInstanceOf[VarCharVector]
+    val deletionTimestampVec      = root.getVector("deletion_timestamp").asInstanceOf[BigIntVector]
+    val skipTimestampVec          = root.getVector("skip_timestamp").asInstanceOf[BigIntVector]
+    val reasonVec                 = root.getVector("reason").asInstanceOf[VarCharVector]
+    val operationVec              = root.getVector("operation").asInstanceOf[VarCharVector]
+    val retryAfterVec             = root.getVector("retry_after").asInstanceOf[BigIntVector]
+    val skipCountVec              = root.getVector("skip_count").asInstanceOf[IntVector]
+    val minReaderVersionVec       = root.getVector("min_reader_version").asInstanceOf[IntVector]
+    val minWriterVersionVec       = root.getVector("min_writer_version").asInstanceOf[IntVector]
+    val metadataIdVec             = root.getVector("id").asInstanceOf[VarCharVector]
+    val metadataNameVec           = root.getVector("metadata_name").asInstanceOf[VarCharVector]
+    val metadataDescriptionVec    = root.getVector("metadata_description").asInstanceOf[VarCharVector]
+    val schemaStringVec           = root.getVector("schema_string").asInstanceOf[VarCharVector]
+    val configurationVec          = root.getVector("configuration").asInstanceOf[VarCharVector]
+    val createdTimeVec            = root.getVector("created_time").asInstanceOf[BigIntVector]
+    val formatProviderVec         = root.getVector("format_provider").asInstanceOf[VarCharVector]
+    val formatOptionsVec          = root.getVector("format_options").asInstanceOf[VarCharVector]
     // List vectors for split_tags, companion_source_files, partition_columns, reader/writer_features
-    val splitTagsVec = root.getVector("split_tags").asInstanceOf[ListVector]
+    val splitTagsVec            = root.getVector("split_tags").asInstanceOf[ListVector]
     val companionSourceFilesVec = root.getVector("companion_source_files").asInstanceOf[ListVector]
-    val partitionColumnsVec = root.getVector("partition_columns").asInstanceOf[ListVector]
-    val readerFeaturesVec = root.getVector("reader_features").asInstanceOf[ListVector]
-    val writerFeaturesVec = root.getVector("writer_features").asInstanceOf[ListVector]
+    val partitionColumnsVec     = root.getVector("partition_columns").asInstanceOf[ListVector]
+    val readerFeaturesVec       = root.getVector("reader_features").asInstanceOf[ListVector]
+    val writerFeaturesVec       = root.getVector("writer_features").asInstanceOf[ListVector]
 
     // Allocate all vectors
     root.allocateNew()
 
-    actions.zipWithIndex.foreach { case (action, i) =>
-      action match {
-        case a: AddAction =>
-          setString(actionTypeVec, i, "add")
-          setString(pathVec, i, a.path)
-          sizeVec.setSafe(i, a.size)
-          modTimeVec.setSafe(i, a.modificationTime)
-          dataChangeVec.setSafe(i, if (a.dataChange) 1 else 0)
-          a.partitionValues match {
-            case m if m.nonEmpty => setString(partitionValuesVec, i, mapper.writeValueAsString(m.asJava))
-            case _ => partitionValuesVec.setNull(i)
-          }
-          a.numRecords.foreach(numRecordsVec.setSafe(i, _))
-          a.minValues.foreach(m => setString(minValuesVec, i, mapper.writeValueAsString(m.asJava)))
-          a.maxValues.foreach(m => setString(maxValuesVec, i, mapper.writeValueAsString(m.asJava)))
-          a.stats.foreach(s => setString(statsVec, i, s))
-          a.footerStartOffset.foreach(footerStartVec.setSafe(i, _))
-          a.footerEndOffset.foreach(footerEndVec.setSafe(i, _))
-          a.docMappingJson.foreach(s => setString(docMappingJsonVec, i, s))
-          a.docMappingRef.foreach(s => setString(docMappingRefVec, i, s))
-          a.uncompressedSizeBytes.foreach(uncompressedSizeVec.setSafe(i, _))
-          a.timeRangeStart.foreach { t =>
-            try { timeRangeStartVec.setSafe(i, t.toLong) } catch {
-              case _: NumberFormatException =>
-                logger.warn(s"Cannot parse timeRangeStart '$t' as Long for ${a.path}, time-based pruning disabled for this split")
+    actions.zipWithIndex.foreach {
+      case (action, i) =>
+        action match {
+          case a: AddAction =>
+            setString(actionTypeVec, i, "add")
+            setString(pathVec, i, a.path)
+            sizeVec.setSafe(i, a.size)
+            modTimeVec.setSafe(i, a.modificationTime)
+            dataChangeVec.setSafe(i, if (a.dataChange) 1 else 0)
+            a.partitionValues match {
+              case m if m.nonEmpty => setString(partitionValuesVec, i, mapper.writeValueAsString(m.asJava))
+              case _               => partitionValuesVec.setNull(i)
             }
-          }
-          a.timeRangeEnd.foreach { t =>
-            try { timeRangeEndVec.setSafe(i, t.toLong) } catch {
-              case _: NumberFormatException =>
-                logger.warn(s"Cannot parse timeRangeEnd '$t' as Long for ${a.path}, time-based pruning disabled for this split")
+            a.numRecords.foreach(numRecordsVec.setSafe(i, _))
+            a.minValues.foreach(m => setString(minValuesVec, i, mapper.writeValueAsString(m.asJava)))
+            a.maxValues.foreach(m => setString(maxValuesVec, i, mapper.writeValueAsString(m.asJava)))
+            a.stats.foreach(s => setString(statsVec, i, s))
+            a.footerStartOffset.foreach(footerStartVec.setSafe(i, _))
+            a.footerEndOffset.foreach(footerEndVec.setSafe(i, _))
+            a.docMappingJson.foreach(s => setString(docMappingJsonVec, i, s))
+            a.docMappingRef.foreach(s => setString(docMappingRefVec, i, s))
+            a.uncompressedSizeBytes.foreach(uncompressedSizeVec.setSafe(i, _))
+            a.timeRangeStart.foreach { t =>
+              try timeRangeStartVec.setSafe(i, t.toLong)
+              catch {
+                case _: NumberFormatException =>
+                  logger.warn(s"Cannot parse timeRangeStart '$t' as Long for ${a.path}, time-based pruning disabled for this split")
+              }
             }
-          }
-          a.companionDeltaVersion.foreach(companionDeltaVersionVec.setSafe(i, _))
-          a.companionFastFieldMode.foreach(s => setString(companionFastFieldModeVec, i, s))
-          a.splitTags.foreach(tags => writeStringList(splitTagsVec, i, tags.toSeq))
-          a.companionSourceFiles.foreach(files => writeStringList(companionSourceFilesVec, i, files))
+            a.timeRangeEnd.foreach { t =>
+              try timeRangeEndVec.setSafe(i, t.toLong)
+              catch {
+                case _: NumberFormatException =>
+                  logger.warn(
+                    s"Cannot parse timeRangeEnd '$t' as Long for ${a.path}, time-based pruning disabled for this split"
+                  )
+              }
+            }
+            a.companionDeltaVersion.foreach(companionDeltaVersionVec.setSafe(i, _))
+            a.companionFastFieldMode.foreach(s => setString(companionFastFieldModeVec, i, s))
+            a.splitTags.foreach(tags => writeStringList(splitTagsVec, i, tags.toSeq))
+            a.companionSourceFiles.foreach(files => writeStringList(companionSourceFilesVec, i, files))
 
-        case r: RemoveAction =>
-          setString(actionTypeVec, i, "remove")
-          setString(pathVec, i, r.path)
-          r.deletionTimestamp.foreach(deletionTimestampVec.setSafe(i, _))
-          dataChangeVec.setSafe(i, if (r.dataChange) 1 else 0)
-          r.partitionValues.foreach(m => setString(partitionValuesVec, i, mapper.writeValueAsString(m.asJava)))
-          r.size.foreach(sizeVec.setSafe(i, _))
+          case r: RemoveAction =>
+            setString(actionTypeVec, i, "remove")
+            setString(pathVec, i, r.path)
+            r.deletionTimestamp.foreach(deletionTimestampVec.setSafe(i, _))
+            dataChangeVec.setSafe(i, if (r.dataChange) 1 else 0)
+            r.partitionValues.foreach(m => setString(partitionValuesVec, i, mapper.writeValueAsString(m.asJava)))
+            r.size.foreach(sizeVec.setSafe(i, _))
 
-        case s: SkipAction =>
-          setString(actionTypeVec, i, "mergeskip")
-          setString(pathVec, i, s.path)
-          skipTimestampVec.setSafe(i, s.skipTimestamp)
-          setString(reasonVec, i, s.reason)
-          setString(operationVec, i, s.operation)
-          s.retryAfter.foreach(retryAfterVec.setSafe(i, _))
-          skipCountVec.setSafe(i, s.skipCount)
-          s.partitionValues.foreach(m => setString(partitionValuesVec, i, mapper.writeValueAsString(m.asJava)))
-          s.size.foreach(sizeVec.setSafe(i, _))
+          case s: SkipAction =>
+            setString(actionTypeVec, i, "mergeskip")
+            setString(pathVec, i, s.path)
+            skipTimestampVec.setSafe(i, s.skipTimestamp)
+            setString(reasonVec, i, s.reason)
+            setString(operationVec, i, s.operation)
+            s.retryAfter.foreach(retryAfterVec.setSafe(i, _))
+            skipCountVec.setSafe(i, s.skipCount)
+            s.partitionValues.foreach(m => setString(partitionValuesVec, i, mapper.writeValueAsString(m.asJava)))
+            s.size.foreach(sizeVec.setSafe(i, _))
 
-        case p: ProtocolAction =>
-          setString(actionTypeVec, i, "protocol")
-          minReaderVersionVec.setSafe(i, p.minReaderVersion)
-          minWriterVersionVec.setSafe(i, p.minWriterVersion)
-          p.readerFeatures.foreach(features => writeStringList(readerFeaturesVec, i, features.toSeq))
-          p.writerFeatures.foreach(features => writeStringList(writerFeaturesVec, i, features.toSeq))
+          case p: ProtocolAction =>
+            setString(actionTypeVec, i, "protocol")
+            minReaderVersionVec.setSafe(i, p.minReaderVersion)
+            minWriterVersionVec.setSafe(i, p.minWriterVersion)
+            p.readerFeatures.foreach(features => writeStringList(readerFeaturesVec, i, features.toSeq))
+            p.writerFeatures.foreach(features => writeStringList(writerFeaturesVec, i, features.toSeq))
 
-        case m: MetadataAction =>
-          setString(actionTypeVec, i, "metadata")
-          setString(metadataIdVec, i, m.id)
-          m.name.foreach(n => setString(metadataNameVec, i, n))
-          m.description.foreach(d => setString(metadataDescriptionVec, i, d))
-          setString(schemaStringVec, i, m.schemaString)
-          if (m.partitionColumns.nonEmpty) {
-            writeStringList(partitionColumnsVec, i, m.partitionColumns)
-          }
-          if (m.configuration.nonEmpty) {
-            setString(configurationVec, i, mapper.writeValueAsString(m.configuration.asJava))
-          }
-          m.createdTime.foreach(createdTimeVec.setSafe(i, _))
-          setString(formatProviderVec, i, m.format.provider)
-          if (m.format.options.nonEmpty) {
-            setString(formatOptionsVec, i, mapper.writeValueAsString(m.format.options.asJava))
-          }
+          case m: MetadataAction =>
+            setString(actionTypeVec, i, "metadata")
+            setString(metadataIdVec, i, m.id)
+            m.name.foreach(n => setString(metadataNameVec, i, n))
+            m.description.foreach(d => setString(metadataDescriptionVec, i, d))
+            setString(schemaStringVec, i, m.schemaString)
+            if (m.partitionColumns.nonEmpty) {
+              writeStringList(partitionColumnsVec, i, m.partitionColumns)
+            }
+            if (m.configuration.nonEmpty) {
+              setString(configurationVec, i, mapper.writeValueAsString(m.configuration.asJava))
+            }
+            m.createdTime.foreach(createdTimeVec.setSafe(i, _))
+            setString(formatProviderVec, i, m.format.provider)
+            if (m.format.options.nonEmpty) {
+              setString(formatOptionsVec, i, mapper.writeValueAsString(m.format.options.asJava))
+            }
 
-        case _ => // Unknown action type — skip
-      }
+          case _ => // Unknown action type — skip
+        }
     }
 
     root.setRowCount(actions.size)
     root
   }
 
-  private def setString(vec: VarCharVector, i: Int, value: String): Unit = {
+  private def setString(
+    vec: VarCharVector,
+    i: Int,
+    value: String
+  ): Unit =
     if (value != null) vec.setSafe(i, value.getBytes(java.nio.charset.StandardCharsets.UTF_8))
     else vec.setNull(i)
-  }
 
-  private def writeStringList(vec: ListVector, index: Int, values: Seq[String]): Unit = {
+  private def writeStringList(
+    vec: ListVector,
+    index: Int,
+    values: Seq[String]
+  ): Unit = {
     val writer = vec.getWriter.asInstanceOf[UnionListWriter]
     writer.setPosition(index)
     writer.startList()
     values.foreach { v =>
       val bytes = v.getBytes(java.nio.charset.StandardCharsets.UTF_8)
-      val buf = allocator.buffer(bytes.length)
+      val buf   = allocator.buffer(bytes.length)
       buf.writeBytes(bytes)
       writer.writeVarChar(0, bytes.length, buf)
       buf.close()

--- a/src/main/scala/io/indextables/spark/transaction/ArrowFileEntryExtractor.scala
+++ b/src/main/scala/io/indextables/spark/transaction/ArrowFileEntryExtractor.scala
@@ -21,17 +21,17 @@ import java.nio.charset.StandardCharsets.UTF_8
 
 import scala.jdk.CollectionConverters._
 
-import org.apache.arrow.vector._
-import org.apache.arrow.vector.complex.ListVector
 import org.apache.spark.sql.vectorized.{ArrowColumnVector, ColumnarBatch}
 
 import io.indextables.spark.util.JsonUtil
+import org.apache.arrow.vector._
+import org.apache.arrow.vector.complex.ListVector
 
 /**
  * Extracts AddAction objects from an Arrow ColumnarBatch produced by nativeListFilesArrowFfi.
  *
- * The Arrow schema has 19 fixed columns + N dynamic partition columns (partition:{name}).
- * This extractor reads Arrow vectors directly — no JSON parsing per row.
+ * The Arrow schema has 19 fixed columns + N dynamic partition columns (partition:{name}). This extractor reads Arrow
+ * vectors directly — no JSON parsing per row.
  */
 object ArrowFileEntryExtractor {
 
@@ -40,51 +40,54 @@ object ArrowFileEntryExtractor {
   /**
    * Extract AddAction objects from an Arrow batch.
    *
-   * @param batch           Arrow ColumnarBatch from native FFI
-   * @param partitionColumns Partition column names (for dynamic partition:{name} columns)
-   * @return Seq of AddAction, one per row
+   * @param batch
+   *   Arrow ColumnarBatch from native FFI
+   * @param partitionColumns
+   *   Partition column names (for dynamic partition:{name} columns)
+   * @return
+   *   Seq of AddAction, one per row
    */
   def extract(batch: ColumnarBatch, partitionColumns: Seq[String]): Seq[AddAction] = {
     val numRows = batch.numRows()
     if (numRows == 0) return Seq.empty
 
     // Extract underlying Arrow FieldVectors for direct access
-    val root = (0 until batch.numCols()).map { i =>
-      batch.column(i).asInstanceOf[ArrowColumnVector].getValueVector
-    }
+    val root = (0 until batch.numCols()).map(i => batch.column(i).asInstanceOf[ArrowColumnVector].getValueVector)
 
     // Fixed columns (indices 0-19). Base count is 20 as of tantivy4java 0.34.1.
     // Column 19 is partition_values (JSON map of ALL partition values).
-    val pathVec = root(0).asInstanceOf[VarCharVector]
-    val sizeVec = root(1).asInstanceOf[BigIntVector]
-    val modTimeVec = root(2).asInstanceOf[BigIntVector]
-    val dataChangeVec = root(3).asInstanceOf[BitVector]
-    val numRecordsVec = root(4).asInstanceOf[BigIntVector]
-    val footerStartVec = root(5).asInstanceOf[BigIntVector]
-    val footerEndVec = root(6).asInstanceOf[BigIntVector]
-    val hasFooterVec = root(7).asInstanceOf[BitVector]
-    val deleteOpstampVec = root(8).asInstanceOf[BigIntVector]
-    val splitTagsVec = root(9) // ListVector of Utf8
-    val numMergeOpsVec = root(10).asInstanceOf[IntVector]
-    val docMappingJsonVec = root(11).asInstanceOf[VarCharVector]
-    val docMappingRefVec = root(12).asInstanceOf[VarCharVector]
-    val uncompressedSizeVec = root(13).asInstanceOf[BigIntVector]
-    val timeRangeStartVec = root(14).asInstanceOf[BigIntVector]
-    val timeRangeEndVec = root(15).asInstanceOf[BigIntVector]
-    val companionSourceFilesVec = root(16) // ListVector of Utf8
-    val companionDeltaVersionVec = root(17).asInstanceOf[BigIntVector]
+    val pathVec                   = root(0).asInstanceOf[VarCharVector]
+    val sizeVec                   = root(1).asInstanceOf[BigIntVector]
+    val modTimeVec                = root(2).asInstanceOf[BigIntVector]
+    val dataChangeVec             = root(3).asInstanceOf[BitVector]
+    val numRecordsVec             = root(4).asInstanceOf[BigIntVector]
+    val footerStartVec            = root(5).asInstanceOf[BigIntVector]
+    val footerEndVec              = root(6).asInstanceOf[BigIntVector]
+    val hasFooterVec              = root(7).asInstanceOf[BitVector]
+    val deleteOpstampVec          = root(8).asInstanceOf[BigIntVector]
+    val splitTagsVec              = root(9)                              // ListVector of Utf8
+    val numMergeOpsVec            = root(10).asInstanceOf[IntVector]
+    val docMappingJsonVec         = root(11).asInstanceOf[VarCharVector]
+    val docMappingRefVec          = root(12).asInstanceOf[VarCharVector]
+    val uncompressedSizeVec       = root(13).asInstanceOf[BigIntVector]
+    val timeRangeStartVec         = root(14).asInstanceOf[BigIntVector]
+    val timeRangeEndVec           = root(15).asInstanceOf[BigIntVector]
+    val companionSourceFilesVec   = root(16)                             // ListVector of Utf8
+    val companionDeltaVersionVec  = root(17).asInstanceOf[BigIntVector]
     val companionFastFieldModeVec = root(18).asInstanceOf[VarCharVector]
-    val partitionValuesJsonVec = root(19).asInstanceOf[VarCharVector] // JSON map of ALL partition values
+    val partitionValuesJsonVec    = root(19).asInstanceOf[VarCharVector] // JSON map of ALL partition values
 
     // Dynamic partition columns start at index 20
     val partColVecs = partitionColumns.indices.map(i => root(20 + i).asInstanceOf[VarCharVector])
 
     // Optional stats columns follow partition columns (present when includeStats=true)
-    val statsBaseIdx = 20 + partitionColumns.size
+    val statsBaseIdx    = 20 + partitionColumns.size
     val hasStatsColumns = batch.numCols() > statsBaseIdx
-    val minValuesVec = if (hasStatsColumns) Some(root(statsBaseIdx).asInstanceOf[VarCharVector]) else None
-    val maxValuesVec = if (hasStatsColumns && batch.numCols() > statsBaseIdx + 1)
-      Some(root(statsBaseIdx + 1).asInstanceOf[VarCharVector]) else None
+    val minValuesVec    = if (hasStatsColumns) Some(root(statsBaseIdx).asInstanceOf[VarCharVector]) else None
+    val maxValuesVec =
+      if (hasStatsColumns && batch.numCols() > statsBaseIdx + 1)
+        Some(root(statsBaseIdx + 1).asInstanceOf[VarCharVector])
+      else None
 
     val result = new Array[AddAction](numRows)
 
@@ -94,40 +97,42 @@ object ArrowFileEntryExtractor {
       // including undeclared ones. Dynamic partition:{name} columns are redundant but available.
       val partitionValues = if (!partitionValuesJsonVec.isNull(i)) {
         val jsonStr = new String(partitionValuesJsonVec.get(i), UTF_8)
-        try {
+        try
           mapper.readValue(jsonStr, classOf[java.util.Map[String, String]]).asScala.toMap
-        } catch {
+        catch {
           case _: Exception => Map.empty[String, String]
         }
       } else Map.empty[String, String]
 
       // Extract split tags from List<Utf8>
-      val splitTags = if (splitTagsVec.isNull(i)) None
-      else {
-        splitTagsVec match {
-          case lv: ListVector =>
-            val obj = lv.getObject(i)
-            if (obj != null) {
-              val list = obj.asInstanceOf[java.util.List[_]]
-              Some(list.asScala.map(_.toString).toSet)
-            } else None
-          case _ => None
+      val splitTags =
+        if (splitTagsVec.isNull(i)) None
+        else {
+          splitTagsVec match {
+            case lv: ListVector =>
+              val obj = lv.getObject(i)
+              if (obj != null) {
+                val list = obj.asInstanceOf[java.util.List[_]]
+                Some(list.asScala.map(_.toString).toSet)
+              } else None
+            case _ => None
+          }
         }
-      }
 
       // Extract companion source files from List<Utf8>
-      val companionSourceFiles = if (companionSourceFilesVec.isNull(i)) None
-      else {
-        companionSourceFilesVec match {
-          case lv: ListVector =>
-            val obj = lv.getObject(i)
-            if (obj != null) {
-              val list = obj.asInstanceOf[java.util.List[_]]
-              Some(list.asScala.map(_.toString).toSeq)
-            } else None
-          case _ => None
+      val companionSourceFiles =
+        if (companionSourceFilesVec.isNull(i)) None
+        else {
+          companionSourceFilesVec match {
+            case lv: ListVector =>
+              val obj = lv.getObject(i)
+              if (obj != null) {
+                val list = obj.asInstanceOf[java.util.List[_]]
+                Some(list.asScala.map(_.toString).toSeq)
+              } else None
+            case _ => None
+          }
         }
-      }
 
       require(!pathVec.isNull(i), s"path column must not be null at row $i")
 
@@ -147,10 +152,13 @@ object ArrowFileEntryExtractor {
           else Some(mapper.readValue(new String(v.get(i), UTF_8), classOf[java.util.Map[String, String]]).asScala.toMap)
         },
         numRecords = if (numRecordsVec.isNull(i)) None else Some(numRecordsVec.get(i)),
-        footerStartOffset = if (footerStartVec.isNull(i) || footerStartVec.get(i) <= 0) None else Some(footerStartVec.get(i)),
+        footerStartOffset =
+          if (footerStartVec.isNull(i) || footerStartVec.get(i) <= 0) None else Some(footerStartVec.get(i)),
         footerEndOffset = if (footerEndVec.isNull(i) || footerEndVec.get(i) <= 0) None else Some(footerEndVec.get(i)),
-        hasFooterOffsets = if (!hasFooterVec.isNull(i)) hasFooterVec.get(i) != 0
-          else !footerStartVec.isNull(i) && footerStartVec.get(i) > 0
+        hasFooterOffsets =
+          if (!hasFooterVec.isNull(i)) hasFooterVec.get(i) != 0
+          else
+            !footerStartVec.isNull(i) && footerStartVec.get(i) > 0
             && !footerEndVec.isNull(i) && footerEndVec.get(i) > 0,
         deleteOpstamp = if (deleteOpstampVec.isNull(i)) None else Some(deleteOpstampVec.get(i)),
         splitTags = splitTags,
@@ -162,7 +170,8 @@ object ArrowFileEntryExtractor {
         timeRangeEnd = if (timeRangeEndVec.isNull(i)) None else Some(timeRangeEndVec.get(i).toString),
         companionSourceFiles = companionSourceFiles,
         companionDeltaVersion = if (companionDeltaVersionVec.isNull(i)) None else Some(companionDeltaVersionVec.get(i)),
-        companionFastFieldMode = if (companionFastFieldModeVec.isNull(i)) None else Some(new String(companionFastFieldModeVec.get(i), UTF_8))
+        companionFastFieldMode =
+          if (companionFastFieldModeVec.isNull(i)) None else Some(new String(companionFastFieldModeVec.get(i), UTF_8))
       )
 
       i += 1

--- a/src/main/scala/io/indextables/spark/transaction/ConfigMapper.scala
+++ b/src/main/scala/io/indextables/spark/transaction/ConfigMapper.scala
@@ -22,8 +22,8 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
- * Maps Spark/Hadoop configuration keys to the native tantivy4java config map format expected by JNI
- * transaction log methods.
+ * Maps Spark/Hadoop configuration keys to the native tantivy4java config map format expected by JNI transaction log
+ * methods.
  *
  * This centralizes the credential translation that was previously duplicated across DeltaLogReader,
  * ParquetDirectoryReader, and IcebergSourceReader.
@@ -33,30 +33,30 @@ object ConfigMapper {
   /** Direct 1:1 Spark key → native key mappings. */
   private val directMappings: Seq[(String, String)] = Seq(
     // AWS credentials
-    "spark.indextables.aws.accessKey"     -> "aws_access_key_id",
-    "spark.indextables.aws.secretKey"     -> "aws_secret_access_key",
-    "spark.indextables.aws.sessionToken"  -> "aws_session_token",
-    "spark.indextables.aws.region"        -> "aws_region",
-    "spark.indextables.aws.endpoint"      -> "aws_endpoint",
+    "spark.indextables.aws.accessKey"      -> "aws_access_key_id",
+    "spark.indextables.aws.secretKey"      -> "aws_secret_access_key",
+    "spark.indextables.aws.sessionToken"   -> "aws_session_token",
+    "spark.indextables.aws.region"         -> "aws_region",
+    "spark.indextables.aws.endpoint"       -> "aws_endpoint",
     "spark.indextables.aws.forcePathStyle" -> "aws_force_path_style",
     // Azure credentials
     "spark.indextables.azure.accountName" -> "azure_account_name",
     "spark.indextables.azure.accountKey"  -> "azure_access_key",
     "spark.indextables.azure.bearerToken" -> "azure_bearer_token",
     // Transaction log cache configuration
-    "spark.indextables.transaction.cache.enabled"            -> "cache.enabled",
-    "spark.indextables.transaction.cache.ttl.ms"             -> "cache.ttl.ms",
-    "spark.indextables.transaction.cache.version.ttl.ms"     -> "cache.version.ttl.ms",
-    "spark.indextables.transaction.cache.snapshot.ttl.ms"    -> "cache.snapshot.ttl.ms",
-    "spark.indextables.transaction.cache.fileList.ttl.ms"    -> "cache.file_list.ttl.ms",
-    "spark.indextables.transaction.cache.metadata.ttl.ms"    -> "cache.metadata.ttl.ms",
-    "spark.indextables.transaction.cache.version.capacity"   -> "cache.version.capacity",
-    "spark.indextables.transaction.cache.snapshot.capacity"   -> "cache.snapshot.capacity",
-    "spark.indextables.transaction.cache.fileList.capacity"  -> "cache.file_list.capacity",
+    "spark.indextables.transaction.cache.enabled"           -> "cache.enabled",
+    "spark.indextables.transaction.cache.ttl.ms"            -> "cache.ttl.ms",
+    "spark.indextables.transaction.cache.version.ttl.ms"    -> "cache.version.ttl.ms",
+    "spark.indextables.transaction.cache.snapshot.ttl.ms"   -> "cache.snapshot.ttl.ms",
+    "spark.indextables.transaction.cache.fileList.ttl.ms"   -> "cache.file_list.ttl.ms",
+    "spark.indextables.transaction.cache.metadata.ttl.ms"   -> "cache.metadata.ttl.ms",
+    "spark.indextables.transaction.cache.version.capacity"  -> "cache.version.capacity",
+    "spark.indextables.transaction.cache.snapshot.capacity" -> "cache.snapshot.capacity",
+    "spark.indextables.transaction.cache.fileList.capacity" -> "cache.file_list.capacity",
     // Transaction log concurrency
-    "spark.indextables.transaction.maxConcurrentReads"       -> "max_concurrent_reads",
+    "spark.indextables.transaction.maxConcurrentReads" -> "max_concurrent_reads",
     // Checkpoint interval
-    "spark.indextables.checkpoint.interval"                  -> "checkpoint_interval"
+    "spark.indextables.checkpoint.interval" -> "checkpoint_interval"
   )
 
   /**
@@ -73,9 +73,8 @@ object ConfigMapper {
     val config = new java.util.HashMap[String, String]()
 
     // Apply direct 1:1 mappings
-    for ((sparkKey, nativeKey) <- directMappings) {
+    for ((sparkKey, nativeKey) <- directMappings)
       Option(options.get(sparkKey)).foreach(v => config.put(nativeKey, v))
-    }
 
     // S3 endpoint/pathStyle alternate keys (conditional — only set if primary key not already present)
     Option(options.get("spark.indextables.s3.endpoint")).foreach { v =>
@@ -100,9 +99,8 @@ object ConfigMapper {
     val config = new java.util.HashMap[String, String]()
 
     // Apply direct 1:1 mappings
-    for ((sparkKey, nativeKey) <- directMappings) {
+    for ((sparkKey, nativeKey) <- directMappings)
       options.get(sparkKey).foreach(v => config.put(nativeKey, v))
-    }
 
     // S3 endpoint/pathStyle alternate keys (conditional — only set if primary key not already present)
     options.get("spark.indextables.s3.endpoint").foreach { v =>
@@ -118,9 +116,9 @@ object ConfigMapper {
   /**
    * Normalize a Hadoop Path to a string suitable for native txlog methods.
    *
-   * Delegates to ProtocolNormalizer for cloud scheme conversion (s3a→s3, abfss→azure, wasbs→azure),
-   * which correctly extracts container names from full Azure URLs
-   * (e.g. abfss://container@account.dfs.core.windows.net/path → azure://container/path).
+   * Delegates to ProtocolNormalizer for cloud scheme conversion (s3a→s3, abfss→azure, wasbs→azure), which correctly
+   * extracts container names from full Azure URLs (e.g. abfss://container@account.dfs.core.windows.net/path →
+   * azure://container/path).
    *
    * Also handles local paths by adding file:// scheme for native object_store.
    */

--- a/src/main/scala/io/indextables/spark/transaction/NativeListFilesResult.scala
+++ b/src/main/scala/io/indextables/spark/transaction/NativeListFilesResult.scala
@@ -21,9 +21,9 @@ import org.apache.spark.sql.types.StructType
 
 /**
  * Result of a native Arrow FFI listFiles call. Combines:
- * - File listing (already filtered by partition pruning, data skipping, cooldown)
- * - Table metadata (schema, partition columns, protocol) — eliminates separate JNI calls
- * - Filtering metrics (for DataSkippingMetrics / Spark UI)
+ *   - File listing (already filtered by partition pruning, data skipping, cooldown)
+ *   - Table metadata (schema, partition columns, protocol) — eliminates separate JNI calls
+ *   - Filtering metrics (for DataSkippingMetrics / Spark UI)
  */
 case class NativeListFilesResult(
   files: Seq[AddAction],
@@ -34,8 +34,8 @@ case class NativeListFilesResult(
   metrics: NativeFilteringMetrics)
 
 /**
- * Metrics from native-side filtering, returned alongside the file listing.
- * Used by DataSkippingMetrics.recordScan() and DESCRIBE DATA SKIPPING STATS.
+ * Metrics from native-side filtering, returned alongside the file listing. Used by DataSkippingMetrics.recordScan() and
+ * DESCRIBE DATA SKIPPING STATS.
  */
 case class NativeFilteringMetrics(
   totalFilesBeforeFiltering: Long,

--- a/src/main/scala/io/indextables/spark/transaction/NativeTransactionLog.scala
+++ b/src/main/scala/io/indextables/spark/transaction/NativeTransactionLog.scala
@@ -22,15 +22,17 @@ import java.util.UUID
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
-import io.indextables.spark.util.JsonUtil
-import io.indextables.spark.arrow.ArrowFfiBridge
-import io.indextables.spark.stats.DataSkippingMetrics
-import io.indextables.jni.txlog.{TransactionLogReader, TransactionLogWriter, TxLogSnapshotInfo, WriteResult}
-import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.sources.Filter
 import org.apache.spark.sql.types.{DataType, StructType}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.vectorized.ColumnarBatch
+
+import org.apache.hadoop.fs.Path
+
+import io.indextables.jni.txlog.{TransactionLogReader, TransactionLogWriter, TxLogSnapshotInfo, WriteResult}
+import io.indextables.spark.arrow.ArrowFfiBridge
+import io.indextables.spark.stats.DataSkippingMetrics
+import io.indextables.spark.util.JsonUtil
 import org.slf4j.LoggerFactory
 
 /**
@@ -66,12 +68,14 @@ class NativeTransactionLog(
     // but we set them explicitly to guarantee no silent behavior change on upgrade).
     if (!config.containsKey("cache.ttl.ms")) {
       Option(options.get("spark.indextables.transaction.cache.expirationSeconds")).foreach { v =>
-        try {
+        try
           config.put("cache.ttl.ms", (v.toLong * 1000L).toString)
-        } catch {
+        catch {
           case e: NumberFormatException =>
             throw new IllegalArgumentException(
-              s"Invalid value for spark.indextables.transaction.cache.expirationSeconds: '$v' (expected integer seconds)", e)
+              s"Invalid value for spark.indextables.transaction.cache.expirationSeconds: '$v' (expected integer seconds)",
+              e
+            )
         }
       }
     }
@@ -85,7 +89,7 @@ class NativeTransactionLog(
     // Enables native compare_values_typed to parse bare datetime strings like "2025-11-07 05:00:00".
     // Without this, timestamp data skipping is conservative (never skips) — safe but suboptimal.
     try {
-      val tz = org.apache.spark.sql.SparkSession.active.sessionState.conf.sessionLocalTimeZone
+      val tz            = org.apache.spark.sql.SparkSession.active.sessionState.conf.sessionLocalTimeZone
       val offsetSeconds = java.util.TimeZone.getTimeZone(tz).getOffset(System.currentTimeMillis()) / 1000
       config.put("session.timezone.offset.seconds", offsetSeconds.toString)
     } catch {
@@ -203,7 +207,7 @@ class NativeTransactionLog(
 
   override def commitMergeSplits(removeActions: Seq[RemoveAction], addActions: Seq[AddAction]): Long = {
     val actions: Seq[Action] = removeActions ++ addActions
-    val result = writeActionsViaArrow(actions, retry = true)
+    val result               = writeActionsViaArrow(actions, retry = true)
     recordRetryMetrics(result)
     result.getVersion
   }
@@ -214,7 +218,7 @@ class NativeTransactionLog(
     metadataUpdate: Option[MetadataAction]
   ): Long = {
     val actions: Seq[Action] = removeActions ++ addActions ++ metadataUpdate.toSeq
-    val result = writeActionsViaArrow(actions, retry = true)
+    val result               = writeActionsViaArrow(actions, retry = true)
     recordRetryMetrics(result)
     result.getVersion
   }
@@ -236,13 +240,13 @@ class NativeTransactionLog(
   /**
    * Re-resolve AWS credentials from the configured credential provider and update nativeConfig.
    *
-   * Matches the lifecycle of the old S3CloudStorageProvider pattern: the old code wrapped the
-   * credential provider in V1ToV2CredentialsProviderAdapter so the AWS SDK re-invoked it before
-   * each storage operation. Here we replicate that by calling the provider before each write.
+   * Matches the lifecycle of the old S3CloudStorageProvider pattern: the old code wrapped the credential provider in
+   * V1ToV2CredentialsProviderAdapter so the AWS SDK re-invoked it before each storage operation. Here we replicate that
+   * by calling the provider before each write.
    *
-   * The credential provider (e.g., UnityCatalogAWSCredentialProvider) has an internal Guava
-   * cache, so this is a cache-hit no-op on most calls; an HTTP fetch occurs only when credentials
-   * are near expiration (~40 minutes before the typical 1-hour UC credential TTL).
+   * The credential provider (e.g., UnityCatalogAWSCredentialProvider) has an internal Guava cache, so this is a
+   * cache-hit no-op on most calls; an HTTP fetch occurs only when credentials are near expiration (~40 minutes before
+   * the typical 1-hour UC credential TTL).
    *
    * No-ops if no credential provider class is configured (static credentials or default chain).
    */
@@ -281,9 +285,9 @@ class NativeTransactionLog(
   private def writeActionsViaArrow(actions: Seq[Action], retry: Boolean): WriteResult = {
     refreshCredentials()
     val (arrowArray, arrowSchema, arrayAddr, schemaAddr) = ActionsToArrowConverter.exportAsFfi(actions)
-    try {
+    try
       TransactionLogWriter.writeVersionArrowFfi(nativeTablePath, nativeConfig, arrayAddr, schemaAddr, retry)
-    } finally {
+    finally {
       arrowArray.close()
       arrowSchema.close()
     }
@@ -299,7 +303,7 @@ class NativeTransactionLog(
       logger.debug("Protocol auto-upgrade disabled via configuration, skipping")
       return
     }
-    val current       = getProtocol()
+    val current         = getProtocol()
     val effectiveReader = math.max(current.minReaderVersion, newMinReaderVersion)
     val effectiveWriter = math.max(current.minWriterVersion, newMinWriterVersion)
     if (effectiveReader == current.minReaderVersion && effectiveWriter == current.minWriterVersion) {
@@ -330,7 +334,7 @@ class NativeTransactionLog(
   override def listFilesWithPartitionFilters(partitionFilters: Seq[Filter]): Seq[AddAction] =
     listFilesWithAllFilters(partitionFilters, Seq.empty)
 
-  override def listFilesWithAllFilters(partitionFilters: Seq[Filter], dataFilters: Seq[Filter]): Seq[AddAction] = {
+  override def listFilesWithAllFilters(partitionFilters: Seq[Filter], dataFilters: Seq[Filter]): Seq[AddAction] =
     // Data skipping already applied natively — no need to export stats back to JVM
     listFilesArrow(
       partitionFilters = SparkFilterToNativeFilter.convertOrNull(partitionFilters),
@@ -338,15 +342,13 @@ class NativeTransactionLog(
       excludeCooldown = false,
       includeStats = false
     ).files
-  }
 
   /**
-   * List files with all filtering applied natively in a single JNI call.
-   * Returns files + table metadata + filtering metrics.
+   * List files with all filtering applied natively in a single JNI call. Returns files + table metadata + filtering
+   * metrics.
    *
-   * Replaces the old multi-step pipeline:
-   * getSnapshotInfo → readManifest × N → readPostCheckpointChanges →
-   * JVM log replay → partition pruning → data skipping → cooldown filtering → schema restore
+   * Replaces the old multi-step pipeline: getSnapshotInfo → readManifest × N → readPostCheckpointChanges → JVM log
+   * replay → partition pruning → data skipping → cooldown filtering → schema restore
    */
   def listFilesWithMetadata(
     partitionFilters: Seq[Filter],
@@ -361,17 +363,16 @@ class NativeTransactionLog(
     )
 
   /**
-   * List files excluding those in cooldown/skip state.
-   * Replaces the old pattern: listFiles() then filterFilesInCooldown().
+   * List files excluding those in cooldown/skip state. Replaces the old pattern: listFiles() then
+   * filterFilesInCooldown().
    */
-  def listFilesExcludingCooldown(filters: Seq[Filter] = Seq.empty): Seq[AddAction] = {
+  def listFilesExcludingCooldown(filters: Seq[Filter] = Seq.empty): Seq[AddAction] =
     listFilesArrow(
       partitionFilters = SparkFilterToNativeFilter.convertOrNull(filters),
       dataFilters = null,
       excludeCooldown = true,
       includeStats = true // merge path needs full metadata
     ).files
-  }
 
   private def listFilesArrow(
     partitionFilters: String,
@@ -384,26 +385,29 @@ class NativeTransactionLog(
     // Native returns numColumns in result JSON; we only import that many.
     // 20 base (including partition_values JSON col) + up to 20 partition cols + 2 stats = 42
     val maxCols = 42
-    val bridge = new ArrowFfiBridge()
+    val bridge  = new ArrowFfiBridge()
     try {
       val (arrays, schemas, arrayAddrs, schemaAddrs) = bridge.allocateStructs(maxCols)
 
       // Field types for type-aware data skipping are auto-extracted from
       // MetadataAction.schema_string by the native layer — no JVM-side work needed.
-      val resultJson = try {
-        TransactionLogReader.listFilesArrowFfi(
-          nativeTablePath, nativeConfig,
-          partitionFilters,
-          dataFilters,
-          excludeCooldown,
-          includeStats,
-          arrayAddrs, schemaAddrs
-        )
-      } catch {
-        case e: RuntimeException if e.getMessage != null && e.getMessage.contains("not initialized") =>
-          logger.debug(s"Table not yet initialized at $nativeTablePath")
-          null
-      }
+      val resultJson =
+        try
+          TransactionLogReader.listFilesArrowFfi(
+            nativeTablePath,
+            nativeConfig,
+            partitionFilters,
+            dataFilters,
+            excludeCooldown,
+            includeStats,
+            arrayAddrs,
+            schemaAddrs
+          )
+        catch {
+          case e: RuntimeException if e.getMessage != null && e.getMessage.contains("not initialized") =>
+            logger.debug(s"Table not yet initialized at $nativeTablePath")
+            null
+        }
 
       if (resultJson == null) {
         closeUnusedStructs(arrays, schemas, 0)
@@ -419,13 +423,15 @@ class NativeTransactionLog(
 
       // Parse result metadata
       val resultNode = mapper.readTree(resultJson)
-      val numRows = resultNode.get("numRows").asLong()
+      val numRows    = resultNode.get("numRows").asLong()
       val numColumns = resultNode.get("numColumns").asInt()
 
       // Extract table metadata (eliminates separate getSchema/getPartitionColumns/getProtocol calls)
       // schemaJson now returns the table data schema (MetadataAction.schema_string) in Spark StructType JSON format
-      val schemaJson = if (resultNode.has("schemaJson") && !resultNode.get("schemaJson").isNull)
-        resultNode.get("schemaJson").asText() else null
+      val schemaJson =
+        if (resultNode.has("schemaJson") && !resultNode.get("schemaJson").isNull)
+          resultNode.get("schemaJson").asText()
+        else null
       val schema = if (schemaJson != null && schemaJson.nonEmpty) {
         Some(DataType.fromJson(schemaJson).asInstanceOf[StructType])
       } else None
@@ -441,8 +447,8 @@ class NativeTransactionLog(
 
       val metadataConfig = if (resultNode.has("metadataConfigJson") && !resultNode.get("metadataConfigJson").isNull) {
         val configNode = mapper.readTree(resultNode.get("metadataConfigJson").asText())
-        val entries = scala.collection.mutable.Map[String, String]()
-        val it = configNode.fields()
+        val entries    = scala.collection.mutable.Map[String, String]()
+        val it         = configNode.fields()
         while (it.hasNext) {
           val entry = it.next()
           entries.put(entry.getKey, entry.getValue.asText())
@@ -475,11 +481,10 @@ class NativeTransactionLog(
           schemas.take(numColumns),
           numRows.toInt
         )
-        try {
+        try
           ArrowFileEntryExtractor.extract(batch, partitionColumns)
-        } finally {
+        finally
           batch.close()
-        }
       } else {
         Seq.empty
       }
@@ -492,9 +497,8 @@ class NativeTransactionLog(
         metadataConfig = metadataConfig,
         metrics = metrics
       )
-    } finally {
+    } finally
       bridge.close()
-    }
   }
 
   override def getTotalRowCount(): Long =
@@ -600,7 +604,7 @@ class NativeTransactionLog(
     )
     val skipJson = ActionJsonSerializer.skipActionToJson(skipAction)
     refreshCredentials()
-    val version  = TransactionLogWriter.skipFile(nativeTablePath, nativeConfig, skipJson)
+    val version = TransactionLogWriter.skipFile(nativeTablePath, nativeConfig, skipJson)
     version
   }
 
@@ -676,17 +680,17 @@ class NativeTransactionLog(
   // ------------------------------------------------------------------------------------
 
   /**
-   * Get the current snapshot from the native layer. Returns null if the table is not yet
-   * initialized (e.g., during the write path before any data is committed).
+   * Get the current snapshot from the native layer. Returns null if the table is not yet initialized (e.g., during the
+   * write path before any data is committed).
    *
-   * Caching is handled entirely by the native layer's global CACHE_REGISTRY, which is
-   * automatically invalidated by write operations across all instances.
+   * Caching is handled entirely by the native layer's global CACHE_REGISTRY, which is automatically invalidated by
+   * write operations across all instances.
    */
   private def getOrRefreshSnapshot(): TxLogSnapshotInfo = {
     refreshCredentials()
-    try {
+    try
       TransactionLogReader.getSnapshotInfo(nativeTablePath, nativeConfig)
-    } catch {
+    catch {
       case e: RuntimeException if e.getMessage != null && e.getMessage.contains("not initialized") =>
         logger.debug(s"Table not yet initialized at $nativeTablePath")
         null
@@ -700,8 +704,8 @@ class NativeTransactionLog(
   }
 
   /**
-   * Retry an operation with exponential backoff. The operation is called on each attempt
-   * and should return a WriteResult from writeVersionOnce.
+   * Retry an operation with exponential backoff. The operation is called on each attempt and should return a
+   * WriteResult from writeVersionOnce.
    */
   private def retryWithBackoff(operationName: String)(operation: () => WriteResult): Long = {
     val maxAttempts = options.getInt("spark.indextables.state.retry.maxAttempts", 10)
@@ -732,7 +736,7 @@ class NativeTransactionLog(
     )
   }
 
-  private def recordRetryMetrics(result: WriteResult): Unit = {
+  private def recordRetryMetrics(result: WriteResult): Unit =
     lastRetryMetrics = Some(
       TxRetryMetrics(
         attemptsMade = result.getRetries + 1,
@@ -741,7 +745,6 @@ class NativeTransactionLog(
         conflictedVersions = result.getConflictedVersions.asScala.map(_.toLong).toSeq
       )
     )
-  }
 
   private def parseMetadataJson(metadataJson: String): MetadataAction =
     mapper.readValue(metadataJson, classOf[MetadataAction])
@@ -754,8 +757,10 @@ class NativeTransactionLog(
   ): Unit = {
     var i = usedCount
     while (i < arrays.length) {
-      try { arrays(i).close() } catch { case _: Exception => }
-      try { schemas(i).close() } catch { case _: Exception => }
+      try arrays(i).close()
+      catch { case _: Exception => }
+      try schemas(i).close()
+      catch { case _: Exception => }
       i += 1
     }
   }

--- a/src/main/scala/io/indextables/spark/transaction/SparkFilterToNativeFilter.scala
+++ b/src/main/scala/io/indextables/spark/transaction/SparkFilterToNativeFilter.scala
@@ -18,26 +18,25 @@
 package io.indextables.spark.transaction
 
 import org.apache.spark.sql.sources._
+
 import io.indextables.tantivy4java.filter.PartitionFilter
 
 /**
  * Converts Spark DataSource V2 Filter objects to tantivy4java PartitionFilter JSON.
  *
- * Used for both partition filters (evaluated against partition_values) and data filters
- * (evaluated against min_values/max_values for data skipping). The same JSON format is
- * used for both — the native layer determines the evaluation target.
+ * Used for both partition filters (evaluated against partition_values) and data filters (evaluated against
+ * min_values/max_values for data skipping). The same JSON format is used for both — the native layer determines the
+ * evaluation target.
  */
 object SparkFilterToNativeFilter {
 
   /**
-   * Split pushed filters into partition filters and data (non-partition) filters.
-   * Partition filters reference only partition columns; data filters reference non-partition columns.
+   * Split pushed filters into partition filters and data (non-partition) filters. Partition filters reference only
+   * partition columns; data filters reference non-partition columns.
    *
-   * Data filters are further restricted to only include filters on fields where native
-   * data skipping (can_skip_by_stats) works correctly. Fields with type-dependent
-   * serialization (Date, Timestamp, Binary) are excluded because filter.value.toString()
-   * produces a different format than the stored min/max stats strings.
-   *
+   * Data filters are further restricted to only include filters on fields where native data skipping
+   * (can_skip_by_stats) works correctly. Fields with type-dependent serialization (Date, Timestamp, Binary) are
+   * excluded because filter.value.toString() produces a different format than the stored min/max stats strings.
    */
   def splitFilters(
     pushedFilters: Array[Filter],
@@ -92,8 +91,8 @@ object SparkFilterToNativeFilter {
   }
 
   /**
-   * Convert a value to the same string format used by transaction log min/max statistics.
-   * This ensures native can_skip_by_stats compares like-for-like.
+   * Convert a value to the same string format used by transaction log min/max statistics. This ensures native
+   * can_skip_by_stats compares like-for-like.
    */
   private def toStatCompatibleString(value: Any): String = value match {
     case ts: java.sql.Timestamp =>
@@ -104,39 +103,39 @@ object SparkFilterToNativeFilter {
       // Stats store dates as ISO strings or epoch days. ISO format works for both
       // native string comparison and typed date comparison.
       d.toLocalDate.toString
-    case null => null
+    case null  => null
     case other => other.toString
   }
 
   /** Convert a single Spark Filter to a PartitionFilter. Returns None for unsupported filters. */
   def convert(filter: Filter): Option[PartitionFilter] = filter match {
-    case EqualTo(attr, value)            => Some(PartitionFilter.eq(attr, toStatCompatibleString(value)))
-    case EqualNullSafe(attr, value)      =>
+    case EqualTo(attr, value) => Some(PartitionFilter.eq(attr, toStatCompatibleString(value)))
+    case EqualNullSafe(attr, value) =>
       if (value == null) Some(PartitionFilter.isNull(attr))
       else Some(PartitionFilter.eq(attr, toStatCompatibleString(value)))
     case GreaterThan(attr, value)        => Some(PartitionFilter.gt(attr, toStatCompatibleString(value)))
     case GreaterThanOrEqual(attr, value) => Some(PartitionFilter.gte(attr, toStatCompatibleString(value)))
     case LessThan(attr, value)           => Some(PartitionFilter.lt(attr, toStatCompatibleString(value)))
     case LessThanOrEqual(attr, value)    => Some(PartitionFilter.lte(attr, toStatCompatibleString(value)))
-    case In(attr, values)                =>
+    case In(attr, values) =>
       val strValues = values.filter(_ != null).map(toStatCompatibleString)
       if (strValues.nonEmpty) Some(PartitionFilter.in(attr, strValues: _*))
       else None
-    case IsNull(attr)                    => Some(PartitionFilter.isNull(attr))
-    case IsNotNull(attr)                 => Some(PartitionFilter.isNotNull(attr))
-    case StringStartsWith(attr, value)   => Some(PartitionFilter.stringStartsWith(attr, value))
-    case StringEndsWith(attr, value)     => Some(PartitionFilter.stringEndsWith(attr, value))
-    case StringContains(attr, value)     => Some(PartitionFilter.stringContains(attr, value))
-    case Not(child)                      =>
+    case IsNull(attr)                  => Some(PartitionFilter.isNull(attr))
+    case IsNotNull(attr)               => Some(PartitionFilter.isNotNull(attr))
+    case StringStartsWith(attr, value) => Some(PartitionFilter.stringStartsWith(attr, value))
+    case StringEndsWith(attr, value)   => Some(PartitionFilter.stringEndsWith(attr, value))
+    case StringContains(attr, value)   => Some(PartitionFilter.stringContains(attr, value))
+    case Not(child) =>
       convert(child).map(PartitionFilter.not)
-    case And(left, right)                =>
+    case And(left, right) =>
       (convert(left), convert(right)) match {
         case (Some(l), Some(r)) => Some(PartitionFilter.and(l, r))
         case (Some(l), None)    => Some(l)
         case (None, Some(r))    => Some(r)
         case (None, None)       => None
       }
-    case Or(left, right)                 =>
+    case Or(left, right) =>
       (convert(left), convert(right)) match {
         case (Some(l), Some(r)) => Some(PartitionFilter.or(l, r))
         case _                  => None // Can't push OR if one side is unsupported

--- a/src/main/scala/io/indextables/spark/transaction/TransactionLogFactory.scala
+++ b/src/main/scala/io/indextables/spark/transaction/TransactionLogFactory.scala
@@ -37,8 +37,8 @@ object TransactionLogFactory {
   /**
    * Create a transaction log instance.
    *
-   * Resolves credentials from Hadoop config, Spark config, and DataSource options using the same
-   * precedence chain as the read path (ConfigNormalization + CredentialProviderFactory).
+   * Resolves credentials from Hadoop config, Spark config, and DataSource options using the same precedence chain as
+   * the read path (ConfigNormalization + CredentialProviderFactory).
    *
    * @param tablePath
    *   The path to the table
@@ -57,9 +57,9 @@ object TransactionLogFactory {
     logger.debug(s"Creating NativeTransactionLog for $tablePath")
 
     // Merge configs with same precedence as read path: Hadoop < Spark config < options
-    val hadoopConf = spark.sparkContext.hadoopConfiguration
+    val hadoopConf    = spark.sparkContext.hadoopConfiguration
     val hadoopConfigs = io.indextables.spark.util.ConfigNormalization.extractTantivyConfigsFromHadoop(hadoopConf)
-    val sparkConfigs = io.indextables.spark.util.ConfigNormalization.extractTantivyConfigsFromSpark(spark)
+    val sparkConfigs  = io.indextables.spark.util.ConfigNormalization.extractTantivyConfigsFromSpark(spark)
     val optionConfigs = io.indextables.spark.util.ConfigNormalization.extractTantivyConfigsFromOptions(options)
 
     val mergedConfigs = io.indextables.spark.util.ConfigNormalization.mergeWithPrecedence(
@@ -74,7 +74,8 @@ object TransactionLogFactory {
     // class key, and injects explicit credentials. We re-add the provider class afterward so
     // CloudStorageProvider and executors can still invoke it for fresh credential refresh.
     val providerClassKey = "spark.indextables.aws.credentialsProviderClass"
-    val providerClassOpt = mergedConfigs.get(providerClassKey)
+    val providerClassOpt = mergedConfigs
+      .get(providerClassKey)
       .orElse(mergedConfigs.get(providerClassKey.toLowerCase))
 
     // Strip source-table-specific keys before resolving credentials for this txlog's storage path.
@@ -107,8 +108,8 @@ object TransactionLogFactory {
   /**
    * Create a native transaction log instance directly.
    *
-   * Convenience method that bypasses SparkSession parameter. Useful for tests.
-   * Credentials must already be present in the options map.
+   * Convenience method that bypasses SparkSession parameter. Useful for tests. Credentials must already be present in
+   * the options map.
    */
   def createNative(
     tablePath: Path,

--- a/src/main/scala/io/indextables/spark/transaction/TransactionLogInterface.scala
+++ b/src/main/scala/io/indextables/spark/transaction/TransactionLogInterface.scala
@@ -143,8 +143,8 @@ trait TransactionLogInterface extends AutoCloseable {
   /**
    * List visible files with both partition and data filters applied natively.
    *
-   * Partition filters are evaluated against partition_values (exact match).
-   * Data filters are evaluated against min_values/max_values (range overlap / data skipping).
+   * Partition filters are evaluated against partition_values (exact match). Data filters are evaluated against
+   * min_values/max_values (range overlap / data skipping).
    *
    * @param partitionFilters
    *   Filters on partition columns
@@ -385,14 +385,17 @@ trait TransactionLogInterface extends AutoCloseable {
   /**
    * Create a checkpoint at the current state using resolved credentials.
    *
-   * Callers must pass pre-serialized JSON for entries, metadata, and protocol.
-   * Implementations must use their own internally-resolved credential config so that
-   * cloud storage credentials (e.g. Unity Catalog) are correctly applied.
+   * Callers must pass pre-serialized JSON for entries, metadata, and protocol. Implementations must use their own
+   * internally-resolved credential config so that cloud storage credentials (e.g. Unity Catalog) are correctly applied.
    *
-   * @param entriesJson  JSON array of AddActions for all currently visible files
-   * @param metadataJson JSON of the MetadataAction
-   * @param protocolJson JSON of the ProtocolAction
-   * @return LastCheckpointInfo describing the written checkpoint
+   * @param entriesJson
+   *   JSON array of AddActions for all currently visible files
+   * @param metadataJson
+   *   JSON of the MetadataAction
+   * @param protocolJson
+   *   JSON of the ProtocolAction
+   * @return
+   *   LastCheckpointInfo describing the written checkpoint
    */
   def createCheckpoint(
     entriesJson: String,

--- a/src/main/scala/io/indextables/spark/util/CloudPathUtils.scala
+++ b/src/main/scala/io/indextables/spark/util/CloudPathUtils.scala
@@ -48,8 +48,8 @@ object CloudPathUtils {
   /**
    * Parse an Azure storage path into (container, blobPath).
    *
-   * Supports azure://, wasb://, wasbs://, abfs://, and abfss:// schemes. Handles Hadoop-style
-   * container@account.host URLs.
+   * Supports azure://, wasb://, wasbs://, abfs://, and abfss:// schemes. Handles Hadoop-style container@account.host
+   * URLs.
    *
    * @param path
    *   Azure path (e.g., "wasbs://container@account.blob.core.windows.net/path")

--- a/src/main/scala/io/indextables/spark/util/ConfigParsingUtils.scala
+++ b/src/main/scala/io/indextables/spark/util/ConfigParsingUtils.scala
@@ -18,6 +18,7 @@
 package io.indextables.spark.util
 
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
 import org.slf4j.LoggerFactory
 
 /**

--- a/src/main/scala/io/indextables/spark/util/FilterUtils.scala
+++ b/src/main/scala/io/indextables/spark/util/FilterUtils.scala
@@ -19,9 +19,7 @@ package io.indextables.spark.util
 
 import org.apache.spark.sql.sources._
 
-/**
- * Shared utilities for extracting metadata from Spark Filter objects.
- */
+/** Shared utilities for extracting metadata from Spark Filter objects. */
 object FilterUtils {
 
   /**

--- a/src/main/scala/io/indextables/spark/util/SplitMetadataFactory.scala
+++ b/src/main/scala/io/indextables/spark/util/SplitMetadataFactory.scala
@@ -62,25 +62,25 @@ object SplitMetadataFactory {
     }
 
     new QuickwitSplit.SplitMetadata(
-      splitId,                                                              // splitId
-      "tantivy4spark-index",                                                // indexUid
-      0L,                                                                   // partitionId
-      "tantivy4spark-source",                                               // sourceId
-      "tantivy4spark-node",                                                 // nodeId
-      toLongSafe(addAction.numRecords),                                     // numDocs
-      toLongSafe(addAction.uncompressedSizeBytes, addAction.size),          // uncompressedSizeBytes
-      addAction.timeRangeStart.map(Instant.parse).orNull,                   // timeRangeStart
-      addAction.timeRangeEnd.map(Instant.parse).orNull,                     // timeRangeEnd
-      System.currentTimeMillis() / 1000,                                    // createTimestamp
-      "Mature",                                                             // maturity
-      tags,                                                                 // tags
-      footerStartOffset,                                                    // footerStartOffset
-      footerEndOffset,                                                      // footerEndOffset
-      toLongSafe(addAction.deleteOpstamp),                                  // deleteOpstamp
-      addAction.numMergeOps.getOrElse(0),                                   // numMergeOps
-      "doc-mapping-uid",                                                    // docMappingUid
-      addAction.docMappingJson.orNull,                                      // docMappingJson
-      java.util.Collections.emptyList[QuickwitSplit.SkippedSplit]()         // skippedSplits
+      splitId,                                                      // splitId
+      "tantivy4spark-index",                                        // indexUid
+      0L,                                                           // partitionId
+      "tantivy4spark-source",                                       // sourceId
+      "tantivy4spark-node",                                         // nodeId
+      toLongSafe(addAction.numRecords),                             // numDocs
+      toLongSafe(addAction.uncompressedSizeBytes, addAction.size),  // uncompressedSizeBytes
+      addAction.timeRangeStart.map(Instant.parse).orNull,           // timeRangeStart
+      addAction.timeRangeEnd.map(Instant.parse).orNull,             // timeRangeEnd
+      System.currentTimeMillis() / 1000,                            // createTimestamp
+      "Mature",                                                     // maturity
+      tags,                                                         // tags
+      footerStartOffset,                                            // footerStartOffset
+      footerEndOffset,                                              // footerEndOffset
+      toLongSafe(addAction.deleteOpstamp),                          // deleteOpstamp
+      addAction.numMergeOps.getOrElse(0),                           // numMergeOps
+      "doc-mapping-uid",                                            // docMappingUid
+      addAction.docMappingJson.orNull,                              // docMappingJson
+      java.util.Collections.emptyList[QuickwitSplit.SkippedSplit]() // skippedSplits
     )
   }
 
@@ -90,8 +90,10 @@ object SplitMetadataFactory {
     case Some(i: Int)               => i.toLong
     case Some(i: java.lang.Integer) => i.toLong
     case Some(l: java.lang.Long)    => l
-    case Some(other)                => try { other.toString.toLong } catch { case _: NumberFormatException => fallback }
-    case None                       => fallback
+    case Some(other) =>
+      try other.toString.toLong
+      catch { case _: NumberFormatException => fallback }
+    case None => fallback
   }
 
   /**

--- a/src/main/scala/io/indextables/spark/util/TimingUtils.scala
+++ b/src/main/scala/io/indextables/spark/util/TimingUtils.scala
@@ -17,9 +17,7 @@
 
 package io.indextables.spark.util
 
-/**
- * Shared timing measurement utility.
- */
+/** Shared timing measurement utility. */
 object TimingUtils {
 
   /**

--- a/src/main/scala/io/indextables/spark/write/ArrowFfiWriteConfig.scala
+++ b/src/main/scala/io/indextables/spark/write/ArrowFfiWriteConfig.scala
@@ -17,8 +17,9 @@
 
 package io.indextables.spark.write
 
-import io.indextables.spark.util.{ConfigParsingUtils, SizeParser}
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+import io.indextables.spark.util.{ConfigParsingUtils, SizeParser}
 import org.slf4j.LoggerFactory
 
 /**
@@ -66,8 +67,8 @@ object ArrowFfiWriteConfig {
   val KEY_HEAP_SIZE  = "spark.indextables.indexWriter.heapSize"
 
   // Default values
-  val DEFAULT_BATCH_SIZE: Int  = 8192
-  val DEFAULT_HEAP_SIZE: Long  = 256L * 1024 * 1024 // 256MB
+  val DEFAULT_BATCH_SIZE: Int = 8192
+  val DEFAULT_HEAP_SIZE: Long = 256L * 1024 * 1024 // 256MB
 
   def default: ArrowFfiWriteConfig = ArrowFfiWriteConfig()
 
@@ -86,7 +87,13 @@ object ArrowFfiWriteConfig {
     warnIfDeprecatedKeyPresent(key => options.containsKey(key))
 
     val batchSize = ConfigParsingUtils.getIntOption(options, KEY_BATCH_SIZE, DEFAULT_BATCH_SIZE, mustBePositive = true)
-    val heapSize  = ConfigParsingUtils.getLongOption(options, KEY_HEAP_SIZE, DEFAULT_HEAP_SIZE, mustBePositive = true, supportSizeSuffix = true)
+    val heapSize = ConfigParsingUtils.getLongOption(
+      options,
+      KEY_HEAP_SIZE,
+      DEFAULT_HEAP_SIZE,
+      mustBePositive = true,
+      supportSizeSuffix = true
+    )
 
     val config = ArrowFfiWriteConfig(
       batchSize = batchSize,

--- a/src/main/scala/io/indextables/spark/write/OptimizedWriteConfig.scala
+++ b/src/main/scala/io/indextables/spark/write/OptimizedWriteConfig.scala
@@ -104,12 +104,24 @@ object OptimizedWriteConfig {
   def default: OptimizedWriteConfig = OptimizedWriteConfig()
 
   def fromOptions(options: CaseInsensitiveStringMap): OptimizedWriteConfig = {
-    val enabled              = ConfigParsingUtils.getBooleanOption(options, KEY_ENABLED, DEFAULT_ENABLED)
-    val targetSplitSizeBytes = ConfigParsingUtils.parseSizeOption(options, KEY_TARGET_SPLIT_SIZE, DEFAULT_TARGET_SPLIT_SIZE_BYTES)
-    val samplingRatio        = ConfigParsingUtils.getDoubleOption(options, KEY_SAMPLING_RATIO, DEFAULT_SAMPLING_RATIO, minExclusive = Some(0.0))
-    val minRowsForEstimation = ConfigParsingUtils.getLongOption(options, KEY_MIN_ROWS_FOR_EST, DEFAULT_MIN_ROWS_FOR_ESTIMATION, mustBePositive = true)
-    val distributionMode     = ConfigParsingUtils.getStringOption(options, KEY_DISTRIBUTION_MODE, DEFAULT_DISTRIBUTION_MODE, VALID_DISTRIBUTION_MODES)
-    val maxSplitSizeBytes    = ConfigParsingUtils.parseSizeOption(options, KEY_MAX_SPLIT_SIZE, DEFAULT_MAX_SPLIT_SIZE_BYTES)
+    val enabled = ConfigParsingUtils.getBooleanOption(options, KEY_ENABLED, DEFAULT_ENABLED)
+    val targetSplitSizeBytes =
+      ConfigParsingUtils.parseSizeOption(options, KEY_TARGET_SPLIT_SIZE, DEFAULT_TARGET_SPLIT_SIZE_BYTES)
+    val samplingRatio =
+      ConfigParsingUtils.getDoubleOption(options, KEY_SAMPLING_RATIO, DEFAULT_SAMPLING_RATIO, minExclusive = Some(0.0))
+    val minRowsForEstimation = ConfigParsingUtils.getLongOption(
+      options,
+      KEY_MIN_ROWS_FOR_EST,
+      DEFAULT_MIN_ROWS_FOR_ESTIMATION,
+      mustBePositive = true
+    )
+    val distributionMode = ConfigParsingUtils.getStringOption(
+      options,
+      KEY_DISTRIBUTION_MODE,
+      DEFAULT_DISTRIBUTION_MODE,
+      VALID_DISTRIBUTION_MODES
+    )
+    val maxSplitSizeBytes = ConfigParsingUtils.parseSizeOption(options, KEY_MAX_SPLIT_SIZE, DEFAULT_MAX_SPLIT_SIZE_BYTES)
 
     val config = OptimizedWriteConfig(
       enabled = enabled,

--- a/src/test/scala/io/indextables/spark/CloudS3TestBase.scala
+++ b/src/test/scala/io/indextables/spark/CloudS3TestBase.scala
@@ -85,9 +85,9 @@ abstract class CloudS3TestBase extends AnyFunSuite with Matchers with BeforeAndA
   }
 
   /**
-   * Load AWS credentials from ~/.aws/credentials and set them in Spark and Hadoop config.
-   * The native transaction log requires explicit credential configuration via
-   * spark.indextables.aws.* keys (it does not auto-resolve from Hadoop's filesystem API).
+   * Load AWS credentials from ~/.aws/credentials and set them in Spark and Hadoop config. The native transaction log
+   * requires explicit credential configuration via spark.indextables.aws.* keys (it does not auto-resolve from Hadoop's
+   * filesystem API).
    */
   private def loadAndConfigureAwsCredentials(): Unit =
     try {

--- a/src/test/scala/io/indextables/spark/TestBase.scala
+++ b/src/test/scala/io/indextables/spark/TestBase.scala
@@ -145,6 +145,7 @@ trait TestBase extends AnyFunSuite with Matchers with BeforeAndAfterAll with Bef
 }
 
 object TestBase {
+
   /** DataSource format string for IndexTables4Spark. Usable from non-TestBase test classes too. */
   val INDEXTABLES_FORMAT: String = "indextables"
 }

--- a/src/test/scala/io/indextables/spark/config/SizeParsingTest.scala
+++ b/src/test/scala/io/indextables/spark/config/SizeParsingTest.scala
@@ -10,7 +10,11 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterEach
 
 /** Test to verify that human-readable size formats work for indexWriter.heapSize */
-class SizeParsingTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class SizeParsingTest
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   var spark: SparkSession = _
   var tempDir: File       = _

--- a/src/test/scala/io/indextables/spark/core/BucketAggregationEmptySplitTest.scala
+++ b/src/test/scala/io/indextables/spark/core/BucketAggregationEmptySplitTest.scala
@@ -17,7 +17,7 @@
 
 package io.indextables.spark.core
 
-import org.apache.spark.sql.connector.expressions.aggregate.{CountStar, AggregateFunc}
+import org.apache.spark.sql.connector.expressions.aggregate.{AggregateFunc, CountStar}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.vectorized.ColumnarBatch
 
@@ -27,23 +27,29 @@ import org.scalatest.matchers.should.Matchers
 /**
  * Tests for assembleBucketBatch with empty splits (0 rows).
  *
- * Uses CountStar for all aggregate expressions because FieldReference is package-private
- * in Spark 3.5. The fix is about column count sizing, not agg types.
+ * Uses CountStar for all aggregate expressions because FieldReference is package-private in Spark 3.5. The fix is about
+ * column count sizing, not agg types.
  */
 class BucketAggregationEmptySplitTest extends AnyFunSuite with Matchers {
 
   private def emptyBatch: ColumnarBatch = new ColumnarBatch(Array.empty, 0)
 
   test("assembleBucketBatch should handle empty split (0 rows) without exception") {
-    val schema = StructType(Seq(
-      StructField("bucket_key", StringType),
-      StructField("cnt", LongType)
-    ))
+    val schema = StructType(
+      Seq(
+        StructField("bucket_key", StringType),
+        StructField("cnt", LongType)
+      )
+    )
     val aggExprs: Array[AggregateFunc] = Array(new CountStar())
     val dataGroupByCols                = Array("bucket_key")
 
     val result = GroupByColumnarReaderUtils.assembleBucketBatch(
-      emptyBatch, Array.empty[String], aggExprs, dataGroupByCols, schema
+      emptyBatch,
+      Array.empty[String],
+      aggExprs,
+      dataGroupByCols,
+      schema
     )
     try {
       result.numRows() shouldBe 0
@@ -52,13 +58,15 @@ class BucketAggregationEmptySplitTest extends AnyFunSuite with Matchers {
   }
 
   test("assembleBucketBatch empty split column count equals groupByCols + aggExprs") {
-    val schema = StructType(Seq(
-      StructField("col1", StringType),
-      StructField("col2", StringType),
-      StructField("cnt", LongType),
-      StructField("total", LongType),
-      StructField("min_val", LongType)
-    ))
+    val schema = StructType(
+      Seq(
+        StructField("col1", StringType),
+        StructField("col2", StringType),
+        StructField("cnt", LongType),
+        StructField("total", LongType),
+        StructField("min_val", LongType)
+      )
+    )
     val aggExprs: Array[AggregateFunc] = Array(
       new CountStar(),
       new CountStar(),
@@ -67,7 +75,11 @@ class BucketAggregationEmptySplitTest extends AnyFunSuite with Matchers {
     val dataGroupByCols = Array("col1", "col2")
 
     val result = GroupByColumnarReaderUtils.assembleBucketBatch(
-      emptyBatch, Array.empty[String], aggExprs, dataGroupByCols, schema
+      emptyBatch,
+      Array.empty[String],
+      aggExprs,
+      dataGroupByCols,
+      schema
     )
     try {
       result.numRows() shouldBe 0
@@ -76,14 +88,20 @@ class BucketAggregationEmptySplitTest extends AnyFunSuite with Matchers {
   }
 
   test("assembleBucketBatch empty split with single agg and no GROUP BY columns") {
-    val schema = StructType(Seq(
-      StructField("cnt", LongType)
-    ))
+    val schema = StructType(
+      Seq(
+        StructField("cnt", LongType)
+      )
+    )
     val aggExprs: Array[AggregateFunc] = Array(new CountStar())
     val dataGroupByCols                = Array.empty[String]
 
     val result = GroupByColumnarReaderUtils.assembleBucketBatch(
-      emptyBatch, Array.empty[String], aggExprs, dataGroupByCols, schema
+      emptyBatch,
+      Array.empty[String],
+      aggExprs,
+      dataGroupByCols,
+      schema
     )
     try {
       result.numRows() shouldBe 0
@@ -92,15 +110,21 @@ class BucketAggregationEmptySplitTest extends AnyFunSuite with Matchers {
   }
 
   test("assembleBucketBatch empty split should produce columns with correct types") {
-    val schema = StructType(Seq(
-      StructField("dt", DateType),
-      StructField("cnt", LongType)
-    ))
+    val schema = StructType(
+      Seq(
+        StructField("dt", DateType),
+        StructField("cnt", LongType)
+      )
+    )
     val aggExprs: Array[AggregateFunc] = Array(new CountStar())
     val dataGroupByCols                = Array("dt")
 
     val result = GroupByColumnarReaderUtils.assembleBucketBatch(
-      emptyBatch, Array.empty[String], aggExprs, dataGroupByCols, schema
+      emptyBatch,
+      Array.empty[String],
+      aggExprs,
+      dataGroupByCols,
+      schema
     )
     try {
       result.numRows() shouldBe 0
@@ -111,13 +135,15 @@ class BucketAggregationEmptySplitTest extends AnyFunSuite with Matchers {
   }
 
   test("assembleBucketBatch empty split with multiple GROUP BY and multiple aggs") {
-    val schema = StructType(Seq(
-      StructField("a", StringType),
-      StructField("b", StringType),
-      StructField("c", StringType),
-      StructField("cnt", LongType),
-      StructField("total", LongType)
-    ))
+    val schema = StructType(
+      Seq(
+        StructField("a", StringType),
+        StructField("b", StringType),
+        StructField("c", StringType),
+        StructField("cnt", LongType),
+        StructField("total", LongType)
+      )
+    )
     val aggExprs: Array[AggregateFunc] = Array(
       new CountStar(),
       new CountStar()
@@ -125,7 +151,11 @@ class BucketAggregationEmptySplitTest extends AnyFunSuite with Matchers {
     val dataGroupByCols = Array("a", "b", "c")
 
     val result = GroupByColumnarReaderUtils.assembleBucketBatch(
-      emptyBatch, Array.empty[String], aggExprs, dataGroupByCols, schema
+      emptyBatch,
+      Array.empty[String],
+      aggExprs,
+      dataGroupByCols,
+      schema
     )
     try {
       result.numRows() shouldBe 0
@@ -134,20 +164,26 @@ class BucketAggregationEmptySplitTest extends AnyFunSuite with Matchers {
   }
 
   test("assembleBucketBatch empty split with multiple GROUP BY cols produces correct column count") {
-    val schema = StructType(Seq(
-      StructField("x", StringType),
-      StructField("y", StringType),
-      StructField("cnt", LongType)
-    ))
+    val schema = StructType(
+      Seq(
+        StructField("x", StringType),
+        StructField("y", StringType),
+        StructField("cnt", LongType)
+      )
+    )
     val aggExprs: Array[AggregateFunc] = Array(new CountStar())
     val dataGroupByCols                = Array("x", "y")
 
     val result = GroupByColumnarReaderUtils.assembleBucketBatch(
-      emptyBatch, Array.empty[String], aggExprs, dataGroupByCols, schema
+      emptyBatch,
+      Array.empty[String],
+      aggExprs,
+      dataGroupByCols,
+      schema
     )
-    try {
+    try
       result.numCols() shouldBe 3
-    } finally result.close()
+    finally result.close()
   }
 
   test("assembleBucketBatch empty split with zero GROUP BY cols and zero aggs") {
@@ -156,7 +192,11 @@ class BucketAggregationEmptySplitTest extends AnyFunSuite with Matchers {
     val dataGroupByCols = Array.empty[String]
 
     val result = GroupByColumnarReaderUtils.assembleBucketBatch(
-      emptyBatch, Array.empty[String], aggExprs, dataGroupByCols, schema
+      emptyBatch,
+      Array.empty[String],
+      aggExprs,
+      dataGroupByCols,
+      schema
     )
     try {
       result.numRows() shouldBe 0

--- a/src/test/scala/io/indextables/spark/core/BucketAggregationFfiParityTest.scala
+++ b/src/test/scala/io/indextables/spark/core/BucketAggregationFfiParityTest.scala
@@ -34,7 +34,10 @@ import org.scalatest.matchers.should.Matchers
  * the results match exactly. This ensures the FFI columnar path produces identical results to the object-based
  * InternalRow fallback path for all bucket aggregation types.
  */
-class BucketAggregationFfiParityTest extends AnyFunSuite with Matchers with io.indextables.spark.testutils.FileCleanupHelper {
+class BucketAggregationFfiParityTest
+    extends AnyFunSuite
+    with Matchers
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private val PROVIDER   = io.indextables.spark.TestBase.INDEXTABLES_FORMAT
   private val EXTENSIONS = "io.indextables.spark.extensions.IndexTables4SparkExtensions"

--- a/src/test/scala/io/indextables/spark/core/CompanionColumnarDatePartitionReadTest.scala
+++ b/src/test/scala/io/indextables/spark/core/CompanionColumnarDatePartitionReadTest.scala
@@ -24,8 +24,8 @@ import org.apache.spark.sql.types._
 import io.indextables.spark.TestBase
 
 /**
- * Integration tests for DateType handling in CompanionColumnarPartitionReader.createConstantColumnVector.
- * Validates that date-partitioned data round-trips correctly through write and read paths.
+ * Integration tests for DateType handling in CompanionColumnarPartitionReader.createConstantColumnVector. Validates
+ * that date-partitioned data round-trips correctly through write and read paths.
  */
 class CompanionColumnarDatePartitionReadTest extends TestBase {
 
@@ -80,9 +80,7 @@ class CompanionColumnarDatePartitionReadTest extends TestBase {
       val result = df.filter(df("event_date") === "2024-01-15").collect()
 
       result.length shouldBe 2
-      result.foreach { row =>
-        row.getAs[Date]("event_date") shouldBe Date.valueOf("2024-01-15")
-      }
+      result.foreach(row => row.getAs[Date]("event_date") shouldBe Date.valueOf("2024-01-15"))
       val ids = result.map(_.getAs[String]("id")).sorted
       ids shouldBe Array("a", "b")
     }

--- a/src/test/scala/io/indextables/spark/core/IndexQueryAllSafetyCheckTest.scala
+++ b/src/test/scala/io/indextables/spark/core/IndexQueryAllSafetyCheckTest.scala
@@ -30,7 +30,10 @@ import org.scalatest.BeforeAndAfterAll
  * Tests for the _indexall safety check that rejects queries searching too many fields. Uses tantivy4java's
  * SplitQuery.countQueryFields() for accurate field counting.
  */
-class IndexQueryAllSafetyCheckTest extends AnyFunSuite with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class IndexQueryAllSafetyCheckTest
+    extends AnyFunSuite
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   @transient private var _spark: SparkSession = _
   private var tempDir: java.nio.file.Path     = _

--- a/src/test/scala/io/indextables/spark/core/NativeMemoryIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/core/NativeMemoryIntegrationTest.scala
@@ -36,7 +36,12 @@ import org.scalatest.matchers.should.Matchers
  * Spark requires `spark.memory.offHeap.enabled=true` with a non-zero `spark.memory.offHeap.size` for off-heap
  * allocations to succeed.
  */
-class NativeMemoryIntegrationTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class NativeMemoryIntegrationTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
   protected var tempDir: String     = _

--- a/src/test/scala/io/indextables/spark/core/PartitionPruningOptimizationIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/core/PartitionPruningOptimizationIntegrationTest.scala
@@ -27,11 +27,10 @@ class PartitionPruningOptimizationIntegrationTest extends TestBase {
 
   private val provider = INDEXTABLES_FORMAT
 
-  override def beforeEach(): Unit = {
+  override def beforeEach(): Unit =
     super.beforeEach()
-    // Clear partition filter cache before each test
-    // Native caches are managed by tantivy4java
-  }
+  // Clear partition filter cache before each test
+  // Native caches are managed by tantivy4java
 
   test("Integration: equality filter with partition index") {
     withTempPath { path =>

--- a/src/test/scala/io/indextables/spark/core/RangeAggregationDiagnosticTest.scala
+++ b/src/test/scala/io/indextables/spark/core/RangeAggregationDiagnosticTest.scala
@@ -14,7 +14,10 @@ import org.scalatest.matchers.should.Matchers
  * Diagnostic test: Range aggregation works at tantivy4java level but returns NULL|6 via Spark SQL. This test isolates
  * where the bug is.
  */
-class RangeAggregationDiagnosticTest extends AnyFunSuite with Matchers with io.indextables.spark.testutils.FileCleanupHelper {
+class RangeAggregationDiagnosticTest
+    extends AnyFunSuite
+    with Matchers
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   test("Range aggregation directly via tantivy4java on Spark-written split") {
     val spark = SparkSession

--- a/src/test/scala/io/indextables/spark/core/SimpleAggregatePushdownTest.scala
+++ b/src/test/scala/io/indextables/spark/core/SimpleAggregatePushdownTest.scala
@@ -360,7 +360,7 @@ class SimpleAggregatePushdownTest extends TestBase with io.indextables.spark.tes
     )
 
     // For testing: create a mock TransactionLog with empty files
-    val transactionLog = TransactionLogFactory.create(new Path("/mock/path"), spark)
+    val transactionLog  = TransactionLogFactory.create(new Path("/mock/path"), spark)
     val broadcastConfig = spark.sparkContext.broadcast(Map[String, String]())
 
     // Test that we can create the scan builder

--- a/src/test/scala/io/indextables/spark/core/TantVsFfiSplitComparisonTest.scala
+++ b/src/test/scala/io/indextables/spark/core/TantVsFfiSplitComparisonTest.scala
@@ -4,8 +4,8 @@ import io.indextables.spark.TestBase
 
 /**
  * Validates Arrow FFI split behavior:
- *   1. EndsWith/Contains pushdown on FFI-written splits
- *   2. Partition filters don't leak to tantivy on FFI splits (which don't index partition cols)
+ *   1. EndsWith/Contains pushdown on FFI-written splits 2. Partition filters don't leak to tantivy on FFI splits (which
+ *      don't index partition cols)
  */
 class TantVsFfiSplitComparisonTest extends TestBase {
 

--- a/src/test/scala/io/indextables/spark/core/TransactionLogCountDatePartitionTest.scala
+++ b/src/test/scala/io/indextables/spark/core/TransactionLogCountDatePartitionTest.scala
@@ -26,8 +26,8 @@ import org.apache.spark.sql.types._
 import io.indextables.spark.TestBase
 
 /**
- * Tests for DateType handling in TransactionLogGroupByCountPartitionReader.convertPartitionValue.
- * Covers both the ISO date string path and the epoch-day integer fallback (Commit 2).
+ * Tests for DateType handling in TransactionLogGroupByCountPartitionReader.convertPartitionValue. Covers both the ISO
+ * date string path and the epoch-day integer fallback (Commit 2).
  */
 class TransactionLogCountDatePartitionTest extends TestBase {
 
@@ -86,9 +86,11 @@ class TransactionLogCountDatePartitionTest extends TestBase {
       val df = spark.read.format("io.indextables.spark.core.IndexTables4SparkTableProvider").load(tempPath)
       df.createOrReplaceTempView("date_group_test")
 
-      val result = spark.sql(
-        "SELECT event_date, count(*) as cnt FROM date_group_test WHERE event_date >= '2024-02-01' GROUP BY event_date"
-      ).collect()
+      val result = spark
+        .sql(
+          "SELECT event_date, count(*) as cnt FROM date_group_test WHERE event_date >= '2024-02-01' GROUP BY event_date"
+        )
+        .collect()
 
       result.length shouldBe 2
       val countMap = result.map(r => (r.getAs[Date]("event_date").toString, r.getAs[Long]("cnt"))).toMap
@@ -101,13 +103,20 @@ class TransactionLogCountDatePartitionTest extends TestBase {
 
   private lazy val convertPartitionValueMethod = {
     val m = classOf[TransactionLogGroupByCountPartitionReader].getDeclaredMethod(
-      "convertPartitionValue", classOf[String], classOf[DataType], classOf[String]
+      "convertPartitionValue",
+      classOf[String],
+      classOf[DataType],
+      classOf[String]
     )
     m.setAccessible(true)
     m
   }
 
-  private def invokeConvertPartitionValue(value: String, dataType: DataType, columnName: String): Any = {
+  private def invokeConvertPartitionValue(
+    value: String,
+    dataType: DataType,
+    columnName: String
+  ): Any = {
     val partition = TransactionLogGroupByCountPartition(
       groupedCounts = Seq.empty,
       groupByColumns = Array(columnName),

--- a/src/test/scala/io/indextables/spark/core/V2MultiPathTest.scala
+++ b/src/test/scala/io/indextables/spark/core/V2MultiPathTest.scala
@@ -208,8 +208,8 @@ class V2MultiPathTest extends TestBase with BeforeAndAfterAll with BeforeAndAfte
         .save(siblingPath)
 
       // Read each path individually to verify separation
-      val parentResult = spark.read.format(INDEXTABLES_FORMAT).load(parentPath)
-      val childResult  = spark.read.format(INDEXTABLES_FORMAT).load(childPath)
+      val parentResult  = spark.read.format(INDEXTABLES_FORMAT).load(parentPath)
+      val childResult   = spark.read.format(INDEXTABLES_FORMAT).load(childPath)
       val siblingResult = spark.read.format(INDEXTABLES_FORMAT).load(siblingPath)
 
       // Verify each dataset is distinct

--- a/src/test/scala/io/indextables/spark/debug/MicrosecondPrecisionValidationTest.scala
+++ b/src/test/scala/io/indextables/spark/debug/MicrosecondPrecisionValidationTest.scala
@@ -254,7 +254,7 @@ class MicrosecondPrecisionValidationTest extends AnyFunSuite with BeforeAndAfter
 
       // Compute expected microseconds from the same Timestamp used to write, so the
       // assertion is timezone-independent (Timestamp.valueOf interprets in JVM-local TZ).
-      val expectedTs = Timestamp.valueOf("2025-11-07 07:00:00.000001")
+      val expectedTs     = Timestamp.valueOf("2025-11-07 07:00:00.000001")
       val expectedMicros = expectedTs.getTime / 1000 * 1000000L + expectedTs.getNanos / 1000L
 
       println(s"\n🔬 Microsecond validation:")

--- a/src/test/scala/io/indextables/spark/indexing/IpAddressFieldTest.scala
+++ b/src/test/scala/io/indextables/spark/indexing/IpAddressFieldTest.scala
@@ -438,13 +438,13 @@ class IpAddressFieldTest extends TestBase {
 
       // IPs at and around 192.168.1.0/24 boundaries
       val data = Seq(
-        ("outside-low",  "192.168.0.255"),
+        ("outside-low", "192.168.0.255"),
         ("boundary-low", "192.168.1.0"),
-        ("inside1",      "192.168.1.1"),
-        ("inside2",      "192.168.1.128"),
-        ("boundary-hi",  "192.168.1.255"),
-        ("outside-hi",   "192.168.2.0"),
-        ("unrelated",    "10.0.0.1")
+        ("inside1", "192.168.1.1"),
+        ("inside2", "192.168.1.128"),
+        ("boundary-hi", "192.168.1.255"),
+        ("outside-hi", "192.168.2.0"),
+        ("unrelated", "10.0.0.1")
       ).toDF("name", "ip")
 
       data.write
@@ -478,10 +478,10 @@ class IpAddressFieldTest extends TestBase {
       import spark.implicits._
 
       val data = Seq(
-        ("ten-a",    "10.0.0.1"),
-        ("ten-b",    "10.255.255.254"),
-        ("other",    "172.16.0.1"),
-        ("other2",   "192.168.1.1")
+        ("ten-a", "10.0.0.1"),
+        ("ten-b", "10.255.255.254"),
+        ("other", "172.16.0.1"),
+        ("other2", "192.168.1.1")
       ).toDF("name", "ip")
 
       data.write
@@ -534,13 +534,13 @@ class IpAddressFieldTest extends TestBase {
       import spark.implicits._
 
       val data = Seq(
-        ("outside-low",  "192.168.0.255"),
+        ("outside-low", "192.168.0.255"),
         ("boundary-low", "192.168.1.0"),
-        ("inside1",      "192.168.1.1"),
-        ("inside2",      "192.168.1.128"),
-        ("boundary-hi",  "192.168.1.255"),
-        ("outside-hi",   "192.168.2.0"),
-        ("unrelated",    "10.0.0.1")
+        ("inside1", "192.168.1.1"),
+        ("inside2", "192.168.1.128"),
+        ("boundary-hi", "192.168.1.255"),
+        ("outside-hi", "192.168.2.0"),
+        ("unrelated", "10.0.0.1")
       ).toDF("name", "ip")
 
       data.write
@@ -571,9 +571,9 @@ class IpAddressFieldTest extends TestBase {
       import spark.implicits._
 
       val data = Seq(
-        ("ten-a",  "10.0.0.1"),
-        ("ten-b",  "10.0.1.5"),
-        ("other",  "172.16.0.1")
+        ("ten-a", "10.0.0.1"),
+        ("ten-b", "10.0.1.5"),
+        ("other", "172.16.0.1")
       ).toDF("name", "ip")
 
       data.write
@@ -607,9 +607,9 @@ class IpAddressFieldTest extends TestBase {
         .format("io.indextables.spark.core.IndexTables4SparkTableProvider")
         .load(tablePath)
 
-      val cidrIds      = df.filter($"ip" === "192.168.1.0/24").collect().map(_.getString(0)).toSet
-      val wildcardIds  = df.filter($"ip" === "192.168.1.*").collect().map(_.getString(0)).toSet
-      val explicitIds  = df
+      val cidrIds     = df.filter($"ip" === "192.168.1.0/24").collect().map(_.getString(0)).toSet
+      val wildcardIds = df.filter($"ip" === "192.168.1.*").collect().map(_.getString(0)).toSet
+      val explicitIds = df
         .filter($"ip" >= "192.168.1.0" && $"ip" <= "192.168.1.255")
         .collect()
         .map(_.getString(0))
@@ -626,11 +626,11 @@ class IpAddressFieldTest extends TestBase {
       import spark.implicits._
 
       val data = Seq(
-        ("ten-a",     "10.0.0.1"),
-        ("ten-b",     "10.0.0.2"),
+        ("ten-a", "10.0.0.1"),
+        ("ten-b", "10.0.0.2"),
         ("private-a", "192.168.1.1"),
         ("private-b", "192.168.1.2"),
-        ("other",     "172.16.0.1")
+        ("other", "172.16.0.1")
       ).toDF("name", "ip")
 
       data.write
@@ -657,10 +657,10 @@ class IpAddressFieldTest extends TestBase {
       import spark.implicits._
 
       val data = Seq(
-        ("ten-a",     "10.0.0.1"),
-        ("ten-b",     "10.0.0.2"),
+        ("ten-a", "10.0.0.1"),
+        ("ten-b", "10.0.0.2"),
         ("private-a", "192.168.1.1"),
-        ("other",     "172.16.0.1")
+        ("other", "172.16.0.1")
       ).toDF("name", "ip")
 
       data.write
@@ -686,11 +686,11 @@ class IpAddressFieldTest extends TestBase {
       import spark.implicits._
 
       val data = Seq(
-        ("ten-a",     "10.0.0.1"),
-        ("ten-b",     "10.0.0.2"),
+        ("ten-a", "10.0.0.1"),
+        ("ten-b", "10.0.0.2"),
         ("private-a", "192.168.1.1"),
         ("private-b", "192.168.1.2"),
-        ("other",     "172.16.0.1")
+        ("other", "172.16.0.1")
       ).toDF("name", "ip")
 
       data.write
@@ -843,8 +843,8 @@ class IpAddressFieldTest extends TestBase {
       val data = Seq(
         ("192.168.1.1", "us-east", 100),
         ("192.168.1.2", "us-east", 200),
-        ("192.168.1.3", "eu-west",  50),
-        ("10.0.0.1",    "us-east", 999)  // outside CIDR — must not appear in results
+        ("192.168.1.3", "eu-west", 50),
+        ("10.0.0.1", "us-east", 999) // outside CIDR — must not appear in results
       ).toDF("ip", "region", "requests")
 
       data.write
@@ -867,11 +867,11 @@ class IpAddressFieldTest extends TestBase {
       // 10.0.0.1 must be excluded; only the two 192.168.1.x regions remain
       result.length shouldBe 2
       result(0).getString(0) shouldBe "eu-west"
-      result(0).getLong(1)   shouldBe 1
-      result(0).getLong(2)   shouldBe 50
+      result(0).getLong(1) shouldBe 1
+      result(0).getLong(2) shouldBe 50
       result(1).getString(0) shouldBe "us-east"
-      result(1).getLong(1)   shouldBe 2
-      result(1).getLong(2)   shouldBe 300
+      result(1).getLong(1) shouldBe 2
+      result(1).getLong(2) shouldBe 300
     }
   }
 

--- a/src/test/scala/io/indextables/spark/indexing/IpAddressHistogramTest.scala
+++ b/src/test/scala/io/indextables/spark/indexing/IpAddressHistogramTest.scala
@@ -25,15 +25,14 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 /**
- * Validates that IP CIDR/wildcard filters work correctly on the histogram/bucket
- * aggregation execution path (GroupByAggregateColumnarReader → nativeAggregateArrowFfi
- * → perform_search_async_impl_leaf_response_with_aggregations).
+ * Validates that IP CIDR/wildcard filters work correctly on the histogram/bucket aggregation execution path
+ * (GroupByAggregateColumnarReader → nativeAggregateArrowFfi →
+ * perform_search_async_impl_leaf_response_with_aggregations).
  *
- * Uses a dedicated Spark session (like BucketAggregationTest) to avoid codegen cache
- * interference from the shared TestBase session.
+ * Uses a dedicated Spark session (like BucketAggregationTest) to avoid codegen cache interference from the shared
+ * TestBase session.
  */
-class IpAddressHistogramTest extends AnyFunSuite with Matchers
-    with io.indextables.spark.testutils.FileCleanupHelper {
+class IpAddressHistogramTest extends AnyFunSuite with Matchers with io.indextables.spark.testutils.FileCleanupHelper {
 
   def createTestSession(): SparkSession =
     SparkSession
@@ -44,7 +43,7 @@ class IpAddressHistogramTest extends AnyFunSuite with Matchers
       .getOrCreate()
 
   test("IP CIDR filter with histogram aggregation") {
-    val spark = createTestSession()
+    val spark   = createTestSession()
     val tempDir = Files.createTempDirectory("ip-histogram-test").toFile
 
     try {
@@ -53,9 +52,9 @@ class IpAddressHistogramTest extends AnyFunSuite with Matchers
       // Two IPs inside 192.168.1.0/24 with requests in different histogram buckets,
       // one IP outside the CIDR that must be excluded by the pushed-down filter.
       val data = Seq(
-        ("s1", "192.168.1.1", 15.0),  // bucket 0.0   (0–50)
-        ("s2", "192.168.1.2", 75.0),  // bucket 50.0  (50–100)
-        ("s3", "10.0.0.1",   200.0)   // outside CIDR — must NOT appear in results
+        ("s1", "192.168.1.1", 15.0), // bucket 0.0   (0–50)
+        ("s2", "192.168.1.2", 75.0), // bucket 50.0  (50–100)
+        ("s3", "10.0.0.1", 200.0)    // outside CIDR — must NOT appear in results
       ).toDF("name", "ip", "requests")
 
       data.write
@@ -71,15 +70,17 @@ class IpAddressHistogramTest extends AnyFunSuite with Matchers
 
       df.createOrReplaceTempView("ip_hist")
 
-      val result = spark.sql(
-        """
-          |SELECT indextables_histogram(requests, 50.0) AS bucket, COUNT(*) AS cnt
-          |FROM ip_hist
-          |WHERE ip = '192.168.1.0/24'
-          |GROUP BY indextables_histogram(requests, 50.0)
-          |ORDER BY bucket
-          |""".stripMargin
-      ).collect()
+      val result = spark
+        .sql(
+          """
+            |SELECT indextables_histogram(requests, 50.0) AS bucket, COUNT(*) AS cnt
+            |FROM ip_hist
+            |WHERE ip = '192.168.1.0/24'
+            |GROUP BY indextables_histogram(requests, 50.0)
+            |ORDER BY bucket
+            |""".stripMargin
+        )
+        .collect()
 
       // s1 → bucket 0.0; s2 → bucket 50.0; s3 excluded by CIDR filter
       result.length shouldBe 2
@@ -88,21 +89,21 @@ class IpAddressHistogramTest extends AnyFunSuite with Matchers
       result(1).getAs[Double]("bucket") shouldBe 50.0
       result(1).getAs[Long]("cnt") shouldBe 1
 
-    } finally {
-      try { deleteRecursively(tempDir) } finally { spark.stop() }
-    }
+    } finally
+      try deleteRecursively(tempDir)
+      finally spark.stop()
   }
 
   test("IP wildcard filter with histogram aggregation") {
-    val spark = createTestSession()
+    val spark   = createTestSession()
     val tempDir = Files.createTempDirectory("ip-wildcard-histogram-test").toFile
 
     try {
       import spark.implicits._
 
       val data = Seq(
-        ("s1", "10.0.0.1",  20.0),   // bucket 0.0   — inside 10.0.*.*
-        ("s2", "10.0.0.2",  80.0),   // bucket 50.0  — inside 10.0.*.*
+        ("s1", "10.0.0.1", 20.0),    // bucket 0.0   — inside 10.0.*.*
+        ("s2", "10.0.0.2", 80.0),    // bucket 50.0  — inside 10.0.*.*
         ("s3", "10.0.1.1", 120.0),   // bucket 100.0 — inside 10.0.*.*
         ("s4", "192.168.1.1", 999.0) // outside wildcard — must NOT appear
       ).toDF("name", "ip", "requests")
@@ -120,15 +121,17 @@ class IpAddressHistogramTest extends AnyFunSuite with Matchers
 
       df.createOrReplaceTempView("ip_wildcard_hist")
 
-      val result = spark.sql(
-        """
-          |SELECT indextables_histogram(requests, 50.0) AS bucket, COUNT(*) AS cnt
-          |FROM ip_wildcard_hist
-          |WHERE ip = '10.0.*.*'
-          |GROUP BY indextables_histogram(requests, 50.0)
-          |ORDER BY bucket
-          |""".stripMargin
-      ).collect()
+      val result = spark
+        .sql(
+          """
+            |SELECT indextables_histogram(requests, 50.0) AS bucket, COUNT(*) AS cnt
+            |FROM ip_wildcard_hist
+            |WHERE ip = '10.0.*.*'
+            |GROUP BY indextables_histogram(requests, 50.0)
+            |ORDER BY bucket
+            |""".stripMargin
+        )
+        .collect()
 
       // s1 → 0.0; s2 → 50.0; s3 → 100.0; s4 excluded
       result.length shouldBe 3
@@ -139,8 +142,8 @@ class IpAddressHistogramTest extends AnyFunSuite with Matchers
       result(2).getAs[Double]("bucket") shouldBe 100.0
       result(2).getAs[Long]("cnt") shouldBe 1
 
-    } finally {
-      try { deleteRecursively(tempDir) } finally { spark.stop() }
-    }
+    } finally
+      try deleteRecursively(tempDir)
+      finally spark.stop()
   }
 }

--- a/src/test/scala/io/indextables/spark/indexing/IpAddressIndexQueryTest.scala
+++ b/src/test/scala/io/indextables/spark/indexing/IpAddressIndexQueryTest.scala
@@ -28,8 +28,8 @@ import io.indextables.spark.TestBase
  *   - Multiple terms (IN): ip_field:192.168.1.1 OR ip_field:10.0.0.1
  *
  * CIDR and wildcard patterns are transparently expanded by tantivy4java:
- *   - CIDR: ip indexquery '192.168.1.0/24'  →  range [192.168.1.0 TO 192.168.1.255]
- *   - Wildcard: ip indexquery '192.168.1.*'  →  same range
+ *   - CIDR: ip indexquery '192.168.1.0/24' → range [192.168.1.0 TO 192.168.1.255]
+ *   - Wildcard: ip indexquery '192.168.1.*' → same range
  */
 class IpAddressIndexQueryTest extends TestBase {
 

--- a/src/test/scala/io/indextables/spark/integration/DataSkippingVerificationTest.scala
+++ b/src/test/scala/io/indextables/spark/integration/DataSkippingVerificationTest.scala
@@ -37,7 +37,7 @@ import org.scalatest.BeforeAndAfterEach
 
 class DataSkippingVerificationTest extends TestBase with BeforeAndAfterEach {
 
-  private var testTablePath: Path            = _
+  private var testTablePath: Path                     = _
   private var transactionLog: TransactionLogInterface = _
 
   override def beforeEach(): Unit = {

--- a/src/test/scala/io/indextables/spark/integration/TransactionLogStatisticsTest.scala
+++ b/src/test/scala/io/indextables/spark/integration/TransactionLogStatisticsTest.scala
@@ -33,7 +33,7 @@ import org.scalatest.BeforeAndAfterEach
  */
 class TransactionLogStatisticsTest extends TestBase with BeforeAndAfterEach {
 
-  private var testTablePath: Path            = _
+  private var testTablePath: Path                     = _
   private var transactionLog: TransactionLogInterface = _
 
   override def beforeEach(): Unit = {

--- a/src/test/scala/io/indextables/spark/io/merge/DownloadManagerTest.scala
+++ b/src/test/scala/io/indextables/spark/io/merge/DownloadManagerTest.scala
@@ -26,7 +26,11 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterEach
 
-class DownloadManagerTest extends AnyFunSuite with Matchers with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class DownloadManagerTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private var tempDir: File = _
 

--- a/src/test/scala/io/indextables/spark/io/merge/LocalCopyDownloaderTest.scala
+++ b/src/test/scala/io/indextables/spark/io/merge/LocalCopyDownloaderTest.scala
@@ -24,7 +24,11 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterEach
 
-class LocalCopyDownloaderTest extends AnyFunSuite with Matchers with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class LocalCopyDownloaderTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private var tempDir: File = _
 

--- a/src/test/scala/io/indextables/spark/prewarm/AsyncPrewarmJobManagerTest.scala
+++ b/src/test/scala/io/indextables/spark/prewarm/AsyncPrewarmJobManagerTest.scala
@@ -102,9 +102,9 @@ class AsyncPrewarmJobManagerTest extends AnyFunSuite with Matchers with BeforeAn
 
     // Retry the rejection check — the slot counter may take a moment to update
     // after the work lambda begins executing on the thread pool.
-    var rejected = false
+    var rejected  = false
     var rejectMsg = ""
-    var attempts = 0
+    var attempts  = 0
     while (!rejected && attempts < 20) {
       Thread.sleep(25)
       val result2 = AsyncPrewarmJobManager.tryStartJob(
@@ -112,7 +112,8 @@ class AsyncPrewarmJobManagerTest extends AnyFunSuite with Matchers with BeforeAn
         tablePath = "s3://bucket/table",
         hostname = "host1",
         totalSplits = 5,
-        work = () => AsyncPrewarmJobResult(s"job-2-attempt-$attempts", "s3://bucket/table", "host1", 5, 5, 50, true, None)
+        work =
+          () => AsyncPrewarmJobResult(s"job-2-attempt-$attempts", "s3://bucket/table", "host1", 5, 5, 50, true, None)
       )
       result2.left.foreach { msg => rejected = true; rejectMsg = msg }
       attempts += 1

--- a/src/test/scala/io/indextables/spark/prewarm/CacheBehaviorWithoutPrewarmTest.scala
+++ b/src/test/scala/io/indextables/spark/prewarm/CacheBehaviorWithoutPrewarmTest.scala
@@ -31,7 +31,10 @@ import org.slf4j.LoggerFactory
  *   - First query should populate the cache
  *   - Second identical query should get 100% cache hits (no new components)
  */
-class CacheBehaviorWithoutPrewarmTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class CacheBehaviorWithoutPrewarmTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private val logger = LoggerFactory.getLogger(classOf[CacheBehaviorWithoutPrewarmTest])
 

--- a/src/test/scala/io/indextables/spark/prewarm/CloudAzureAsyncPrewarmValidationTest.scala
+++ b/src/test/scala/io/indextables/spark/prewarm/CloudAzureAsyncPrewarmValidationTest.scala
@@ -38,7 +38,9 @@ import io.indextables.spark.CloudAzureTestBase
  *   1. System properties: test.azure.storageAccount, test.azure.accountKey 2. ~/.azure/credentials file (matches
  *      tantivy4java pattern) 3. Environment variables: AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY
  */
-class CloudAzureAsyncPrewarmValidationTest extends CloudAzureTestBase with io.indextables.spark.testutils.FileCleanupHelper {
+class CloudAzureAsyncPrewarmValidationTest
+    extends CloudAzureTestBase
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   // Generate unique test run ID to avoid conflicts
   private val testRunId = UUID.randomUUID().toString.substring(0, 8)

--- a/src/test/scala/io/indextables/spark/prewarm/CloudAzurePrewarmCacheValidationTest.scala
+++ b/src/test/scala/io/indextables/spark/prewarm/CloudAzurePrewarmCacheValidationTest.scala
@@ -43,7 +43,9 @@ import io.indextables.spark.CloudAzureTestBase
  *   1. System properties: test.azure.storageAccount, test.azure.accountKey 2. ~/.azure/credentials file (matches
  *      tantivy4java pattern) 3. Environment variables: AZURE_STORAGE_ACCOUNT, AZURE_STORAGE_KEY
  */
-class CloudAzurePrewarmCacheValidationTest extends CloudAzureTestBase with io.indextables.spark.testutils.FileCleanupHelper {
+class CloudAzurePrewarmCacheValidationTest
+    extends CloudAzureTestBase
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   // Generate unique test run ID to avoid conflicts
   private val testRunId = UUID.randomUUID().toString.substring(0, 8)

--- a/src/test/scala/io/indextables/spark/prewarm/CloudS3CompanionParquetColumnsPrewarmTest.scala
+++ b/src/test/scala/io/indextables/spark/prewarm/CloudS3CompanionParquetColumnsPrewarmTest.scala
@@ -46,7 +46,9 @@ import io.indextables.spark.CloudS3TestBase
  *   - Run with: TANTIVY4JAVA_PERFLOG=1 mvn test-compile scalatest:test \
  *     -DwildcardSuites='io.indextables.spark.prewarm.CloudS3CompanionParquetColumnsPrewarmTest'
  */
-class CloudS3CompanionParquetColumnsPrewarmTest extends CloudS3TestBase with io.indextables.spark.testutils.FileCleanupHelper {
+class CloudS3CompanionParquetColumnsPrewarmTest
+    extends CloudS3TestBase
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private val S3_BUCKET    = System.getProperty("test.s3.bucket", "test-tantivy4sparkbucket")
   private val S3_REGION    = System.getProperty("test.s3.region", "us-east-2")

--- a/src/test/scala/io/indextables/spark/prewarm/CompanionParquetColumnsPrewarmTest.scala
+++ b/src/test/scala/io/indextables/spark/prewarm/CompanionParquetColumnsPrewarmTest.scala
@@ -50,7 +50,11 @@ import org.slf4j.LoggerFactory
  *
  * No cloud credentials needed — runs entirely on local filesystem.
  */
-class CompanionParquetColumnsPrewarmTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class CompanionParquetColumnsPrewarmTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private val logger = LoggerFactory.getLogger(classOf[CompanionParquetColumnsPrewarmTest])
 

--- a/src/test/scala/io/indextables/spark/prewarm/PrewarmCacheMissValidationTest.scala
+++ b/src/test/scala/io/indextables/spark/prewarm/PrewarmCacheMissValidationTest.scala
@@ -39,7 +39,10 @@ import org.slf4j.LoggerFactory
  *      segments 4. Record cache stats after prewarm 5. Execute queries that would normally cause cache misses 6. Verify
  *      no new cache misses occurred
  */
-class PrewarmCacheMissValidationTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class PrewarmCacheMissValidationTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private val logger = LoggerFactory.getLogger(classOf[PrewarmCacheMissValidationTest])
 

--- a/src/test/scala/io/indextables/spark/prewarm/PrewarmCatchUpTest.scala
+++ b/src/test/scala/io/indextables/spark/prewarm/PrewarmCatchUpTest.scala
@@ -35,7 +35,10 @@ import org.slf4j.LoggerFactory
  *   1. Prewarm state is tracked per split 2. New hosts trigger catch-up prewarming 3. New splits discovered in
  *      transaction log trigger catch-up 4. State tracking is consistent across operations
  */
-class PrewarmCatchUpTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class PrewarmCatchUpTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private val logger = LoggerFactory.getLogger(classOf[PrewarmCatchUpTest])
 

--- a/src/test/scala/io/indextables/spark/prewarm/PrewarmReadTimeIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/prewarm/PrewarmReadTimeIntegrationTest.scala
@@ -33,7 +33,10 @@ import org.slf4j.LoggerFactory
  *
  * Tests that prewarm executes automatically when reading data with appropriate config set.
  */
-class PrewarmReadTimeIntegrationTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class PrewarmReadTimeIntegrationTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private val logger = LoggerFactory.getLogger(classOf[PrewarmReadTimeIntegrationTest])
 

--- a/src/test/scala/io/indextables/spark/sql/CheckpointCommandTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/CheckpointCommandTest.scala
@@ -28,7 +28,11 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 
 /** Tests for CHECKPOINT INDEXTABLES command. */
-class CheckpointCommandTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class CheckpointCommandTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private var spark: SparkSession = _
   private var tempDir: File       = _
@@ -232,21 +236,21 @@ class CheckpointCommandTest extends AnyFunSuite with Matchers with BeforeAndAfte
   }
 
   /**
-   * Regression test: CHECKPOINT INDEXTABLES must resolve credentials via TransactionLogFactory.create(),
-   * not bypass it with a freshly-built nativeConfig from ConfigMapper.toNativeConfig(options).
+   * Regression test: CHECKPOINT INDEXTABLES must resolve credentials via TransactionLogFactory.create(), not bypass it
+   * with a freshly-built nativeConfig from ConfigMapper.toNativeConfig(options).
    *
-   * Before the fix (commit c75465ba), CheckpointCommand called TransactionLogWriter.createCheckpoint
-   * with a nativeConfig built directly from raw options — bypassing resolveCredentialsOnDriver.
-   * On Databricks/UC, this meant no credentials were injected into nativeConfig, causing the native
-   * Rust layer to use anonymous/instance-role access and fail with 403 on UC-controlled S3 paths.
+   * Before the fix (commit c75465ba), CheckpointCommand called TransactionLogWriter.createCheckpoint with a
+   * nativeConfig built directly from raw options — bypassing resolveCredentialsOnDriver. On Databricks/UC, this meant
+   * no credentials were injected into nativeConfig, causing the native Rust layer to use anonymous/instance-role access
+   * and fail with 403 on UC-controlled S3 paths.
    *
-   * After the fix, CheckpointCommand delegates through transactionLog.createCheckpoint(), which uses
-   * the NativeTransactionLog's own nativeConfig (populated via TransactionLogFactory.create's
-   * resolveCredentialsOnDriver call) and also calls refreshCredentials() before the write.
+   * After the fix, CheckpointCommand delegates through transactionLog.createCheckpoint(), which uses the
+   * NativeTransactionLog's own nativeConfig (populated via TransactionLogFactory.create's resolveCredentialsOnDriver
+   * call) and also calls refreshCredentials() before the write.
    *
-   * We verify via MockTableCredentialProvider: if CHECKPOINT calls resolveCredentialsOnDriver,
-   * getCredentials() is invoked and pathCredentialCallCount increments. If it bypasses resolution,
-   * the count stays unchanged after checkpoint.
+   * We verify via MockTableCredentialProvider: if CHECKPOINT calls resolveCredentialsOnDriver, getCredentials() is
+   * invoked and pathCredentialCallCount increments. If it bypasses resolution, the count stays unchanged after
+   * checkpoint.
    */
   test("CHECKPOINT INDEXTABLES invokes credential provider from Spark conf (regression for credential bypass bug)") {
     import io.indextables.spark.testutils.MockTableCredentialProvider

--- a/src/test/scala/io/indextables/spark/sql/CloudS3PurgeOnWriteTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/CloudS3PurgeOnWriteTest.scala
@@ -208,11 +208,11 @@ class CloudS3PurgeOnWriteTest extends CloudS3TestBase {
 
     // Common write options for this test
     val s3Opts = Map(
-      "spark.indextables.aws.accessKey"        -> accessKey,
-      "spark.indextables.aws.secretKey"        -> secretKey,
-      "spark.indextables.aws.region"           -> S3_REGION,
-      "spark.indextables.checkpoint.enabled"   -> "true",
-      "spark.indextables.checkpoint.interval"  -> "10"
+      "spark.indextables.aws.accessKey"       -> accessKey,
+      "spark.indextables.aws.secretKey"       -> secretKey,
+      "spark.indextables.aws.region"          -> S3_REGION,
+      "spark.indextables.checkpoint.enabled"  -> "true",
+      "spark.indextables.checkpoint.interval" -> "10"
     )
 
     // Write 12 times to create version files 0-11 and a checkpoint at version 10
@@ -235,9 +235,11 @@ class CloudS3PurgeOnWriteTest extends CloudS3TestBase {
     assert(versionFilesBefore >= 10, s"Should have at least 10 version files before purge, got $versionFilesBefore")
 
     // Run synchronous purge via SQL (no sleep/timing dependency)
-    spark.sql(
-      s"PURGE INDEXTABLE '$tablePath' OLDER THAN 0 HOURS TRANSACTION LOG RETENTION 0 HOURS"
-    ).collect()
+    spark
+      .sql(
+        s"PURGE INDEXTABLE '$tablePath' OLDER THAN 0 HOURS TRANSACTION LOG RETENTION 0 HOURS"
+      )
+      .collect()
 
     // Verify old pre-checkpoint version files were deleted
     val versionFilesAfter = fs.listStatus(txLogPath).count(_.getPath.getName.matches("\\d+\\.json"))

--- a/src/test/scala/io/indextables/spark/sql/ConcurrentTableRootCommandsTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/ConcurrentTableRootCommandsTest.scala
@@ -43,7 +43,11 @@ import org.scalatest.BeforeAndAfterAll
  *
  * Run with: mvn test-compile scalatest:test -DwildcardSuites='io.indextables.spark.sql.ConcurrentTableRootCommandsTest'
  */
-class ConcurrentTableRootCommandsTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class ConcurrentTableRootCommandsTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private var spark: SparkSession = _
   private var tempDir: File       = _

--- a/src/test/scala/io/indextables/spark/sql/DescribeDiskCacheCommandTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/DescribeDiskCacheCommandTest.scala
@@ -28,7 +28,11 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 
 /** Tests for DESCRIBE INDEXTABLES DISK CACHE command. */
-class DescribeDiskCacheCommandTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class DescribeDiskCacheCommandTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private var spark: SparkSession = _
   private var tempDir: File       = _

--- a/src/test/scala/io/indextables/spark/sql/DescribeStateCommandTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/DescribeStateCommandTest.scala
@@ -18,14 +18,13 @@
 package io.indextables.spark.sql
 
 import org.apache.spark.sql.types.{StringType => SparkStringType, StructField, StructType}
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import org.apache.hadoop.fs.Path
 
 import io.indextables.spark.io.CloudStorageProviderFactory
 import io.indextables.spark.transaction.{AddAction, TransactionLogFactory}
 import io.indextables.spark.TestBase
-
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 class DescribeStateCommandTest extends TestBase {
 

--- a/src/test/scala/io/indextables/spark/sql/DescribeStorageStatsCommandTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/DescribeStorageStatsCommandTest.scala
@@ -28,7 +28,11 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
 
 /** Tests for DESCRIBE INDEXTABLES STORAGE STATS command. */
-class DescribeStorageStatsCommandTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class DescribeStorageStatsCommandTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private var spark: SparkSession = _
   private var tempDir: File       = _

--- a/src/test/scala/io/indextables/spark/sql/DescribeTransactionLogTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/DescribeTransactionLogTest.scala
@@ -27,7 +27,10 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterEach
 
 /** Tests for DESCRIBE INDEXTABLES TRANSACTION LOG command. */
-class DescribeTransactionLogTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class DescribeTransactionLogTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   var spark: SparkSession = _
   var tempDir: String     = _

--- a/src/test/scala/io/indextables/spark/sql/DocumentPreservationValidationTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/DocumentPreservationValidationTest.scala
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory
  */
 class DocumentPreservationValidationTest extends TestBase with BeforeAndAfterEach {
 
-  private val logger                         = LoggerFactory.getLogger(classOf[DocumentPreservationValidationTest])
-  private var tempTablePath: String          = _
+  private val logger                = LoggerFactory.getLogger(classOf[DocumentPreservationValidationTest])
+  private var tempTablePath: String = _
   private var transactionLog: TransactionLogInterface = _
 
   override def beforeEach(): Unit = {
@@ -152,7 +152,7 @@ class DocumentPreservationValidationTest extends TestBase with BeforeAndAfterEac
     )
 
     // Step 4: Query all documents BEFORE merge (baseline)
-    val beforeMergeDF = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
+    val beforeMergeDF     = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
     val beforeMergeCount  = beforeMergeDF.count()
     val beforeMergeDocIds = beforeMergeDF.select("id").collect().map(_.getLong(0)).sorted
 
@@ -201,7 +201,7 @@ class DocumentPreservationValidationTest extends TestBase with BeforeAndAfterEac
     )
 
     // Step 7: Query all documents AFTER merge (validation)
-    val afterMergeDF = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
+    val afterMergeDF     = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
     val afterMergeCount  = afterMergeDF.count()
     val afterMergeDocIds = afterMergeDF.select("id").collect().map(_.getLong(0)).sorted
 

--- a/src/test/scala/io/indextables/spark/sql/DropPartitionsIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/DropPartitionsIntegrationTest.scala
@@ -28,7 +28,10 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterEach
 
 /** Integration tests for DROP INDEXTABLES PARTITIONS command. */
-class DropPartitionsIntegrationTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class DropPartitionsIntegrationTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   var spark: SparkSession = _
   var tempDir: String     = _
@@ -572,7 +575,7 @@ class DropPartitionsIntegrationTest extends AnyFunSuite with BeforeAndAfterEach 
       assert(count2 == 4, s"Expected 4 records after second insert, got $count2")
 
       // Verify both partitions exist
-      val df = spark.read.format(io.indextables.spark.TestBase.INDEXTABLES_FORMAT).load(tablePath)
+      val df               = spark.read.format(io.indextables.spark.TestBase.INDEXTABLES_FORMAT).load(tablePath)
       val partition01Count = df.filter($"partition_key" === "01").count()
       val partition02Count = df.filter($"partition_key" === "02").count()
       println(s"[AVRO] Partition counts: 01=$partition01Count, 02=$partition02Count")

--- a/src/test/scala/io/indextables/spark/sql/FfiProfilerCommandsTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/FfiProfilerCommandsTest.scala
@@ -74,13 +74,13 @@ class FfiProfilerCommandsTest extends AnyFunSuite with Matchers with BeforeAndAf
 
   test("ENABLE TANTIVY4SPARK PROFILER should work as alias") {
     val result = spark.sql("ENABLE TANTIVY4SPARK PROFILER")
-    val rows = result.collect()
+    val rows   = result.collect()
     rows(0).getString(0) shouldBe "enabled"
   }
 
   test("enable indextables profiler should be case insensitive") {
     val result = spark.sql("enable indextables profiler")
-    val rows = result.collect()
+    val rows   = result.collect()
     rows(0).getString(0) shouldBe "enabled"
   }
 
@@ -99,14 +99,14 @@ class FfiProfilerCommandsTest extends AnyFunSuite with Matchers with BeforeAndAf
   test("DISABLE TANTIVY4SPARK PROFILER should work as alias") {
     FfiProfiler.enable()
     val result = spark.sql("DISABLE TANTIVY4SPARK PROFILER")
-    val rows = result.collect()
+    val rows   = result.collect()
     rows(0).getString(0) shouldBe "disabled"
   }
 
   // ===== DESCRIBE PROFILER tests =====
 
   test("DESCRIBE INDEXTABLES PROFILER should return section schema") {
-    val result = spark.sql("DESCRIBE INDEXTABLES PROFILER")
+    val result  = spark.sql("DESCRIBE INDEXTABLES PROFILER")
     val columns = result.columns.toSeq
     columns shouldBe Seq("section", "category", "calls", "total_ms", "avg_us", "min_us", "max_us")
   }
@@ -133,7 +133,7 @@ class FfiProfilerCommandsTest extends AnyFunSuite with Matchers with BeforeAndAf
   // ===== DESCRIBE PROFILER CACHE tests =====
 
   test("DESCRIBE INDEXTABLES PROFILER CACHE should return cache schema") {
-    val result = spark.sql("DESCRIBE INDEXTABLES PROFILER CACHE")
+    val result  = spark.sql("DESCRIBE INDEXTABLES PROFILER CACHE")
     val columns = result.columns.toSeq
     columns shouldBe Seq("cache", "hits", "misses", "hit_rate")
   }
@@ -155,7 +155,7 @@ class FfiProfilerCommandsTest extends AnyFunSuite with Matchers with BeforeAndAf
   // ===== RESET PROFILER tests =====
 
   test("RESET INDEXTABLES PROFILER should return section schema") {
-    val result = spark.sql("RESET INDEXTABLES PROFILER")
+    val result  = spark.sql("RESET INDEXTABLES PROFILER")
     val columns = result.columns.toSeq
     columns shouldBe Seq("section", "category", "calls", "total_ms", "avg_us", "min_us", "max_us")
   }
@@ -170,7 +170,7 @@ class FfiProfilerCommandsTest extends AnyFunSuite with Matchers with BeforeAndAf
   }
 
   test("RESET INDEXTABLES PROFILER CACHE should return cache schema") {
-    val result = spark.sql("RESET INDEXTABLES PROFILER CACHE")
+    val result  = spark.sql("RESET INDEXTABLES PROFILER CACHE")
     val columns = result.columns.toSeq
     columns shouldBe Seq("cache", "hits", "misses", "hit_rate")
   }
@@ -206,12 +206,14 @@ class FfiProfilerCommandsTest extends AnyFunSuite with Matchers with BeforeAndAf
   test("profiler should capture non-zero section counters after index read") {
     val tempPath = Files.createTempDirectory("ffi-profiler-test").toString
     try {
-      val schema = StructType(Array(
-        StructField("id", IntegerType, nullable = false),
-        StructField("name", StringType, nullable = false)
-      ))
+      val schema = StructType(
+        Array(
+          StructField("id", IntegerType, nullable = false),
+          StructField("name", StringType, nullable = false)
+        )
+      )
       val data = Seq(Row(1, "Alice"), Row(2, "Bob"), Row(3, "Charlie"))
-      val df = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+      val df   = spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
 
       val format = "io.indextables.spark.core.IndexTables4SparkTableProvider"
       df.write.format(format).mode("overwrite").save(tempPath)
@@ -226,7 +228,7 @@ class FfiProfilerCommandsTest extends AnyFunSuite with Matchers with BeforeAndAf
 
       // Check that profiler captured something
       val result = spark.sql("DESCRIBE INDEXTABLES PROFILER")
-      val rows = result.collect()
+      val rows   = result.collect()
       rows.length should be > 0
 
       // At least one section should have non-zero calls
@@ -239,10 +241,9 @@ class FfiProfilerCommandsTest extends AnyFunSuite with Matchers with BeforeAndAf
       afterReset.length shouldBe 0
 
       spark.sql("DISABLE INDEXTABLES PROFILER")
-    } finally {
+    } finally
       try org.apache.commons.io.FileUtils.deleteDirectory(new java.io.File(tempPath))
       catch { case _: Exception => }
-    }
   }
 
   // ===== SQL passthrough test =====

--- a/src/test/scala/io/indextables/spark/sql/FlushDiskCacheCommandTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/FlushDiskCacheCommandTest.scala
@@ -35,7 +35,10 @@ import org.slf4j.LoggerFactory
  *   - Output schema validation
  *   - Integration with GlobalSplitCacheManager and DriverSplitLocalityManager
  */
-class FlushDiskCacheCommandTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class FlushDiskCacheCommandTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private val logger = LoggerFactory.getLogger(classOf[FlushDiskCacheCommandTest])
 

--- a/src/test/scala/io/indextables/spark/sql/GroupByAggQueryDebugTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/GroupByAggQueryDebugTest.scala
@@ -35,7 +35,11 @@ import org.scalatest.BeforeAndAfterAll
  * (string), owner (int), subscriptionFilter (array[string]), message_date (date - partition-key), message_hour
  * (string), asv (string)
  */
-class GroupByAggQueryDebugTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class GroupByAggQueryDebugTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private var spark: SparkSession = _
   private var tempDir: File       = _

--- a/src/test/scala/io/indextables/spark/sql/InvalidateTransactionLogCacheCommandTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/InvalidateTransactionLogCacheCommandTest.scala
@@ -206,8 +206,8 @@ class InvalidateTransactionLogCacheCommandTest extends TestBase {
   }
 
   /**
-   * Regression test: global invalidation must clear the native txlog cache, not only the
-   * JVM-level EnhancedTransactionLogCache. Before the fix, the global case only called
+   * Regression test: global invalidation must clear the native txlog cache, not only the JVM-level
+   * EnhancedTransactionLogCache. Before the fix, the global case only called
    * EnhancedTransactionLogCache.clearGlobalCaches() and never touched the native Rust cache.
    */
   test("global invalidation clears native txlog cache and subsequent reads still succeed") {
@@ -250,9 +250,7 @@ class InvalidateTransactionLogCacheCommandTest extends TestBase {
     }
   }
 
-  /**
-   * Verify that two distinct tables both have their native caches cleared by a global invalidation.
-   */
+  /** Verify that two distinct tables both have their native caches cleared by a global invalidation. */
   test("global invalidation clears native cache for all tables, not just one") {
     withTempPath { tempDir1 =>
       withTempPath { tempDir2 =>
@@ -261,10 +259,16 @@ class InvalidateTransactionLogCacheCommandTest extends TestBase {
         def addAndWarm(path: String): io.indextables.spark.transaction.TransactionLogInterface = {
           val tl = TransactionLogFactory.create(new Path(path), spark)
           tl.initialize(schema)
-          tl.addFile(io.indextables.spark.transaction.AddAction(
-            path = "f.split", partitionValues = Map.empty, size = 10L,
-            modificationTime = System.currentTimeMillis(), dataChange = true, numRecords = Some(1L)
-          ))
+          tl.addFile(
+            io.indextables.spark.transaction.AddAction(
+              path = "f.split",
+              partitionValues = Map.empty,
+              size = 10L,
+              modificationTime = System.currentTimeMillis(),
+              dataChange = true,
+              numRecords = Some(1L)
+            )
+          )
           tl.listFiles() // warm cache
           tl
         }

--- a/src/test/scala/io/indextables/spark/sql/MergeSplitsBatchTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/MergeSplitsBatchTest.scala
@@ -36,7 +36,7 @@ class MergeSplitsBatchTest extends TestBase with BeforeAndAfterEach {
 
   private val logger = LoggerFactory.getLogger(classOf[MergeSplitsBatchTest])
 
-  var tempTablePath: String          = _
+  var tempTablePath: String                   = _
   var transactionLog: TransactionLogInterface = _
 
   override def beforeEach(): Unit = {

--- a/src/test/scala/io/indextables/spark/sql/MergeSplitsNumRecordsTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/MergeSplitsNumRecordsTest.scala
@@ -33,7 +33,11 @@ import org.scalatest.BeforeAndAfterEach
  * Integration test to validate that merge operations correctly populate the numRecords field in transaction log
  * AddAction from tantivy4java metadata
  */
-class MergeSplitsNumRecordsTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class MergeSplitsNumRecordsTest
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   var spark: SparkSession = _
   var tempDir: File       = _
@@ -206,7 +210,7 @@ class MergeSplitsNumRecordsTest extends AnyFlatSpec with Matchers with BeforeAnd
     println(s"✅ Created ${addActionsBeforeMerge.length} separate files ready for merging")
 
     // Verify data integrity
-    val dataCheck = spark.read.format(io.indextables.spark.TestBase.INDEXTABLES_FORMAT).load(tablePath)
+    val dataCheck         = spark.read.format(io.indextables.spark.TestBase.INDEXTABLES_FORMAT).load(tablePath)
     val actualRecordCount = dataCheck.count()
 
     println(s"Actual record count: $actualRecordCount")

--- a/src/test/scala/io/indextables/spark/sql/MergeSplitsPartitionTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/MergeSplitsPartitionTest.scala
@@ -37,7 +37,7 @@ class MergeSplitsPartitionTest extends TestBase with BeforeAndAfterEach {
 
   private val logger = LoggerFactory.getLogger(classOf[MergeSplitsPartitionTest])
 
-  var tempTablePath: String          = _
+  var tempTablePath: String                   = _
   var transactionLog: TransactionLogInterface = _
 
   override def beforeEach(): Unit = {

--- a/src/test/scala/io/indextables/spark/sql/MergeSplitsSkippedFilesTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/MergeSplitsSkippedFilesTest.scala
@@ -84,7 +84,7 @@ class MergeSplitsSkippedFilesTest extends TestBase with Matchers {
       beforeMergeActions.foreach(action => println(s"  - ${action.path} (${action.size} bytes)"))
 
       // Step 3: Verify we can read all data before merge
-      val beforeMergeDF = spark.read.format(INDEXTABLES_FORMAT).load(outputPath)
+      val beforeMergeDF      = spark.read.format(INDEXTABLES_FORMAT).load(outputPath)
       val beforeMergeRecords = beforeMergeDF.count()
       beforeMergeRecords shouldBe 150
 
@@ -103,7 +103,7 @@ class MergeSplitsSkippedFilesTest extends TestBase with Matchers {
         afterMergeActions.foreach(action => println(s"  - ${action.path} (${action.size} bytes)"))
 
         // Step 6: Verify data integrity
-        val afterMergeDF = spark.read.format(INDEXTABLES_FORMAT).load(outputPath)
+        val afterMergeDF      = spark.read.format(INDEXTABLES_FORMAT).load(outputPath)
         val afterMergeRecords = afterMergeDF.count()
 
         println(s"Data integrity check: $beforeMergeRecords -> $afterMergeRecords records")

--- a/src/test/scala/io/indextables/spark/sql/MergeSplitsTempDirectoryTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/MergeSplitsTempDirectoryTest.scala
@@ -37,8 +37,8 @@ class MergeSplitsTempDirectoryTest extends TestBase with BeforeAndAfterEach {
 
   private val logger = LoggerFactory.getLogger(classOf[MergeSplitsTempDirectoryTest])
 
-  var tempTablePath: String          = _
-  var customTempDir: String          = _
+  var tempTablePath: String                   = _
+  var customTempDir: String                   = _
   var transactionLog: TransactionLogInterface = _
 
   override def beforeEach(): Unit = {

--- a/src/test/scala/io/indextables/spark/sql/MergeSplitsValidationTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/MergeSplitsValidationTest.scala
@@ -40,7 +40,7 @@ class MergeSplitsValidationTest extends TestBase with BeforeAndAfterEach {
 
   private val logger = LoggerFactory.getLogger(classOf[MergeSplitsValidationTest])
 
-  var tempTablePath: String          = _
+  var tempTablePath: String                   = _
   var transactionLog: TransactionLogInterface = _
 
   /**
@@ -233,8 +233,8 @@ class MergeSplitsValidationTest extends TestBase with BeforeAndAfterEach {
     validateMergedFilesCanBeRead()
 
     // Validate that data is still readable and complete
-    val mergedData  = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
-    val actualCount = mergedData.count()
+    val mergedData    = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
+    val actualCount   = mergedData.count()
     val expectedCount = 300L // 3 writes * 100 records each
     assert(actualCount == expectedCount, s"Should preserve all data: expected $expectedCount, got $actualCount")
 
@@ -294,8 +294,8 @@ class MergeSplitsValidationTest extends TestBase with BeforeAndAfterEach {
     )
 
     // Validate data integrity
-    val mergedData  = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
-    val actualCount = mergedData.count()
+    val mergedData    = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
+    val actualCount   = mergedData.count()
     val expectedCount = 300L // 2 writes * 150 records each
     assert(actualCount == expectedCount, s"Should preserve all data: expected $expectedCount, got $actualCount")
 
@@ -341,8 +341,8 @@ class MergeSplitsValidationTest extends TestBase with BeforeAndAfterEach {
     validateAllFilesExist()
 
     // Validate data integrity
-    val mergedData  = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
-    val actualCount = mergedData.count()
+    val mergedData    = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
+    val actualCount   = mergedData.count()
     val expectedCount = 320L // 4 writes * 80 records each
     assert(actualCount == expectedCount, s"Should preserve all data: expected $expectedCount, got $actualCount")
 
@@ -401,8 +401,8 @@ class MergeSplitsValidationTest extends TestBase with BeforeAndAfterEach {
     validateAllFilesExist()
 
     // Validate that data is still readable and complete
-    val mergedData  = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
-    val actualCount = mergedData.count()
+    val mergedData    = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
+    val actualCount   = mergedData.count()
     val expectedCount = 320L // 8 writes * 40 records each
     assert(actualCount == expectedCount, s"Should preserve all data: expected $expectedCount, got $actualCount")
 
@@ -487,8 +487,8 @@ class MergeSplitsValidationTest extends TestBase with BeforeAndAfterEach {
     validateAllFilesExist()
 
     // Validate that all data is preserved despite the grouping limit
-    val mergedData  = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
-    val actualCount = mergedData.count()
+    val mergedData    = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
+    val actualCount   = mergedData.count()
     val expectedCount = 360L // 12 writes * 30 records each
     assert(actualCount == expectedCount, s"Should preserve all data: expected $expectedCount, got $actualCount")
 
@@ -592,8 +592,8 @@ class MergeSplitsValidationTest extends TestBase with BeforeAndAfterEach {
     }
 
     // Validate that data is still readable and complete
-    val mergedData  = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
-    val actualCount = mergedData.count()
+    val mergedData    = spark.read.format(INDEXTABLES_FORMAT).load(tempTablePath)
+    val actualCount   = mergedData.count()
     val expectedCount = 300L // 3 writes * 100 records each
     assert(actualCount == expectedCount, s"Should preserve all data: expected $expectedCount, got $actualCount")
 

--- a/src/test/scala/io/indextables/spark/sql/PartitionedDatasetTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/PartitionedDatasetTest.scala
@@ -21,13 +21,13 @@ import java.io.File
 import java.nio.file.{Files, Paths}
 import java.sql.Timestamp
 import java.time.{LocalDate, LocalDateTime}
+import java.util.zip.GZIPInputStream
 
 import scala.util.Random
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions._
 
-import java.util.zip.GZIPInputStream
 import io.indextables.spark.TestBase
 import org.apache.commons.io.FileUtils
 
@@ -197,7 +197,7 @@ class PartitionedDatasetTest extends TestBase {
     }
 
     // Verify data integrity after merge
-    val df = spark.read.format(INDEXTABLES_FORMAT).load(testDataPath)
+    val df                = spark.read.format(INDEXTABLES_FORMAT).load(testDataPath)
     val totalRecordsAfter = df.count()
     assert(totalRecordsAfter == 2400, "Should preserve all records after partition merge")
 
@@ -206,7 +206,6 @@ class PartitionedDatasetTest extends TestBase {
     println(s"Accessible partitions after merge: $distinctPartitions")
     assert(distinctPartitions > 0, "Should still have accessible partitions after merge")
   }
-
 
   test("Complex partitioned queries with IndexQuery operations") {
     // Generate test data with varied content
@@ -427,12 +426,14 @@ class PartitionedDatasetTest extends TestBase {
     val hasPartitionInfo = logFiles.exists { file =>
       val rawBytes = Files.readAllBytes(file.toPath)
       // Decompress if needed (handles both compressed and uncompressed files)
-      val decompressedBytes = try {
-        val gzis = new GZIPInputStream(new java.io.ByteArrayInputStream(rawBytes))
-        try gzis.readAllBytes() finally gzis.close()
-      } catch {
-        case _: java.util.zip.ZipException => rawBytes // Not compressed
-      }
+      val decompressedBytes =
+        try {
+          val gzis = new GZIPInputStream(new java.io.ByteArrayInputStream(rawBytes))
+          try gzis.readAllBytes()
+          finally gzis.close()
+        } catch {
+          case _: java.util.zip.ZipException => rawBytes // Not compressed
+        }
       val content = new String(decompressedBytes, "UTF-8")
       content.contains("partitionBy") || content.contains("load_date") || content.contains("load_hour")
     }

--- a/src/test/scala/io/indextables/spark/sql/PartitionedMergeTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/PartitionedMergeTest.scala
@@ -30,17 +30,14 @@ import io.indextables.spark.TestBase
 import org.apache.commons.io.FileUtils
 
 /**
- * Standalone reproducer for the regression introduced in tantivy4java 0.34.1:
- * RemoveAction tombstones written via writeVersionArrowFfi are not being applied
- * when reading back the Avro-format transaction log. After a MERGE SPLITS operation
- * (which adds new merged splits and removes old splits), the file listing returns
- * both the old and new splits, causing duplicate records.
+ * Standalone reproducer for the regression introduced in tantivy4java 0.34.1: RemoveAction tombstones written via
+ * writeVersionArrowFfi are not being applied when reading back the Avro-format transaction log. After a MERGE SPLITS
+ * operation (which adds new merged splits and removes old splits), the file listing returns both the old and new
+ * splits, causing duplicate records.
  *
- * Expected: 1800 records after global merge
- * Actual:   ~5788 records (original splits + merged splits both visible)
+ * Expected: 1800 records after global merge Actual: ~5788 records (original splits + merged splits both visible)
  *
- * Run with:
- *   mvn test-compile scalatest:test -DwildcardSuites='io.indextables.spark.sql.PartitionedMergeTest'
+ * Run with: mvn test-compile scalatest:test -DwildcardSuites='io.indextables.spark.sql.PartitionedMergeTest'
  */
 class PartitionedMergeTest extends TestBase {
 
@@ -58,19 +55,18 @@ class PartitionedMergeTest extends TestBase {
 
   override def afterEach(): Unit = {
     super.afterEach()
-    try {
+    try
       if (testDataPath != null) FileUtils.deleteDirectory(new File(testDataPath))
-    } catch {
+    catch {
       case _: Exception =>
     }
   }
 
-  override def afterAll(): Unit = {
+  override def afterAll(): Unit =
     super.afterAll()
-  }
 
   test("Merge splits across all partitions without WHERE clause") {
-    val timeSeriesData = generateTimeSeriesData(spark, totalRecords = 1800, daysSpan = 3)
+    val timeSeriesData    = generateTimeSeriesData(spark, totalRecords = 1800, daysSpan = 3)
     val repartitionedData = timeSeriesData.repartition(30)
 
     repartitionedData.write
@@ -96,7 +92,7 @@ class PartitionedMergeTest extends TestBase {
       assert(filesAfterGlobalMerge <= filesBefore, "Should have same or fewer files after global merge")
     }
 
-    val df = spark.read.format(INDEXTABLES_FORMAT).load(testDataPath)
+    val df                = spark.read.format(INDEXTABLES_FORMAT).load(testDataPath)
     val totalRecordsAfter = df.count()
     assert(totalRecordsAfter == 1800, "Should preserve all records after global merge")
 

--- a/src/test/scala/io/indextables/spark/sql/PrewarmCacheCommandTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/PrewarmCacheCommandTest.scala
@@ -33,7 +33,10 @@ import org.slf4j.LoggerFactory
  *
  * Tests field validation (fail-fast vs warn-skip), segment selection, and output validation.
  */
-class PrewarmCacheCommandTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class PrewarmCacheCommandTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private val logger = LoggerFactory.getLogger(classOf[PrewarmCacheCommandTest])
 

--- a/src/test/scala/io/indextables/spark/sql/PrewarmLocalityVerificationTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/PrewarmLocalityVerificationTest.scala
@@ -26,7 +26,10 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterEach
 
 /** Tests to verify that prewarm command tracks and reports locality correctly. */
-class PrewarmLocalityVerificationTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class PrewarmLocalityVerificationTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   var spark: SparkSession   = _
   var tempTablePath: String = _

--- a/src/test/scala/io/indextables/spark/sql/PurgeIndexTableErrorHandlingTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/PurgeIndexTableErrorHandlingTest.scala
@@ -29,7 +29,10 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterEach
 
 /** Error handling and edge case tests for PURGE INDEXTABLE command. */
-class PurgeIndexTableErrorHandlingTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class PurgeIndexTableErrorHandlingTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   var spark: SparkSession = _
   var tempDir: String     = _

--- a/src/test/scala/io/indextables/spark/sql/PurgeIndexTableIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/PurgeIndexTableIntegrationTest.scala
@@ -29,7 +29,10 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.BeforeAndAfterEach
 
 /** Integration tests for PURGE INDEXTABLE command. Tests actual file operations with orphaned splits. */
-class PurgeIndexTableIntegrationTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class PurgeIndexTableIntegrationTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   var spark: SparkSession = _
   var tempDir: String     = _
@@ -605,9 +608,9 @@ class PurgeIndexTableIntegrationTest extends AnyFunSuite with BeforeAndAfterEach
     println(s"After second batch - all checkpoint files: ${allCheckpointFiles.mkString(", ")}")
 
     // Find part files - pattern: checkpoint.<uuid>.<partnum>.json
-    val partFilePattern   = """(\d+)\.checkpoint\.([a-f0-9]+)\.\d{5}\.json""".r
-    val manifestPattern   = """(\d+)\.checkpoint\.json""".r
-    val avroStateDirPat   = """state-v(\d{20})""".r
+    val partFilePattern = """(\d+)\.checkpoint\.([a-f0-9]+)\.\d{5}\.json""".r
+    val manifestPattern = """(\d+)\.checkpoint\.json""".r
+    val avroStateDirPat = """state-v(\d{20})""".r
 
     val partFilesByVersion = allCheckpointFiles
       .flatMap(f => partFilePattern.findFirstMatchIn(f).map(m => (m.group(1).toLong, f)))

--- a/src/test/scala/io/indextables/spark/sql/PurgeIndexTableTransactionLogCleanupTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/PurgeIndexTableTransactionLogCleanupTest.scala
@@ -91,8 +91,8 @@ class PurgeIndexTableTransactionLogCleanupTest extends AnyFunSuite with BeforeAn
     val txLogPath = new Path(s"$tablePath/_transaction_log")
 
     // Verify we have transaction log files and a checkpoint
-    val txLogEntries = fs.listStatus(txLogPath)
-    val filesBeforeCleanup = txLogEntries.map(_.getPath.getName).toSet
+    val txLogEntries        = fs.listStatus(txLogPath)
+    val filesBeforeCleanup  = txLogEntries.map(_.getPath.getName).toSet
     val avroStateDirPattern = """^state-v\d{20}$""".r
     val hasCheckpoint = filesBeforeCleanup.exists(_.contains(".checkpoint.json")) ||
       txLogEntries.exists(s => s.isDirectory && avroStateDirPattern.findFirstIn(s.getPath.getName).isDefined)
@@ -375,8 +375,8 @@ class PurgeIndexTableTransactionLogCleanupTest extends AnyFunSuite with BeforeAn
 
     // Also verify we have a checkpoint at version 12
     val txLogEntriesBefore = fs.listStatus(txLogPath)
-    val filesBeforePurge = txLogEntriesBefore.map(_.getPath.getName).toSet
-    val avroStateDirPat = """^state-v\d{20}$""".r
+    val filesBeforePurge   = txLogEntriesBefore.map(_.getPath.getName).toSet
+    val avroStateDirPat    = """^state-v\d{20}$""".r
     val hasCheckpointBefore = filesBeforePurge.exists(_.contains(".checkpoint.json")) ||
       txLogEntriesBefore.exists(s => s.isDirectory && avroStateDirPat.findFirstIn(s.getPath.getName).isDefined)
     assert(hasCheckpointBefore, "Should have checkpoint file or Avro state directory")
@@ -401,7 +401,7 @@ class PurgeIndexTableTransactionLogCleanupTest extends AnyFunSuite with BeforeAn
     val filesAfterPurgeList = fs.listStatus(txLogPath).map(_.getPath.getName).sorted
     println(s"Transaction log files after purge: ${filesAfterPurgeList.mkString(", ")}")
 
-    val filesAfterPurge = filesAfterPurgeList.toSet
+    val filesAfterPurge        = filesAfterPurgeList.toSet
     val txLogEntriesAfterPurge = fs.listStatus(txLogPath)
     val hasCheckpointAfterPurge = filesAfterPurge.exists(_.contains(".checkpoint.json")) ||
       txLogEntriesAfterPurge.exists(s => s.isDirectory && avroStateDirPat.findFirstIn(s.getPath.getName).isDefined)

--- a/src/test/scala/io/indextables/spark/sql/PurgeRaceConditionBugReproductionTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/PurgeRaceConditionBugReproductionTest.scala
@@ -45,7 +45,10 @@ import org.scalatest.BeforeAndAfterEach
  *   - With current BUGGY code: Tests should FAIL
  *   - After fix is applied: Tests should PASS
  */
-class PurgeRaceConditionBugReproductionTest extends AnyFunSuite with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class PurgeRaceConditionBugReproductionTest
+    extends AnyFunSuite
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   var spark: SparkSession = _
   var fs: FileSystem      = _

--- a/src/test/scala/io/indextables/spark/sql/RepairIndexFilesTransactionLogReplacementSuite.scala
+++ b/src/test/scala/io/indextables/spark/sql/RepairIndexFilesTransactionLogReplacementSuite.scala
@@ -61,7 +61,7 @@ class RepairIndexFilesTransactionLogReplacementSuite extends TestBase {
         .save(tablePath)
 
       // 2. Read original table and collect results
-      val originalDf = spark.read.format(INDEXTABLES_FORMAT).load(tablePath)
+      val originalDf      = spark.read.format(INDEXTABLES_FORMAT).load(tablePath)
       val originalResults = originalDf.orderBy("id").collect()
       val originalCount   = originalDf.count()
 
@@ -91,7 +91,7 @@ class RepairIndexFilesTransactionLogReplacementSuite extends TestBase {
       fs.rename(repairedLogPath, originalLogPath)
 
       // 6. Read table with repaired transaction log
-      val repairedDf = spark.read.format(INDEXTABLES_FORMAT).load(tablePath)
+      val repairedDf      = spark.read.format(INDEXTABLES_FORMAT).load(tablePath)
       val repairedResults = repairedDf.orderBy("id").collect()
       val repairedCount   = repairedDf.count()
 
@@ -263,8 +263,8 @@ class RepairIndexFilesTransactionLogReplacementSuite extends TestBase {
       fs.rename(repairedLogPath, originalLogPath)
 
       // 9. Read table with consolidated transaction log
-      val repairedDf    = spark.read.format(INDEXTABLES_FORMAT).load(tablePath)
-      val repairedCount = repairedDf.count()
+      val repairedDf      = spark.read.format(INDEXTABLES_FORMAT).load(tablePath)
+      val repairedCount   = repairedDf.count()
       val repairedResults = repairedDf.orderBy("id").collect()
 
       // 10. Validate identical results

--- a/src/test/scala/io/indextables/spark/sql/StreamingCompanionEndToEndTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/StreamingCompanionEndToEndTest.scala
@@ -34,7 +34,11 @@ import org.scalatest.BeforeAndAfterAll
  *      in the next cycle. 3. A no-changes poll leaves the companion unmodified. 4. A second new commit is picked up by
  *      a subsequent cycle. 5. A restart resumes from the last synced version without re-indexing existing data.
  */
-class StreamingCompanionEndToEndTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class StreamingCompanionEndToEndTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sql/StreamingCompanionErrorRecoveryTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/StreamingCompanionErrorRecoveryTest.scala
@@ -32,13 +32,11 @@ import io.indextables.spark.TestBase
  * Uses a controllable syncFn lambda to simulate failures without requiring actual Delta/Iceberg tables. The parquet
  * source format is used so cheapSourceVersion always returns None, ensuring syncFn is called every cycle.
  */
-class StreamingCompanionErrorRecoveryTest
-    extends TestBase
-    with io.indextables.spark.testutils.FileCleanupHelper {
+class StreamingCompanionErrorRecoveryTest extends TestBase with io.indextables.spark.testutils.FileCleanupHelper {
 
   override protected def deleteRecursively(file: File): Unit = super[FileCleanupHelper].deleteRecursively(file)
 
-  private val tempDirs = new java.util.concurrent.CopyOnWriteArrayList[File]()
+  private val tempDirs                 = new java.util.concurrent.CopyOnWriteArrayList[File]()
   private var sharedSourcePath: String = _
 
   private def makeTempDir(prefix: String): String = {
@@ -94,7 +92,11 @@ class StreamingCompanionErrorRecoveryTest
       val destPath  = makeTempDir("streaming-dest")
       val callCount = new AtomicInteger(0)
 
-      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (_, _, _) => {
+      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (
+        _,
+        _,
+        _
+      ) => {
         callCount.incrementAndGet()
         throw new RuntimeException("simulated failure")
       }
@@ -117,7 +119,11 @@ class StreamingCompanionErrorRecoveryTest
       val destPath  = makeTempDir("streaming-dest2")
       val callCount = new AtomicInteger(0)
 
-      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (_, _, _) => {
+      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (
+        _,
+        _,
+        _
+      ) => {
         callCount.incrementAndGet()
         throw new RuntimeException("simulated failure")
       }
@@ -147,7 +153,11 @@ class StreamingCompanionErrorRecoveryTest
       // Pattern: fail, fail, succeed, fail, fail, succeed, fail, fail, succeed...
       // If error counter wasn't reset, the 3rd failure would abort.
       // Since it IS reset by successes, the stream continues past 6+ calls.
-      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (_, _, _) => {
+      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (
+        _,
+        _,
+        _
+      ) => {
         val n = callCount.incrementAndGet()
         if (n % 3 == 0) {
           Seq.empty // every 3rd call succeeds, resetting consecutive errors
@@ -191,7 +201,11 @@ class StreamingCompanionErrorRecoveryTest
       val destPath   = makeTempDir("streaming-backoff")
       val timestamps = new java.util.concurrent.CopyOnWriteArrayList[Long]()
 
-      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (_, _, _) => {
+      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (
+        _,
+        _,
+        _
+      ) => {
         timestamps.add(System.currentTimeMillis())
         throw new RuntimeException("simulated failure")
       }
@@ -205,7 +219,7 @@ class StreamingCompanionErrorRecoveryTest
       // 4 calls, 3 intervals between them
       timestamps.size() shouldBe 4
 
-      val ts = (0 until timestamps.size()).map(timestamps.get)
+      val ts        = (0 until timestamps.size()).map(timestamps.get)
       val intervals = ts.sliding(2).map { case Seq(a, b) => b - a }.toSeq
 
       // With multiplier=2 and pollInterval=500ms:
@@ -235,7 +249,11 @@ class StreamingCompanionErrorRecoveryTest
       val destPath  = makeTempDir("streaming-exact-count")
       val callCount = new AtomicInteger(0)
 
-      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (_, _, _) => {
+      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (
+        _,
+        _,
+        _
+      ) => {
         callCount.incrementAndGet()
         throw new RuntimeException("simulated failure")
       }
@@ -255,7 +273,11 @@ class StreamingCompanionErrorRecoveryTest
     val destPath  = makeTempDir("streaming-success")
     val callCount = new AtomicInteger(0)
 
-    val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (_, _, _) => {
+    val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (
+      _,
+      _,
+      _
+    ) => {
       callCount.incrementAndGet()
       Seq.empty
     }
@@ -281,10 +303,14 @@ class StreamingCompanionErrorRecoveryTest
   test("interrupt during backoff sleep should exit cleanly") {
     spark.conf.set("spark.indextables.companion.stream.maxConsecutiveErrors", "100")
     try {
-      val destPath = makeTempDir("streaming-interrupt")
+      val destPath      = makeTempDir("streaming-interrupt")
       val firstCallDone = new AtomicBoolean(false)
 
-      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (_, _, _) => {
+      val syncFn: (SparkSession, Long, Option[Long]) => Seq[Row] = (
+        _,
+        _,
+        _
+      ) => {
         firstCallDone.set(true)
         throw new RuntimeException("simulated failure")
       }

--- a/src/test/scala/io/indextables/spark/sql/StreamingCompanionIcebergEndToEndTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/StreamingCompanionIcebergEndToEndTest.scala
@@ -48,7 +48,11 @@ import org.scalatest.BeforeAndAfterAll
  * unmodified.</li> <li>A second new snapshot is picked up by a subsequent cycle.</li> <li>A restart resumes from the
  * last synced snapshot without re-indexing existing data.</li> </ol>
  */
-class StreamingCompanionIcebergEndToEndTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class StreamingCompanionIcebergEndToEndTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sql/TableRootCommandsTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/TableRootCommandsTest.scala
@@ -41,7 +41,11 @@ import org.scalatest.BeforeAndAfterAll
  *   - BUILD COMPANION with TABLE ROOTS clause
  *   - Read-time designator root selection
  */
-class TableRootCommandsTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class TableRootCommandsTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private var spark: SparkSession = _
   private var tempDir: File       = _

--- a/src/test/scala/io/indextables/spark/sql/TruncateTimeTravelTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/TruncateTimeTravelTest.scala
@@ -95,11 +95,11 @@ class TruncateTimeTravelTest extends TestBase {
     val checkpointPattern = """^\d{20}\.checkpoint.*\.json$""".r
     val avroStatePattern  = """^state-v\d{20}$""".r
 
-    val versionCount    = files.count(f => versionPattern.findFirstIn(f.getName).isDefined)
+    val versionCount = files.count(f => versionPattern.findFirstIn(f.getName).isDefined)
     // Count both legacy JSON checkpoints and native Avro state directories
     val checkpointCount = files.count(f =>
       checkpointPattern.findFirstIn(f.getName).isDefined ||
-      (f.isDirectory && avroStatePattern.findFirstIn(f.getName).isDefined)
+        (f.isDirectory && avroStatePattern.findFirstIn(f.getName).isDefined)
     )
 
     (versionCount, checkpointCount)

--- a/src/test/scala/io/indextables/spark/sql/ZeroRecordsFilterTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/ZeroRecordsFilterTest.scala
@@ -28,7 +28,11 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterEach
 
 /** Test to validate that files with zero records are not inserted into the transaction log */
-class ZeroRecordsFilterTest extends AnyFlatSpec with Matchers with BeforeAndAfterEach with io.indextables.spark.testutils.FileCleanupHelper {
+class ZeroRecordsFilterTest
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterEach
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   var spark: SparkSession = _
   var tempDir: File       = _

--- a/src/test/scala/io/indextables/spark/sync/CompanionAggregatePushdownCorrectnessTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionAggregatePushdownCorrectnessTest.scala
@@ -28,7 +28,6 @@ import org.apache.iceberg.{DataFiles, FileFormat}
 import org.apache.iceberg.{Schema => IcebergSchema}
 import org.apache.iceberg.catalog.{Namespace, TableIdentifier}
 import org.apache.iceberg.types.Types
-
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
@@ -37,7 +36,8 @@ import org.scalatest.BeforeAndAfterAll
  * Tests for aggregate pushdown correctness on companion tables built from Delta and Iceberg sources.
  *
  * Unlike CompanionAggregateGuardTest (which tests the guard mechanism), this suite verifies that actual computed values
- * (COUNT, SUM, AVG, MIN, MAX) are correct when aggregate pushdown succeeds on companion tables with fast fields enabled.
+ * (COUNT, SUM, AVG, MIN, MAX) are correct when aggregate pushdown succeeds on companion tables with fast fields
+ * enabled.
  *
  * Uses a deterministic 20-row dataset with pre-calculated expected values for all aggregations.
  */
@@ -258,9 +258,9 @@ class CompanionAggregatePushdownCorrectnessTest
 
       f(companionDf)
     } finally {
-      try { spark.conf.unset("spark.indextables.iceberg.catalogType") }
+      try spark.conf.unset("spark.indextables.iceberg.catalogType")
       catch { case _: Exception => }
-      try { spark.conf.unset("spark.indextables.iceberg.uri") }
+      try spark.conf.unset("spark.indextables.iceberg.uri")
       catch { case _: Exception => }
       server.close()
       deleteRecursively(root)
@@ -369,7 +369,7 @@ class CompanionAggregatePushdownCorrectnessTest
       grouped.length shouldBe 3
 
       for (row <- grouped) {
-        val dept                                = row.getString(0)
+        val dept                                     = row.getString(0)
         val (expCnt, expSum, expAvg, expMin, expMax) = DeptExpected(dept)
 
         withClue(s"department=$dept: ") {
@@ -388,9 +388,7 @@ class CompanionAggregatePushdownCorrectnessTest
   // ═══════════════════════════════════════════════════════════════════════════
 
   test("COUNT(*) on Iceberg companion returns exact row count") {
-    withIcebergCompanion { df =>
-      df.count() shouldBe TotalRows
-    }
+    withIcebergCompanion(df => df.count() shouldBe TotalRows)
   }
 
   test("SUM and AVG on Iceberg companion return correct values") {
@@ -424,7 +422,7 @@ class CompanionAggregatePushdownCorrectnessTest
       grouped.length shouldBe 3
 
       for (row <- grouped) {
-        val dept                                = row.getString(0)
+        val dept                                     = row.getString(0)
         val (expCnt, expSum, expAvg, expMin, expMax) = DeptExpected(dept)
 
         withClue(s"department=$dept: ") {

--- a/src/test/scala/io/indextables/spark/sync/CompanionBucketAggregationTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionBucketAggregationTest.scala
@@ -28,7 +28,6 @@ import org.apache.iceberg.{DataFiles, FileFormat}
 import org.apache.iceberg.{Schema => IcebergSchema}
 import org.apache.iceberg.catalog.{Namespace, TableIdentifier}
 import org.apache.iceberg.types.Types
-
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
@@ -240,9 +239,9 @@ class CompanionBucketAggregationTest
 
       f(companionDf)
     } finally {
-      try { spark.conf.unset("spark.indextables.iceberg.catalogType") }
+      try spark.conf.unset("spark.indextables.iceberg.catalogType")
       catch { case _: Exception => }
-      try { spark.conf.unset("spark.indextables.iceberg.uri") }
+      try spark.conf.unset("spark.indextables.iceberg.uri")
       catch { case _: Exception => }
       server.close()
       deleteRecursively(root)
@@ -306,7 +305,7 @@ class CompanionBucketAggregationTest
       rows.length should be >= 2
 
       val counts = rows.map(_.getAs[Long]("cnt"))
-      counts.sum shouldBe 8L // all 8 rows accounted for
+      counts.sum shouldBe 8L           // all 8 rows accounted for
       counts.foreach(_ should be > 0L) // no empty buckets
     }
   }
@@ -453,7 +452,7 @@ class CompanionBucketAggregationTest
       rows.length should be >= 2
 
       val counts = rows.map(_.getAs[Long]("cnt"))
-      counts.sum shouldBe 8L // all 8 rows accounted for
+      counts.sum shouldBe 8L           // all 8 rows accounted for
       counts.foreach(_ should be > 0L) // no empty buckets
     }
   }

--- a/src/test/scala/io/indextables/spark/sync/CompanionColumnarReadTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionColumnarReadTest.scala
@@ -41,7 +41,11 @@ import org.scalatest.BeforeAndAfterAll
  *   - Schema projection (subset of columns)
  *   - Row vs columnar equivalence
  */
-class CompanionColumnarReadTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class CompanionColumnarReadTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/CompanionCompactStringTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionCompactStringTest.scala
@@ -39,7 +39,11 @@ import org.scalatest.BeforeAndAfterAll
  *
  * No cloud credentials needed — runs entirely on local filesystem.
  */
-class CompanionCompactStringTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class CompanionCompactStringTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 
@@ -1214,9 +1218,8 @@ class CompanionCompactStringTest extends AnyFunSuite with Matchers with BeforeAn
             s"AT LOCATION '$indexPath'"
         )
         result.collect()(0).getString(2) shouldBe "success"
-      } finally {
+      } finally
         spark.conf.unset("spark.indextables.companion.maxAutomaticHashedFastfields")
-      }
     }
   }
 

--- a/src/test/scala/io/indextables/spark/sync/CompanionDistributedArrowFfiTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionDistributedArrowFfiTest.scala
@@ -28,7 +28,6 @@ import org.apache.iceberg.{DataFiles, FileFormat}
 import org.apache.iceberg.{Schema => IcebergSchema}
 import org.apache.iceberg.catalog.{Namespace, TableIdentifier}
 import org.apache.iceberg.types.Types
-
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
@@ -200,17 +199,21 @@ class CompanionDistributedArrowFfiTest
       val distPath    = new File(root, "index-dist").getAbsolutePath
       val nonDistPath = new File(root, "index-nondist").getAbsolutePath
 
-      val distResult = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR ICEBERG 'default.test' AT LOCATION '$distPath'"
-      ).collect()
+      val distResult = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR ICEBERG 'default.test' AT LOCATION '$distPath'"
+        )
+        .collect()
 
       flushCaches()
 
       spark.conf.set("spark.indextables.companion.sync.distributedLogRead.enabled", "false")
       try {
-        val nonDistResult = spark.sql(
-          s"BUILD INDEXTABLES COMPANION FOR ICEBERG 'default.test' AT LOCATION '$nonDistPath'"
-        ).collect()
+        val nonDistResult = spark
+          .sql(
+            s"BUILD INDEXTABLES COMPANION FOR ICEBERG 'default.test' AT LOCATION '$nonDistPath'"
+          )
+          .collect()
 
         distResult(0).getString(2) shouldBe "success"
         nonDistResult(0).getString(2) shouldBe "success"
@@ -238,9 +241,11 @@ class CompanionDistributedArrowFfiTest
       val indexPath = new File(tempDir, "index").getAbsolutePath
 
       createDeltaSource(deltaPath)
-      val buildResult = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' FASTFIELDS MODE HYBRID AT LOCATION '$indexPath'"
-      ).collect()
+      val buildResult = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' FASTFIELDS MODE HYBRID AT LOCATION '$indexPath'"
+        )
+        .collect()
       buildResult(0).getString(2) shouldBe "success"
 
       flushCaches()
@@ -277,9 +282,11 @@ class CompanionDistributedArrowFfiTest
     withIcebergSource("ffi_test") { (_, root) =>
       val indexPath = new File(root, "index").getAbsolutePath
 
-      val buildResult = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR ICEBERG 'default.ffi_test' FASTFIELDS MODE HYBRID AT LOCATION '$indexPath'"
-      ).collect()
+      val buildResult = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR ICEBERG 'default.ffi_test' FASTFIELDS MODE HYBRID AT LOCATION '$indexPath'"
+        )
+        .collect()
       buildResult(0).getString(2) shouldBe "success"
 
       flushCaches()

--- a/src/test/scala/io/indextables/spark/sync/CompanionDropPartitionsTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionDropPartitionsTest.scala
@@ -27,7 +27,6 @@ import org.apache.iceberg.{DataFiles, FileFormat}
 import org.apache.iceberg.{Schema => IcebergSchema}
 import org.apache.iceberg.catalog.{Namespace, TableIdentifier}
 import org.apache.iceberg.types.Types
-
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
@@ -461,9 +460,9 @@ class CompanionDropPartitionsTest
 
       f(root.getAbsolutePath, server)
     } finally {
-      try { spark.conf.unset("spark.indextables.iceberg.catalogType") }
+      try spark.conf.unset("spark.indextables.iceberg.catalogType")
       catch { case _: Exception => }
-      try { spark.conf.unset("spark.indextables.iceberg.uri") }
+      try spark.conf.unset("spark.indextables.iceberg.uri")
       catch { case _: Exception => }
       server.close()
       deleteRecursively(root)

--- a/src/test/scala/io/indextables/spark/sync/CompanionMergeAggregationBugTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionMergeAggregationBugTest.scala
@@ -40,7 +40,11 @@ import org.scalatest.BeforeAndAfterAll
  * (EqualTo, range, In, Not, And, Or, StringStartsWith, StringContains, StringEndsWith), aggregations (COUNT, SUM, AVG,
  * MIN, MAX), GROUP BY, and combined filter + aggregation patterns.
  */
-class CompanionMergeAggregationBugTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class CompanionMergeAggregationBugTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/CompanionMergeSplitsTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionMergeSplitsTest.scala
@@ -26,13 +26,11 @@ import org.apache.spark.sql.types._
 
 import org.apache.hadoop.fs.Path
 
+import io.indextables.spark.transaction.TransactionLogFactory
 import org.apache.iceberg.{DataFiles, FileFormat}
 import org.apache.iceberg.{Schema => IcebergSchema}
 import org.apache.iceberg.catalog.{Namespace, TableIdentifier}
 import org.apache.iceberg.types.Types
-
-import io.indextables.spark.transaction.TransactionLogFactory
-
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
@@ -413,9 +411,9 @@ class CompanionMergeSplitsTest
 
       f(indexPath, df)
     } finally {
-      try { spark.conf.unset("spark.indextables.iceberg.catalogType") }
+      try spark.conf.unset("spark.indextables.iceberg.catalogType")
       catch { case _: Exception => }
-      try { spark.conf.unset("spark.indextables.iceberg.uri") }
+      try spark.conf.unset("spark.indextables.iceberg.uri")
       catch { case _: Exception => }
       server.close()
       deleteRecursively(root)

--- a/src/test/scala/io/indextables/spark/sync/CompanionModeTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionModeTest.scala
@@ -162,39 +162,45 @@ class CompanionModeTest extends TestBase {
       try {
         transactionLog.initialize(getTestSchema())
 
-        transactionLog.addFile(AddAction(
-          path = "companion-1.split",
-          partitionValues = Map("date" -> "2024-01-01"),
-          size = 50000L,
-          modificationTime = 1700000000000L,
-          dataChange = true,
-          numRecords = Some(1000L),
-          companionSourceFiles =
-            Some(Seq("date=2024-01-01/part-00001.parquet", "date=2024-01-01/part-00002.parquet")),
-          companionDeltaVersion = Some(42L),
-          companionFastFieldMode = Some("HYBRID")
-        ))
+        transactionLog.addFile(
+          AddAction(
+            path = "companion-1.split",
+            partitionValues = Map("date" -> "2024-01-01"),
+            size = 50000L,
+            modificationTime = 1700000000000L,
+            dataChange = true,
+            numRecords = Some(1000L),
+            companionSourceFiles =
+              Some(Seq("date=2024-01-01/part-00001.parquet", "date=2024-01-01/part-00002.parquet")),
+            companionDeltaVersion = Some(42L),
+            companionFastFieldMode = Some("HYBRID")
+          )
+        )
 
-        transactionLog.addFile(AddAction(
-          path = "companion-2.split",
-          partitionValues = Map("date" -> "2024-01-02"),
-          size = 60000L,
-          modificationTime = 1700000100000L,
-          dataChange = true,
-          numRecords = Some(2000L),
-          companionSourceFiles = Some(Seq("date=2024-01-02/part-00003.parquet")),
-          companionDeltaVersion = Some(42L),
-          companionFastFieldMode = Some("PARQUET_ONLY")
-        ))
+        transactionLog.addFile(
+          AddAction(
+            path = "companion-2.split",
+            partitionValues = Map("date" -> "2024-01-02"),
+            size = 60000L,
+            modificationTime = 1700000100000L,
+            dataChange = true,
+            numRecords = Some(2000L),
+            companionSourceFiles = Some(Seq("date=2024-01-02/part-00003.parquet")),
+            companionDeltaVersion = Some(42L),
+            companionFastFieldMode = Some("PARQUET_ONLY")
+          )
+        )
 
-        transactionLog.addFile(AddAction(
-          path = "regular.split",
-          partitionValues = Map.empty,
-          size = 30000L,
-          modificationTime = 1700000200000L,
-          dataChange = true,
-          numRecords = Some(500L)
-        ))
+        transactionLog.addFile(
+          AddAction(
+            path = "regular.split",
+            partitionValues = Map.empty,
+            size = 30000L,
+            modificationTime = 1700000200000L,
+            dataChange = true,
+            numRecords = Some(500L)
+          )
+        )
 
         val files = transactionLog.listFiles()
         files should have size 3

--- a/src/test/scala/io/indextables/spark/sync/CompanionMultiPartitionFilterBugTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionMultiPartitionFilterBugTest.scala
@@ -33,7 +33,11 @@ import org.scalatest.BeforeAndAfterAll
  * column + an indexquery condition on a text field, all rows in the first partition are returned instead of only the
  * matching rows.
  */
-class CompanionMultiPartitionFilterBugTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class CompanionMultiPartitionFilterBugTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/CompanionPartitionFilterBugTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionPartitionFilterBugTest.scala
@@ -35,7 +35,11 @@ import org.scalatest.BeforeAndAfterAll
  * group-by aggregate path must all exclude it before converting to a Tantivy query. Otherwise the query returns
  * incorrect results (zero or wrong).
  */
-class CompanionPartitionFilterBugTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class CompanionPartitionFilterBugTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/CompanionPurgeTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionPurgeTest.scala
@@ -27,7 +27,6 @@ import org.apache.iceberg.{DataFiles, FileFormat}
 import org.apache.iceberg.{Schema => IcebergSchema}
 import org.apache.iceberg.catalog.{Namespace, TableIdentifier}
 import org.apache.iceberg.types.Types
-
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterEach
@@ -103,13 +102,12 @@ class CompanionPurgeTest
 
   // ── Delta helpers ───────────────────────────────────────────────────────────
 
-  private def createDeltaSource(deltaPath: String): Unit = {
+  private def createDeltaSource(deltaPath: String): Unit =
     spark
       .createDataFrame(spark.sparkContext.parallelize(testRows), sparkSchema)
       .write
       .format("delta")
       .save(deltaPath)
-  }
 
   private def buildDeltaCompanion(deltaPath: String, indexPath: String): Unit = {
     val result = spark
@@ -121,25 +119,27 @@ class CompanionPurgeTest
     flushCaches()
   }
 
-  private def readCompanion(indexPath: String): org.apache.spark.sql.DataFrame = {
+  private def readCompanion(indexPath: String): org.apache.spark.sql.DataFrame =
     spark.read
       .format(io.indextables.spark.TestBase.INDEXTABLES_FORMAT)
       .option("spark.indextables.read.defaultLimit", "1000")
       .load(indexPath)
-  }
 
-  private def createOrphanFile(indexPath: String, name: String, ageHoursAgo: Long): File = {
+  private def createOrphanFile(
+    indexPath: String,
+    name: String,
+    ageHoursAgo: Long
+  ): File = {
     val orphanFile = new File(indexPath, name)
     orphanFile.createNewFile()
     orphanFile.setLastModified(System.currentTimeMillis() - (ageHoursAgo * 60 * 60 * 1000))
     orphanFile
   }
 
-  private def setAllSplitTimestamps(indexPath: String, ageHoursAgo: Long): Unit = {
+  private def setAllSplitTimestamps(indexPath: String, ageHoursAgo: Long): Unit =
     new File(indexPath).listFiles().filter(_.getName.endsWith(".split")).foreach { f =>
       f.setLastModified(System.currentTimeMillis() - (ageHoursAgo * 60 * 60 * 1000))
     }
-  }
 
   // ── Iceberg helpers ─────────────────────────────────────────────────────────
 
@@ -219,9 +219,9 @@ class CompanionPurgeTest
 
       f(root, indexPath, server, tableId)
     } finally {
-      try { spark.conf.unset("spark.indextables.iceberg.catalogType") }
+      try spark.conf.unset("spark.indextables.iceberg.catalogType")
       catch { case _: Exception => }
-      try { spark.conf.unset("spark.indextables.iceberg.uri") }
+      try spark.conf.unset("spark.indextables.iceberg.uri")
       catch { case _: Exception => }
       server.close()
       deleteRecursively(root)
@@ -423,127 +423,151 @@ class CompanionPurgeTest
   // ═══════════════════════════════════════════════════════════════════════════
 
   test("PURGE on Iceberg companion should delete orphaned splits") {
-    withIcebergCompanion { (_, indexPath, _, _) =>
-      val validSplitsBefore = new File(indexPath).listFiles().count(_.getName.endsWith(".split"))
-      validSplitsBefore should be > 0
+    withIcebergCompanion {
+      (
+        _,
+        indexPath,
+        _,
+        _
+      ) =>
+        val validSplitsBefore = new File(indexPath).listFiles().count(_.getName.endsWith(".split"))
+        validSplitsBefore should be > 0
 
-      // Create orphaned .split files aged 25 hours
-      val orphan1 = createOrphanFile(indexPath, "orphan-ice-1111-2222-3333-444444444444.split", 25)
-      val orphan2 = createOrphanFile(indexPath, "orphan-ice-5555-6666-7777-888888888888.split", 25)
+        // Create orphaned .split files aged 25 hours
+        val orphan1 = createOrphanFile(indexPath, "orphan-ice-1111-2222-3333-444444444444.split", 25)
+        val orphan2 = createOrphanFile(indexPath, "orphan-ice-5555-6666-7777-888888888888.split", 25)
 
-      // Purge
-      val result  = spark.sql(s"PURGE INDEXTABLE '$indexPath' OLDER THAN 0 HOURS").collect()
-      val metrics = result(0).getStruct(1)
+        // Purge
+        val result  = spark.sql(s"PURGE INDEXTABLE '$indexPath' OLDER THAN 0 HOURS").collect()
+        val metrics = result(0).getStruct(1)
 
-      metrics.getString(0) shouldBe "SUCCESS"
-      metrics.getLong(1) should be >= 2L
-      metrics.getLong(2) should be >= 2L
+        metrics.getString(0) shouldBe "SUCCESS"
+        metrics.getLong(1) should be >= 2L
+        metrics.getLong(2) should be >= 2L
 
-      // Verify orphans deleted
-      orphan1.exists() shouldBe false
-      orphan2.exists() shouldBe false
+        // Verify orphans deleted
+        orphan1.exists() shouldBe false
+        orphan2.exists() shouldBe false
 
-      // Verify valid splits preserved
-      val validSplitsAfter = new File(indexPath).listFiles().count(_.getName.endsWith(".split"))
-      validSplitsAfter shouldBe validSplitsBefore
+        // Verify valid splits preserved
+        val validSplitsAfter = new File(indexPath).listFiles().count(_.getName.endsWith(".split"))
+        validSplitsAfter shouldBe validSplitsBefore
 
-      // Verify data still readable
-      val df = readCompanion(indexPath)
-      df.count() shouldBe 5
+        // Verify data still readable
+        val df = readCompanion(indexPath)
+        df.count() shouldBe 5
     }
   }
 
   test("PURGE should not delete valid Iceberg companion splits") {
-    withIcebergCompanion { (_, indexPath, _, _) =>
-      // Set old timestamps on ALL files (valid + will-be-orphaned)
-      setAllSplitTimestamps(indexPath, 25)
+    withIcebergCompanion {
+      (
+        _,
+        indexPath,
+        _,
+        _
+      ) =>
+        // Set old timestamps on ALL files (valid + will-be-orphaned)
+        setAllSplitTimestamps(indexPath, 25)
 
-      // Create orphaned .split file also aged 25 hours
-      val orphan = createOrphanFile(indexPath, "orphan-ice-aaaa-bbbb-cccc-dddddddddddd.split", 25)
+        // Create orphaned .split file also aged 25 hours
+        val orphan = createOrphanFile(indexPath, "orphan-ice-aaaa-bbbb-cccc-dddddddddddd.split", 25)
 
-      val validSplitsBefore = new File(indexPath).listFiles().count(_.getName.endsWith(".split"))
+        val validSplitsBefore = new File(indexPath).listFiles().count(_.getName.endsWith(".split"))
 
-      // Purge
-      val result  = spark.sql(s"PURGE INDEXTABLE '$indexPath' OLDER THAN 0 HOURS").collect()
-      val metrics = result(0).getStruct(1)
+        // Purge
+        val result  = spark.sql(s"PURGE INDEXTABLE '$indexPath' OLDER THAN 0 HOURS").collect()
+        val metrics = result(0).getStruct(1)
 
-      metrics.getString(0) shouldBe "SUCCESS"
+        metrics.getString(0) shouldBe "SUCCESS"
 
-      // Only the orphan should be deleted
-      orphan.exists() shouldBe false
+        // Only the orphan should be deleted
+        orphan.exists() shouldBe false
 
-      val validSplitsAfter = new File(indexPath).listFiles().count(_.getName.endsWith(".split"))
-      validSplitsAfter shouldBe (validSplitsBefore - 1)
+        val validSplitsAfter = new File(indexPath).listFiles().count(_.getName.endsWith(".split"))
+        validSplitsAfter shouldBe (validSplitsBefore - 1)
 
-      // Verify table is still readable
-      val df = readCompanion(indexPath)
-      df.count() shouldBe 5
+        // Verify table is still readable
+        val df = readCompanion(indexPath)
+        df.count() shouldBe 5
     }
   }
 
   test("PURGE on Iceberg companion preserves data integrity") {
-    withIcebergCompanion { (_, indexPath, _, _) =>
-      // Create orphans and purge
-      createOrphanFile(indexPath, "orphan-integrity-1111-2222-3333-444444444444.split", 25)
-      createOrphanFile(indexPath, "orphan-integrity-5555-6666-7777-888888888888.split", 25)
+    withIcebergCompanion {
+      (
+        _,
+        indexPath,
+        _,
+        _
+      ) =>
+        // Create orphans and purge
+        createOrphanFile(indexPath, "orphan-integrity-1111-2222-3333-444444444444.split", 25)
+        createOrphanFile(indexPath, "orphan-integrity-5555-6666-7777-888888888888.split", 25)
 
-      val result  = spark.sql(s"PURGE INDEXTABLE '$indexPath' OLDER THAN 0 HOURS").collect()
-      val metrics = result(0).getStruct(1)
-      metrics.getString(0) shouldBe "SUCCESS"
+        val result  = spark.sql(s"PURGE INDEXTABLE '$indexPath' OLDER THAN 0 HOURS").collect()
+        val metrics = result(0).getStruct(1)
+        metrics.getString(0) shouldBe "SUCCESS"
 
-      // Verify all rows are still correct
-      val df   = readCompanion(indexPath)
-      val rows = df.collect()
-      rows.length shouldBe 5
+        // Verify all rows are still correct
+        val df   = readCompanion(indexPath)
+        val rows = df.collect()
+        rows.length shouldBe 5
 
-      val rowsById = rows.map(r => r.getAs[Int]("id") -> r).toMap
-      rowsById.size shouldBe 5
+        val rowsById = rows.map(r => r.getAs[Int]("id") -> r).toMap
+        rowsById.size shouldBe 5
 
-      rowsById(1).getAs[String]("name") shouldBe "alice"
-      rowsById(2).getAs[String]("name") shouldBe "bob"
-      rowsById(3).getAs[String]("name") shouldBe "charlie"
-      rowsById(4).getAs[String]("name") shouldBe "dave"
-      rowsById(5).getAs[String]("name") shouldBe "eve"
+        rowsById(1).getAs[String]("name") shouldBe "alice"
+        rowsById(2).getAs[String]("name") shouldBe "bob"
+        rowsById(3).getAs[String]("name") shouldBe "charlie"
+        rowsById(4).getAs[String]("name") shouldBe "dave"
+        rowsById(5).getAs[String]("name") shouldBe "eve"
 
-      rowsById(1).getAs[Double]("score") shouldBe 85.0 +- 0.01
-      rowsById(2).getAs[Double]("score") shouldBe 92.5 +- 0.01
-      rowsById(3).getAs[Double]("score") shouldBe 78.0 +- 0.01
-      rowsById(4).getAs[Double]("score") shouldBe 95.1 +- 0.01
-      rowsById(5).getAs[Double]("score") shouldBe 88.3 +- 0.01
+        rowsById(1).getAs[Double]("score") shouldBe 85.0 +- 0.01
+        rowsById(2).getAs[Double]("score") shouldBe 92.5 +- 0.01
+        rowsById(3).getAs[Double]("score") shouldBe 78.0 +- 0.01
+        rowsById(4).getAs[Double]("score") shouldBe 95.1 +- 0.01
+        rowsById(5).getAs[Double]("score") shouldBe 88.3 +- 0.01
     }
   }
 
   test("Re-sync after purge on Iceberg companion") {
-    withIcebergCompanion { (root, indexPath, server, tableId) =>
-      // Create orphans and purge
-      createOrphanFile(indexPath, "orphan-resync-1111-2222-3333-444444444444.split", 25)
+    withIcebergCompanion {
+      (
+        root,
+        indexPath,
+        server,
+        tableId
+      ) =>
+        // Create orphans and purge
+        createOrphanFile(indexPath, "orphan-resync-1111-2222-3333-444444444444.split", 25)
 
-      val purgeResult = spark.sql(s"PURGE INDEXTABLE '$indexPath' OLDER THAN 0 HOURS").collect()
-      val purgeMetrics = purgeResult(0).getStruct(1)
-      purgeMetrics.getString(0) shouldBe "SUCCESS"
+        val purgeResult  = spark.sql(s"PURGE INDEXTABLE '$indexPath' OLDER THAN 0 HOURS").collect()
+        val purgeMetrics = purgeResult(0).getStruct(1)
+        purgeMetrics.getString(0) shouldBe "SUCCESS"
 
-      // Append new data to Iceberg
-      val newRows = Seq(
-        Row(6, "frank", 91.0),
-        Row(7, "grace", 87.5)
-      )
-      appendIcebergSnapshot(server, tableId, newRows, root, 2)
-
-      flushCaches()
-
-      // Re-sync should succeed
-      val resyncResult = spark
-        .sql(
-          s"BUILD INDEXTABLES COMPANION FOR ICEBERG 'default.purge_test' FASTFIELDS MODE HYBRID AT LOCATION '$indexPath'"
+        // Append new data to Iceberg
+        val newRows = Seq(
+          Row(6, "frank", 91.0),
+          Row(7, "grace", 87.5)
         )
-        .collect()
-      resyncResult(0).getString(2) shouldBe "success"
+        appendIcebergSnapshot(server, tableId, newRows, root, 2)
 
-      flushCaches()
+        flushCaches()
 
-      // Verify all rows (original + new) are present via count
-      val df = readCompanion(indexPath)
-      df.count() shouldBe 7
+        // Re-sync should succeed
+        val resyncResult = spark
+          .sql(
+            s"BUILD INDEXTABLES COMPANION FOR ICEBERG 'default.purge_test' FASTFIELDS MODE HYBRID AT LOCATION '$indexPath'"
+          )
+          .collect()
+        resyncResult(0).getString(2) shouldBe "success"
+
+        flushCaches()
+
+        // Verify all rows (original + new) are present via count
+        val df = readCompanion(indexPath)
+        df.count() shouldBe 7
     }
   }
 }

--- a/src/test/scala/io/indextables/spark/sync/CompanionRoundTripTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionRoundTripTest.scala
@@ -34,7 +34,11 @@ import org.scalatest.BeforeAndAfterAll
  * Each test writes known data to a Delta table, builds a companion index, reads ALL rows back through the companion,
  * and asserts that every column of every row matches the original source.
  */
-class CompanionRoundTripTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class CompanionRoundTripTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/CompanionSplitBugReproductionTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionSplitBugReproductionTest.scala
@@ -32,7 +32,11 @@ import org.scalatest.BeforeAndAfterAll
  *   1. Array[String] field returns null with "Cannot deserialize value of type LinkedHashMap" error 2. Date field
  *      throws ClassCastException 3. Any predicate returns zero rows
  */
-class CompanionSplitBugReproductionTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class CompanionSplitBugReproductionTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/CompanionSplitTypeComprehensiveTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionSplitTypeComprehensiveTest.scala
@@ -37,7 +37,11 @@ import org.scalatest.BeforeAndAfterAll
  *   - Partition column values are correctly injected
  *   - Complex types (Array, Struct, Map) are correctly deserialized
  */
-class CompanionSplitTypeComprehensiveTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class CompanionSplitTypeComprehensiveTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/CompanionTruncateTimeTravelTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionTruncateTimeTravelTest.scala
@@ -26,13 +26,11 @@ import org.apache.spark.sql.types._
 
 import org.apache.hadoop.fs.Path
 
+import io.indextables.spark.transaction.TransactionLogFactory
 import org.apache.iceberg.{DataFiles, FileFormat}
 import org.apache.iceberg.{Schema => IcebergSchema}
 import org.apache.iceberg.catalog.{Namespace, TableIdentifier}
 import org.apache.iceberg.types.Types
-
-import io.indextables.spark.transaction.TransactionLogFactory
-
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterAll
@@ -40,8 +38,8 @@ import org.scalatest.BeforeAndAfterAll
 /**
  * Tests for TRUNCATE INDEXTABLES TIME TRAVEL on companion tables built from Delta and Iceberg.
  *
- * Verifies that truncation removes old transaction log versions while preserving data integrity
- * and companion metadata, and that DRY RUN mode previews without deleting.
+ * Verifies that truncation removes old transaction log versions while preserving data integrity and companion metadata,
+ * and that DRY RUN mode previews without deleting.
  */
 class CompanionTruncateTimeTravelTest
     extends AnyFunSuite
@@ -127,8 +125,8 @@ class CompanionTruncateTimeTravelTest
     if (files == null) return (0, 0)
     val versionPattern    = """^\d{20}\.json$""".r
     val checkpointPattern = """^\d{20}\.checkpoint""".r
-    val versionCount    = files.count(f => versionPattern.findFirstIn(f.getName).isDefined)
-    val checkpointCount = files.count(f => checkpointPattern.findFirstIn(f.getName).isDefined)
+    val versionCount      = files.count(f => versionPattern.findFirstIn(f.getName).isDefined)
+    val checkpointCount   = files.count(f => checkpointPattern.findFirstIn(f.getName).isDefined)
     (versionCount, checkpointCount)
   }
 
@@ -139,8 +137,8 @@ class CompanionTruncateTimeTravelTest
       .load(indexPath)
 
   /**
-   * Write initial Delta data (5 rows), build companion, then append 1 row and re-sync
-   * `extraSyncs` times to create multiple tx log versions.
+   * Write initial Delta data (5 rows), build companion, then append 1 row and re-sync `extraSyncs` times to create
+   * multiple tx log versions.
    *
    * Returns (deltaPath, indexPath, totalExpectedRows).
    */
@@ -236,10 +234,12 @@ class CompanionTruncateTimeTravelTest
   }
 
   /**
-   * Create an Iceberg companion with multiple snapshots/syncs. Calls `f` with
-   * (indexPath, icebergTableName, server, rootDir, totalExpectedRows).
+   * Create an Iceberg companion with multiple snapshots/syncs. Calls `f` with (indexPath, icebergTableName, server,
+   * rootDir, totalExpectedRows).
    */
-  private def withIcebergCompanionManySyncs(extraSyncs: Int)(
+  private def withIcebergCompanionManySyncs(
+    extraSyncs: Int
+  )(
     f: (String, String, EmbeddedIcebergRestServer, File, Int) => Unit
   ): Unit = {
     val root         = Files.createTempDirectory("iceberg-truncate-tt").toFile
@@ -294,9 +294,9 @@ class CompanionTruncateTimeTravelTest
 
       f(indexPath, "default.truncate_test", server, root, totalRows)
     } finally {
-      try { spark.conf.unset("spark.indextables.iceberg.catalogType") }
+      try spark.conf.unset("spark.indextables.iceberg.catalogType")
       catch { case _: Exception => }
-      try { spark.conf.unset("spark.indextables.iceberg.uri") }
+      try spark.conf.unset("spark.indextables.iceberg.uri")
       catch { case _: Exception => }
       server.close()
       deleteRecursively(root)
@@ -346,11 +346,9 @@ class CompanionTruncateTimeTravelTest
       row.getLong(2) should be >= 0L // checkpoint_version created
 
       // Verify checkpoint was created (check for checkpoint files or _last_checkpoint)
-      val txLogDir = new java.io.File(indexPath, "_transaction_log")
-      val allFiles = Option(txLogDir.listFiles()).getOrElse(Array.empty)
-      val hasCheckpoint = allFiles.exists(f =>
-        f.getName.contains("checkpoint") || f.getName == "_last_checkpoint"
-      )
+      val txLogDir      = new java.io.File(indexPath, "_transaction_log")
+      val allFiles      = Option(txLogDir.listFiles()).getOrElse(Array.empty)
+      val hasCheckpoint = allFiles.exists(f => f.getName.contains("checkpoint") || f.getName == "_last_checkpoint")
       hasCheckpoint shouldBe true
 
       // Verify data still readable
@@ -460,108 +458,136 @@ class CompanionTruncateTimeTravelTest
   // ═══════════════════════════════════════════════════════════════════════════
 
   test("TRUNCATE on Iceberg companion with many syncs should delete old versions and preserve data") {
-    withIcebergCompanionManySyncs(12) { (indexPath, _, _, _, totalRows) =>
-      // Verify we have many version files before truncation
-      val (versionsBefore, _) = countTransactionLogFiles(indexPath)
-      versionsBefore should be >= 12
+    withIcebergCompanionManySyncs(12) {
+      (
+        indexPath,
+        _,
+        _,
+        _,
+        totalRows
+      ) =>
+        // Verify we have many version files before truncation
+        val (versionsBefore, _) = countTransactionLogFiles(indexPath)
+        versionsBefore should be >= 12
 
-      // Truncate
-      val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$indexPath'")
-      val row    = result.collect().head
+        // Truncate
+        val result = spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$indexPath'")
+        val row    = result.collect().head
 
-      row.getString(1) shouldBe "SUCCESS"
+        row.getString(1) shouldBe "SUCCESS"
 
-      // Verify version count decreased
-      val (versionsAfter, _) = countTransactionLogFiles(indexPath)
-      versionsAfter should be < versionsBefore
+        // Verify version count decreased
+        val (versionsAfter, _) = countTransactionLogFiles(indexPath)
+        versionsAfter should be < versionsBefore
 
-      // Verify data still readable via count (uses tantivy fast fields)
-      flushCaches()
-      val df = readCompanion(indexPath)
-      df.count() shouldBe totalRows
+        // Verify data still readable via count (uses tantivy fast fields)
+        flushCaches()
+        val df = readCompanion(indexPath)
+        df.count() shouldBe totalRows
     }
   }
 
   test("Data integrity preserved after truncation on Iceberg companion") {
-    withIcebergCompanionManySyncs(8) { (indexPath, _, _, _, totalRows) =>
-      // Compute aggregations before truncation
-      flushCaches()
-      val dfBefore    = readCompanion(indexPath)
-      val countBefore = dfBefore.count()
-      val aggBefore = dfBefore
-        .agg(sum("score"), min("score"), max("score"))
-        .collect()(0)
-      val sumBefore = aggBefore.getDouble(0)
-      val minBefore = aggBefore.getDouble(1)
-      val maxBefore = aggBefore.getDouble(2)
+    withIcebergCompanionManySyncs(8) {
+      (
+        indexPath,
+        _,
+        _,
+        _,
+        totalRows
+      ) =>
+        // Compute aggregations before truncation
+        flushCaches()
+        val dfBefore    = readCompanion(indexPath)
+        val countBefore = dfBefore.count()
+        val aggBefore = dfBefore
+          .agg(sum("score"), min("score"), max("score"))
+          .collect()(0)
+        val sumBefore = aggBefore.getDouble(0)
+        val minBefore = aggBefore.getDouble(1)
+        val maxBefore = aggBefore.getDouble(2)
 
-      countBefore shouldBe totalRows
+        countBefore shouldBe totalRows
 
-      // Truncate
-      spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$indexPath'").collect()
+        // Truncate
+        spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$indexPath'").collect()
 
-      // Verify exact same aggregations after truncation
-      flushCaches()
-      val dfAfter    = readCompanion(indexPath)
-      val countAfter = dfAfter.count()
-      val aggAfter = dfAfter
-        .agg(sum("score"), min("score"), max("score"))
-        .collect()(0)
+        // Verify exact same aggregations after truncation
+        flushCaches()
+        val dfAfter    = readCompanion(indexPath)
+        val countAfter = dfAfter.count()
+        val aggAfter = dfAfter
+          .agg(sum("score"), min("score"), max("score"))
+          .collect()(0)
 
-      countAfter shouldBe countBefore
-      aggAfter.getDouble(0) shouldBe sumBefore
-      aggAfter.getDouble(1) shouldBe minBefore
-      aggAfter.getDouble(2) shouldBe maxBefore
+        countAfter shouldBe countBefore
+        aggAfter.getDouble(0) shouldBe sumBefore
+        aggAfter.getDouble(1) shouldBe minBefore
+        aggAfter.getDouble(2) shouldBe maxBefore
     }
   }
 
   test("Companion metadata preserved after truncation on Iceberg companion") {
-    withIcebergCompanionManySyncs(8) { (indexPath, _, _, _, _) =>
-      // Verify companion config exists before truncation
-      val txLogBefore = TransactionLogFactory.create(new Path(indexPath), spark)
-      try {
-        val metadataBefore = txLogBefore.getMetadata()
-        metadataBefore.configuration.get("indextables.companion.enabled") shouldBe Some("true")
-      } finally txLogBefore.close()
+    withIcebergCompanionManySyncs(8) {
+      (
+        indexPath,
+        _,
+        _,
+        _,
+        _
+      ) =>
+        // Verify companion config exists before truncation
+        val txLogBefore = TransactionLogFactory.create(new Path(indexPath), spark)
+        try {
+          val metadataBefore = txLogBefore.getMetadata()
+          metadataBefore.configuration.get("indextables.companion.enabled") shouldBe Some("true")
+        } finally txLogBefore.close()
 
-      // Truncate
-      spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$indexPath'").collect()
+        // Truncate
+        spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$indexPath'").collect()
 
-      // Verify companion config still present after truncation
-      flushCaches()
-      val txLogAfter = TransactionLogFactory.create(new Path(indexPath), spark)
-      try {
-        val metadataAfter = txLogAfter.getMetadata()
-        metadataAfter.configuration.get("indextables.companion.enabled") shouldBe Some("true")
-      } finally txLogAfter.close()
+        // Verify companion config still present after truncation
+        flushCaches()
+        val txLogAfter = TransactionLogFactory.create(new Path(indexPath), spark)
+        try {
+          val metadataAfter = txLogAfter.getMetadata()
+          metadataAfter.configuration.get("indextables.companion.enabled") shouldBe Some("true")
+        } finally txLogAfter.close()
     }
   }
 
   test("Re-sync after truncation on Iceberg companion should succeed") {
-    withIcebergCompanionManySyncs(6) { (indexPath, tableName, server, root, totalRows) =>
-      // Truncate
-      spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$indexPath'").collect()
+    withIcebergCompanionManySyncs(6) {
+      (
+        indexPath,
+        tableName,
+        server,
+        root,
+        totalRows
+      ) =>
+        // Truncate
+        spark.sql(s"TRUNCATE INDEXTABLES TIME TRAVEL '$indexPath'").collect()
 
-      // Append new snapshot to Iceberg
-      val ns      = Namespace.of("default")
-      val tableId = TableIdentifier.of(ns, "truncate_test")
-      val newBatch = makeBatch(totalRows + 1, 5)
-      appendIcebergSnapshot(server, tableId, newBatch, root, 100)
+        // Append new snapshot to Iceberg
+        val ns       = Namespace.of("default")
+        val tableId  = TableIdentifier.of(ns, "truncate_test")
+        val newBatch = makeBatch(totalRows + 1, 5)
+        appendIcebergSnapshot(server, tableId, newBatch, root, 100)
 
-      flushCaches()
+        flushCaches()
 
-      // Re-sync after truncation
-      val syncResult = spark
-        .sql(
-          s"BUILD INDEXTABLES COMPANION FOR ICEBERG '$tableName' FASTFIELDS MODE HYBRID AT LOCATION '$indexPath'"
-        )
-        .collect()
-      syncResult(0).getString(2) shouldBe "success"
+        // Re-sync after truncation
+        val syncResult = spark
+          .sql(
+            s"BUILD INDEXTABLES COMPANION FOR ICEBERG '$tableName' FASTFIELDS MODE HYBRID AT LOCATION '$indexPath'"
+          )
+          .collect()
+        syncResult(0).getString(2) shouldBe "success"
 
-      // Verify new data appears via count
-      flushCaches()
-      val df = readCompanion(indexPath)
-      df.count() shouldBe (totalRows + 5)
+        // Verify new data appears via count
+        flushCaches()
+        val df = readCompanion(indexPath)
+        df.count() shouldBe (totalRows + 5)
     }
   }
 }

--- a/src/test/scala/io/indextables/spark/sync/CompanionWriterHeapSizeTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionWriterHeapSizeTest.scala
@@ -29,8 +29,8 @@ import org.scalatest.BeforeAndAfterAll
 /**
  * Tests for WRITER HEAP SIZE clause with Delta companion builds.
  *
- * Validates that the WRITER HEAP SIZE clause is accepted and produces correct companion indexes
- * with different size units (M, G), as well as confirming builds succeed without the clause.
+ * Validates that the WRITER HEAP SIZE clause is accepted and produces correct companion indexes with different size
+ * units (M, G), as well as confirming builds succeed without the clause.
  */
 class CompanionWriterHeapSizeTest
     extends AnyFunSuite
@@ -98,16 +98,56 @@ class CompanionWriterHeapSizeTest
   private def createDeltaSource(deltaPath: String): Unit = {
     val ss = spark; import ss.implicits._
     Seq(
-      (1, "alice", "The quick brown fox jumps over the lazy dog. This is a sample document with enough content to make heap size relevant."),
-      (2, "bob", "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."),
-      (3, "charlie", "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."),
-      (4, "dave", "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."),
-      (5, "eve", "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."),
-      (6, "frank", "A short text field with some content for testing writer heap size configurations in companion builds."),
-      (7, "grace", "Another piece of text content used in the companion writer heap size test to validate split creation."),
-      (8, "heidi", "Testing various heap size units including megabytes and gigabytes for the companion indexing pipeline."),
-      (9, "ivan", "The writer heap size controls how much memory the tantivy index writer allocates during split creation."),
-      (10, "judy", "Larger heap sizes can improve indexing throughput by reducing the number of intermediate segment merges.")
+      (
+        1,
+        "alice",
+        "The quick brown fox jumps over the lazy dog. This is a sample document with enough content to make heap size relevant."
+      ),
+      (
+        2,
+        "bob",
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+      ),
+      (
+        3,
+        "charlie",
+        "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+      ),
+      (
+        4,
+        "dave",
+        "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
+      ),
+      (
+        5,
+        "eve",
+        "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+      ),
+      (
+        6,
+        "frank",
+        "A short text field with some content for testing writer heap size configurations in companion builds."
+      ),
+      (
+        7,
+        "grace",
+        "Another piece of text content used in the companion writer heap size test to validate split creation."
+      ),
+      (
+        8,
+        "heidi",
+        "Testing various heap size units including megabytes and gigabytes for the companion indexing pipeline."
+      ),
+      (
+        9,
+        "ivan",
+        "The writer heap size controls how much memory the tantivy index writer allocates during split creation."
+      ),
+      (
+        10,
+        "judy",
+        "Larger heap sizes can improve indexing throughput by reducing the number of intermediate segment merges."
+      )
     ).toDF("id", "name", "content")
       .write
       .format("delta")
@@ -124,9 +164,11 @@ class CompanionWriterHeapSizeTest
       val indexPath = new File(tempDir, "index").getAbsolutePath
 
       createDeltaSource(deltaPath)
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WRITER HEAP SIZE 512M AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WRITER HEAP SIZE 512M AT LOCATION '$indexPath'"
+        )
+        .collect()
       result(0).getString(2) shouldBe "success"
       result(0).getInt(4) should be > 0 // splits created
       readCompanion(indexPath).count() shouldBe 10
@@ -139,9 +181,11 @@ class CompanionWriterHeapSizeTest
       val indexPath = new File(tempDir, "index").getAbsolutePath
 
       createDeltaSource(deltaPath)
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WRITER HEAP SIZE 2G AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' WRITER HEAP SIZE 2G AT LOCATION '$indexPath'"
+        )
+        .collect()
       result(0).getString(2) shouldBe "success"
       readCompanion(indexPath).count() shouldBe 10
     }
@@ -153,9 +197,11 @@ class CompanionWriterHeapSizeTest
       val indexPath = new File(tempDir, "index").getAbsolutePath
 
       createDeltaSource(deltaPath)
-      val result = spark.sql(
-        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
-      ).collect()
+      val result = spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+        )
+        .collect()
       result(0).getString(2) shouldBe "success"
       readCompanion(indexPath).count() shouldBe 10
     }

--- a/src/test/scala/io/indextables/spark/sync/DistributedDeltaSyncIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/DistributedDeltaSyncIntegrationTest.scala
@@ -36,7 +36,11 @@ import org.scalatest.BeforeAndAfterAll
  * End-to-end integration tests for distributed log read in BUILD INDEXTABLES COMPANION. Tests the full pipeline with
  * distributed enabled vs disabled, verifying identical results.
  */
-class DistributedDeltaSyncIntegrationTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class DistributedDeltaSyncIntegrationTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/DistributedSourceScannerTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/DistributedSourceScannerTest.scala
@@ -30,7 +30,11 @@ import org.scalatest.BeforeAndAfterAll
  * Tests for DistributedSourceScanner — verifies that distributed Delta and Parquet scans produce the same file set as
  * the existing single-call readers.
  */
-class DistributedSourceScannerTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class DistributedSourceScannerTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/IcebergDatePartitionNormalizationTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/IcebergDatePartitionNormalizationTest.scala
@@ -25,8 +25,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 /**
- * Unit tests for the Iceberg DATE partition normalization helpers in DistributedSourceScanner.
- * Covers: normalizeIcebergDatePartitions, extractDateColumns, resolvePartitionValues.
+ * Unit tests for the Iceberg DATE partition normalization helpers in DistributedSourceScanner. Covers:
+ * normalizeIcebergDatePartitions, extractDateColumns, resolvePartitionValues.
  */
 class IcebergDatePartitionNormalizationTest extends AnyFunSuite with Matchers {
 
@@ -156,11 +156,13 @@ class IcebergDatePartitionNormalizationTest extends AnyFunSuite with Matchers {
   // ── extractDateColumns ─────────────────────────────────────────────────
 
   test("extractDateColumns should extract DATE columns from mixed schema") {
-    val schema = StructType(Seq(
-      StructField("id", IntegerType),
-      StructField("dt", DateType),
-      StructField("name", StringType)
-    ))
+    val schema = StructType(
+      Seq(
+        StructField("id", IntegerType),
+        StructField("dt", DateType),
+        StructField("name", StringType)
+      )
+    )
     DistributedSourceScanner.extractDateColumns(Some(schema)) shouldBe Set("dt")
   }
 
@@ -169,27 +171,33 @@ class IcebergDatePartitionNormalizationTest extends AnyFunSuite with Matchers {
   }
 
   test("extractDateColumns should return empty set when no DATE columns exist") {
-    val schema = StructType(Seq(
-      StructField("id", IntegerType),
-      StructField("name", StringType)
-    ))
+    val schema = StructType(
+      Seq(
+        StructField("id", IntegerType),
+        StructField("name", StringType)
+      )
+    )
     DistributedSourceScanner.extractDateColumns(Some(schema)) shouldBe Set.empty
   }
 
   test("extractDateColumns should find multiple DATE columns") {
-    val schema = StructType(Seq(
-      StructField("start_date", DateType),
-      StructField("end_date", DateType),
-      StructField("name", StringType)
-    ))
+    val schema = StructType(
+      Seq(
+        StructField("start_date", DateType),
+        StructField("end_date", DateType),
+        StructField("name", StringType)
+      )
+    )
     DistributedSourceScanner.extractDateColumns(Some(schema)) shouldBe Set("start_date", "end_date")
   }
 
   test("extractDateColumns should not include TimestampType columns") {
-    val schema = StructType(Seq(
-      StructField("created_at", TimestampType),
-      StructField("name", StringType)
-    ))
+    val schema = StructType(
+      Seq(
+        StructField("created_at", TimestampType),
+        StructField("name", StringType)
+      )
+    )
     DistributedSourceScanner.extractDateColumns(Some(schema)) shouldBe Set.empty
   }
 

--- a/src/test/scala/io/indextables/spark/sync/IcebergSchemaParsingTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/IcebergSchemaParsingTest.scala
@@ -23,18 +23,20 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 /**
- * Unit tests for the Iceberg schema parsing methods extracted to IcebergSourceReader companion object.
- * Covers: parseSchemaJson, convertIcebergSchemaToSpark, all primitive/complex type mappings, nullable semantics.
+ * Unit tests for the Iceberg schema parsing methods extracted to IcebergSourceReader companion object. Covers:
+ * parseSchemaJson, convertIcebergSchemaToSpark, all primitive/complex type mappings, nullable semantics.
  */
 class IcebergSchemaParsingTest extends AnyFunSuite with Matchers {
 
   // ── parseSchemaJson ────────────────────────────────────────────────────
 
   test("parseSchemaJson should parse Spark-format schema JSON") {
-    val original = StructType(Seq(
-      StructField("id", LongType, nullable = true),
-      StructField("name", StringType, nullable = true)
-    ))
+    val original = StructType(
+      Seq(
+        StructField("id", LongType, nullable = true),
+        StructField("name", StringType, nullable = true)
+      )
+    )
     val result = IcebergSourceReader.parseSchemaJson(original.json)
     result shouldBe original
   }
@@ -182,7 +184,7 @@ class IcebergSchemaParsingTest extends AnyFunSuite with Matchers {
         |    }
         |  }]
         |}""".stripMargin
-    val result = IcebergSourceReader.convertIcebergSchemaToSpark(json)
+    val result  = IcebergSourceReader.convertIcebergSchemaToSpark(json)
     val arrType = result.fields(0).dataType.asInstanceOf[ArrayType]
     arrType.elementType shouldBe StringType
     arrType.containsNull shouldBe true
@@ -204,7 +206,7 @@ class IcebergSchemaParsingTest extends AnyFunSuite with Matchers {
         |    }
         |  }]
         |}""".stripMargin
-    val result = IcebergSourceReader.convertIcebergSchemaToSpark(json)
+    val result  = IcebergSourceReader.convertIcebergSchemaToSpark(json)
     val mapType = result.fields(0).dataType.asInstanceOf[MapType]
     mapType.keyType shouldBe StringType
     mapType.valueType shouldBe LongType

--- a/src/test/scala/io/indextables/spark/sync/LocalIcebergSyncIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/LocalIcebergSyncIntegrationTest.scala
@@ -43,7 +43,12 @@ import org.scalatest.BeforeAndAfterAll
  *
  * Tests are automatically skipped if the REST catalog is not reachable.
  */
-class LocalIcebergSyncIntegrationTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with IcebergTestSupport with io.indextables.spark.testutils.FileCleanupHelper {
+class LocalIcebergSyncIntegrationTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with IcebergTestSupport
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private val REST_URI         = "http://localhost:8181"
   private val MINIO_ENDPOINT   = "http://localhost:9000"

--- a/src/test/scala/io/indextables/spark/sync/LocalParquetSyncIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/LocalParquetSyncIntegrationTest.scala
@@ -39,7 +39,11 @@ import org.scalatest.BeforeAndAfterAll
  *
  * No cloud credentials needed -- runs entirely on local filesystem.
  */
-class LocalParquetSyncIntegrationTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class LocalParquetSyncIntegrationTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/LocalSyncIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/LocalSyncIntegrationTest.scala
@@ -37,7 +37,11 @@ import org.scalatest.BeforeAndAfterAll
  *
  * No cloud credentials needed — runs entirely on local filesystem.
  */
-class LocalSyncIntegrationTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class LocalSyncIntegrationTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/MultiTransactionSyncTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/MultiTransactionSyncTest.scala
@@ -36,7 +36,11 @@ import org.scalatest.BeforeAndAfterAll
  * Uses delta-spark (Spark SQL) for all Delta table manipulations rather than delta-standalone, providing realistic
  * Delta transaction histories.
  */
-class MultiTransactionSyncTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class MultiTransactionSyncTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   protected var spark: SparkSession = _
 

--- a/src/test/scala/io/indextables/spark/sync/StringFieldQueryTypeBugTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/StringFieldQueryTypeBugTest.scala
@@ -38,7 +38,11 @@ import org.scalatest.BeforeAndAfterAll
  *
  * See TANTIVY4JAVA_STRING_FIELD_TYPE_BUG.md for root cause details.
  */
-class StringFieldQueryTypeBugTest extends AnyFunSuite with Matchers with BeforeAndAfterAll with io.indextables.spark.testutils.FileCleanupHelper {
+class StringFieldQueryTypeBugTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
 
   private val FORMAT = io.indextables.spark.TestBase.INDEXTABLES_FORMAT
 

--- a/src/test/scala/io/indextables/spark/testutils/TestCredentialProviders.scala
+++ b/src/test/scala/io/indextables/spark/testutils/TestCredentialProviders.scala
@@ -109,8 +109,8 @@ class TestDualCredentialProvider(uri: URI, conf: Configuration)
  * Mock credential provider that implements both AWSCredentialsProvider (path-based, used by Priority 2) and
  * TableCredentialProvider companion (table-ID-based, used by Priority 1.5).
  *
- * Used by TransactionLogFactoryCredentialIsolationTest to verify that the destination txlog credential
- * resolution does NOT use the source table's uc.tableId (regression guard for the UC companion bug).
+ * Used by TransactionLogFactoryCredentialIsolationTest to verify that the destination txlog credential resolution does
+ * NOT use the source table's uc.tableId (regression guard for the UC companion bug).
  *
  * Access keys encode which resolution path was taken so tests can assert the difference:
  *   - Path-based (correct for destination): "path-based-key:<uri>"

--- a/src/test/scala/io/indextables/spark/transaction/ConfigMapperTest.scala
+++ b/src/test/scala/io/indextables/spark/transaction/ConfigMapperTest.scala
@@ -20,6 +20,7 @@ package io.indextables.spark.transaction
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -36,24 +37,24 @@ class ConfigMapperTest extends AnyFunSuite with Matchers {
   // ------------------------------------------------------------------------------------
   test("both overloads produce identical output for the same input") {
     val input = Map(
-      "spark.indextables.aws.accessKey"                         -> "AKID",
-      "spark.indextables.aws.secretKey"                         -> "SECRET",
-      "spark.indextables.aws.region"                            -> "us-west-2",
-      "spark.indextables.azure.accountName"                     -> "myaccount",
-      "spark.indextables.transaction.cache.enabled"             -> "false",
-      "spark.indextables.transaction.cache.ttl.ms"              -> "60000",
-      "spark.indextables.transaction.cache.version.ttl.ms"      -> "120000",
-      "spark.indextables.transaction.cache.snapshot.ttl.ms"     -> "240000",
-      "spark.indextables.transaction.cache.fileList.ttl.ms"     -> "30000",
-      "spark.indextables.transaction.cache.metadata.ttl.ms"     -> "900000",
-      "spark.indextables.transaction.cache.version.capacity"    -> "500",
-      "spark.indextables.transaction.cache.snapshot.capacity"   -> "50",
-      "spark.indextables.transaction.cache.fileList.capacity"   -> "25",
-      "spark.indextables.transaction.maxConcurrentReads"        -> "48",
-      "spark.indextables.checkpoint.interval"                   -> "5"
+      "spark.indextables.aws.accessKey"                       -> "AKID",
+      "spark.indextables.aws.secretKey"                       -> "SECRET",
+      "spark.indextables.aws.region"                          -> "us-west-2",
+      "spark.indextables.azure.accountName"                   -> "myaccount",
+      "spark.indextables.transaction.cache.enabled"           -> "false",
+      "spark.indextables.transaction.cache.ttl.ms"            -> "60000",
+      "spark.indextables.transaction.cache.version.ttl.ms"    -> "120000",
+      "spark.indextables.transaction.cache.snapshot.ttl.ms"   -> "240000",
+      "spark.indextables.transaction.cache.fileList.ttl.ms"   -> "30000",
+      "spark.indextables.transaction.cache.metadata.ttl.ms"   -> "900000",
+      "spark.indextables.transaction.cache.version.capacity"  -> "500",
+      "spark.indextables.transaction.cache.snapshot.capacity" -> "50",
+      "spark.indextables.transaction.cache.fileList.capacity" -> "25",
+      "spark.indextables.transaction.maxConcurrentReads"      -> "48",
+      "spark.indextables.checkpoint.interval"                 -> "5"
     )
 
-    val fromCsMap   = ConfigMapper.toNativeConfig(csMap(input.toSeq: _*))
+    val fromCsMap    = ConfigMapper.toNativeConfig(csMap(input.toSeq: _*))
     val fromScalaMap = ConfigMapper.toNativeConfig(input)
 
     fromCsMap.asScala.toMap shouldBe fromScalaMap.asScala.toMap
@@ -63,55 +64,65 @@ class ConfigMapperTest extends AnyFunSuite with Matchers {
   // AWS credential mapping
   // ------------------------------------------------------------------------------------
   test("AWS credentials are mapped correctly") {
-    val config = ConfigMapper.toNativeConfig(Map(
-      "spark.indextables.aws.accessKey"     -> "AKID",
-      "spark.indextables.aws.secretKey"     -> "SECRET",
-      "spark.indextables.aws.sessionToken"  -> "TOKEN",
-      "spark.indextables.aws.region"        -> "eu-west-1",
-      "spark.indextables.aws.endpoint"      -> "http://localhost:9000",
-      "spark.indextables.aws.forcePathStyle" -> "true"
-    ))
+    val config = ConfigMapper.toNativeConfig(
+      Map(
+        "spark.indextables.aws.accessKey"      -> "AKID",
+        "spark.indextables.aws.secretKey"      -> "SECRET",
+        "spark.indextables.aws.sessionToken"   -> "TOKEN",
+        "spark.indextables.aws.region"         -> "eu-west-1",
+        "spark.indextables.aws.endpoint"       -> "http://localhost:9000",
+        "spark.indextables.aws.forcePathStyle" -> "true"
+      )
+    )
 
-    config.get("aws_access_key_id")     shouldBe "AKID"
+    config.get("aws_access_key_id") shouldBe "AKID"
     config.get("aws_secret_access_key") shouldBe "SECRET"
-    config.get("aws_session_token")     shouldBe "TOKEN"
-    config.get("aws_region")            shouldBe "eu-west-1"
-    config.get("aws_endpoint")          shouldBe "http://localhost:9000"
-    config.get("aws_force_path_style")  shouldBe "true"
+    config.get("aws_session_token") shouldBe "TOKEN"
+    config.get("aws_region") shouldBe "eu-west-1"
+    config.get("aws_endpoint") shouldBe "http://localhost:9000"
+    config.get("aws_force_path_style") shouldBe "true"
   }
 
   // ------------------------------------------------------------------------------------
   // S3 alternate keys with priority
   // ------------------------------------------------------------------------------------
   test("S3 alternate endpoint does not override primary AWS endpoint") {
-    val config = ConfigMapper.toNativeConfig(Map(
-      "spark.indextables.aws.endpoint" -> "http://primary:9000",
-      "spark.indextables.s3.endpoint"  -> "http://alternate:9000"
-    ))
+    val config = ConfigMapper.toNativeConfig(
+      Map(
+        "spark.indextables.aws.endpoint" -> "http://primary:9000",
+        "spark.indextables.s3.endpoint"  -> "http://alternate:9000"
+      )
+    )
 
     config.get("aws_endpoint") shouldBe "http://primary:9000"
   }
 
   test("S3 alternate endpoint is used when primary AWS endpoint is absent") {
-    val config = ConfigMapper.toNativeConfig(Map(
-      "spark.indextables.s3.endpoint" -> "http://alternate:9000"
-    ))
+    val config = ConfigMapper.toNativeConfig(
+      Map(
+        "spark.indextables.s3.endpoint" -> "http://alternate:9000"
+      )
+    )
 
     config.get("aws_endpoint") shouldBe "http://alternate:9000"
   }
 
   test("S3 pathStyleAccess sets aws_force_path_style when true") {
-    val config = ConfigMapper.toNativeConfig(Map(
-      "spark.indextables.s3.pathStyleAccess" -> "true"
-    ))
+    val config = ConfigMapper.toNativeConfig(
+      Map(
+        "spark.indextables.s3.pathStyleAccess" -> "true"
+      )
+    )
 
     config.get("aws_force_path_style") shouldBe "true"
   }
 
   test("S3 pathStyleAccess does not set aws_force_path_style when false") {
-    val config = ConfigMapper.toNativeConfig(Map(
-      "spark.indextables.s3.pathStyleAccess" -> "false"
-    ))
+    val config = ConfigMapper.toNativeConfig(
+      Map(
+        "spark.indextables.s3.pathStyleAccess" -> "false"
+      )
+    )
 
     config.containsKey("aws_force_path_style") shouldBe false
   }
@@ -120,14 +131,16 @@ class ConfigMapperTest extends AnyFunSuite with Matchers {
   // Azure credential mapping
   // ------------------------------------------------------------------------------------
   test("Azure credentials are mapped correctly") {
-    val config = ConfigMapper.toNativeConfig(Map(
-      "spark.indextables.azure.accountName" -> "myaccount",
-      "spark.indextables.azure.accountKey"  -> "mykey",
-      "spark.indextables.azure.bearerToken" -> "mytoken"
-    ))
+    val config = ConfigMapper.toNativeConfig(
+      Map(
+        "spark.indextables.azure.accountName" -> "myaccount",
+        "spark.indextables.azure.accountKey"  -> "mykey",
+        "spark.indextables.azure.bearerToken" -> "mytoken"
+      )
+    )
 
     config.get("azure_account_name") shouldBe "myaccount"
-    config.get("azure_access_key")   shouldBe "mykey"
+    config.get("azure_access_key") shouldBe "mykey"
     config.get("azure_bearer_token") shouldBe "mytoken"
   }
 
@@ -135,25 +148,27 @@ class ConfigMapperTest extends AnyFunSuite with Matchers {
   // Transaction log cache configuration
   // ------------------------------------------------------------------------------------
   test("cache configuration keys are mapped with correct native names") {
-    val config = ConfigMapper.toNativeConfig(Map(
-      "spark.indextables.transaction.cache.enabled"            -> "false",
-      "spark.indextables.transaction.cache.ttl.ms"             -> "60000",
-      "spark.indextables.transaction.cache.version.ttl.ms"     -> "120000",
-      "spark.indextables.transaction.cache.snapshot.ttl.ms"    -> "240000",
-      "spark.indextables.transaction.cache.fileList.ttl.ms"    -> "30000",
-      "spark.indextables.transaction.cache.metadata.ttl.ms"    -> "900000",
-      "spark.indextables.transaction.cache.version.capacity"   -> "500",
-      "spark.indextables.transaction.cache.snapshot.capacity"   -> "50",
-      "spark.indextables.transaction.cache.fileList.capacity"  -> "25"
-    ))
+    val config = ConfigMapper.toNativeConfig(
+      Map(
+        "spark.indextables.transaction.cache.enabled"           -> "false",
+        "spark.indextables.transaction.cache.ttl.ms"            -> "60000",
+        "spark.indextables.transaction.cache.version.ttl.ms"    -> "120000",
+        "spark.indextables.transaction.cache.snapshot.ttl.ms"   -> "240000",
+        "spark.indextables.transaction.cache.fileList.ttl.ms"   -> "30000",
+        "spark.indextables.transaction.cache.metadata.ttl.ms"   -> "900000",
+        "spark.indextables.transaction.cache.version.capacity"  -> "500",
+        "spark.indextables.transaction.cache.snapshot.capacity" -> "50",
+        "spark.indextables.transaction.cache.fileList.capacity" -> "25"
+      )
+    )
 
-    config.get("cache.enabled")           shouldBe "false"
-    config.get("cache.ttl.ms")            shouldBe "60000"
-    config.get("cache.version.ttl.ms")    shouldBe "120000"
-    config.get("cache.snapshot.ttl.ms")   shouldBe "240000"
-    config.get("cache.file_list.ttl.ms")  shouldBe "30000"
-    config.get("cache.metadata.ttl.ms")   shouldBe "900000"
-    config.get("cache.version.capacity")  shouldBe "500"
+    config.get("cache.enabled") shouldBe "false"
+    config.get("cache.ttl.ms") shouldBe "60000"
+    config.get("cache.version.ttl.ms") shouldBe "120000"
+    config.get("cache.snapshot.ttl.ms") shouldBe "240000"
+    config.get("cache.file_list.ttl.ms") shouldBe "30000"
+    config.get("cache.metadata.ttl.ms") shouldBe "900000"
+    config.get("cache.version.capacity") shouldBe "500"
     config.get("cache.snapshot.capacity") shouldBe "50"
     config.get("cache.file_list.capacity") shouldBe "25"
   }
@@ -162,17 +177,21 @@ class ConfigMapperTest extends AnyFunSuite with Matchers {
   // Concurrency and checkpoint
   // ------------------------------------------------------------------------------------
   test("maxConcurrentReads is mapped correctly") {
-    val config = ConfigMapper.toNativeConfig(Map(
-      "spark.indextables.transaction.maxConcurrentReads" -> "48"
-    ))
+    val config = ConfigMapper.toNativeConfig(
+      Map(
+        "spark.indextables.transaction.maxConcurrentReads" -> "48"
+      )
+    )
 
     config.get("max_concurrent_reads") shouldBe "48"
   }
 
   test("checkpoint interval is mapped correctly") {
-    val config = ConfigMapper.toNativeConfig(Map(
-      "spark.indextables.checkpoint.interval" -> "5"
-    ))
+    val config = ConfigMapper.toNativeConfig(
+      Map(
+        "spark.indextables.checkpoint.interval" -> "5"
+      )
+    )
 
     config.get("checkpoint_interval") shouldBe "5"
   }
@@ -186,10 +205,12 @@ class ConfigMapperTest extends AnyFunSuite with Matchers {
   }
 
   test("unrelated keys are not included in native config") {
-    val config = ConfigMapper.toNativeConfig(Map(
-      "spark.indextables.indexWriter.heapSize" -> "200M",
-      "spark.sql.shuffle.partitions"           -> "100"
-    ))
+    val config = ConfigMapper.toNativeConfig(
+      Map(
+        "spark.indextables.indexWriter.heapSize" -> "200M",
+        "spark.sql.shuffle.partitions"           -> "100"
+      )
+    )
 
     config.size() shouldBe 0
   }
@@ -198,12 +219,14 @@ class ConfigMapperTest extends AnyFunSuite with Matchers {
   // CaseInsensitiveStringMap overload — case insensitivity
   // ------------------------------------------------------------------------------------
   test("CaseInsensitiveStringMap overload handles case-insensitive keys") {
-    val config = ConfigMapper.toNativeConfig(csMap(
-      "SPARK.INDEXTABLES.AWS.ACCESSKEY" -> "AKID",
-      "Spark.Indextables.Aws.Region"    -> "us-east-1"
-    ))
+    val config = ConfigMapper.toNativeConfig(
+      csMap(
+        "SPARK.INDEXTABLES.AWS.ACCESSKEY" -> "AKID",
+        "Spark.Indextables.Aws.Region"    -> "us-east-1"
+      )
+    )
 
     config.get("aws_access_key_id") shouldBe "AKID"
-    config.get("aws_region")        shouldBe "us-east-1"
+    config.get("aws_region") shouldBe "us-east-1"
   }
 }

--- a/src/test/scala/io/indextables/spark/transaction/TransactionLogFactoryCredentialIsolationTest.scala
+++ b/src/test/scala/io/indextables/spark/transaction/TransactionLogFactoryCredentialIsolationTest.scala
@@ -23,26 +23,25 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 import org.apache.hadoop.fs.Path
 
-import io.indextables.spark.TestBase
 import io.indextables.spark.utils.CredentialProviderFactory
+import io.indextables.spark.TestBase
 
 /**
  * Regression tests for the Unity Catalog companion build credential isolation bug.
  *
- * Bug: When BUILD INDEXTABLES COMPANION was run for a UC Delta/Iceberg source table,
- * SyncToExternalCommand injected spark.indextables.iceberg.uc.tableId (the SOURCE table's ID)
- * into mergedConfigs, then passed those configs to TransactionLogFactory.create() for the
- * DESTINATION txlog. TransactionLogFactory.create() called resolveCredentialsOnDriver() which
- * hit Priority 1.5 (table-based credentials), using the source table's ID to fetch credentials
- * scoped to the source table's S3 path — not the destination. This caused auth failures when
- * writing the companion index transaction log.
+ * Bug: When BUILD INDEXTABLES COMPANION was run for a UC Delta/Iceberg source table, SyncToExternalCommand injected
+ * spark.indextables.iceberg.uc.tableId (the SOURCE table's ID) into mergedConfigs, then passed those configs to
+ * TransactionLogFactory.create() for the DESTINATION txlog. TransactionLogFactory.create() called
+ * resolveCredentialsOnDriver() which hit Priority 1.5 (table-based credentials), using the source table's ID to fetch
+ * credentials scoped to the source table's S3 path — not the destination. This caused auth failures when writing the
+ * companion index transaction log.
  *
  * Fix: TransactionLogFactory.create() strips spark.indextables.iceberg.uc.tableId before calling
- * resolveCredentialsOnDriver(), falling through to Priority 2 (path-based credential resolution)
- * which correctly fetches credentials for the destination txlog path.
+ * resolveCredentialsOnDriver(), falling through to Priority 2 (path-based credential resolution) which correctly
+ * fetches credentials for the destination txlog path.
  *
- * See also: MockTableCredentialProvider in TestCredentialProviders.scala, which encodes the
- * resolution path in the access key string for assertions.
+ * See also: MockTableCredentialProvider in TestCredentialProviders.scala, which encodes the resolution path in the
+ * access key string for assertions.
  */
 class TransactionLogFactoryCredentialIsolationTest extends TestBase {
 
@@ -50,11 +49,11 @@ class TransactionLogFactoryCredentialIsolationTest extends TestBase {
     "io.indextables.spark.testutils.MockTableCredentialProvider"
 
   /**
-   * Documents the bug: resolveCredentialsOnDriver with uc.tableId present triggers Priority 1.5
-   * and returns source-table-scoped credentials (wrong for destination).
+   * Documents the bug: resolveCredentialsOnDriver with uc.tableId present triggers Priority 1.5 and returns
+   * source-table-scoped credentials (wrong for destination).
    *
-   * This test documents the pre-fix behavior so the regression is clearly understood.
-   * It does NOT call TransactionLogFactory — it tests CredentialProviderFactory directly.
+   * This test documents the pre-fix behavior so the regression is clearly understood. It does NOT call
+   * TransactionLogFactory — it tests CredentialProviderFactory directly.
    */
   test("resolveCredentialsOnDriver uses table credentials when uc.tableId is present (documents bug path)") {
     val sourceTableId = "source-uc-table-id-abc123"
@@ -75,8 +74,8 @@ class TransactionLogFactoryCredentialIsolationTest extends TestBase {
   }
 
   /**
-   * Documents the fix: resolveCredentialsOnDriver without uc.tableId falls through to Priority 2
-   * and returns path-based credentials (correct for destination).
+   * Documents the fix: resolveCredentialsOnDriver without uc.tableId falls through to Priority 2 and returns path-based
+   * credentials (correct for destination).
    */
   test("resolveCredentialsOnDriver uses path credentials when uc.tableId is absent (correct for destination)") {
     val destPath = "s3://companion-index-dest/my-index"
@@ -96,12 +95,12 @@ class TransactionLogFactoryCredentialIsolationTest extends TestBase {
   }
 
   /**
-   * Core regression test: TransactionLogFactory.create() must NOT use the source uc.tableId to
-   * resolve credentials for the destination txlog. Before the fix, the source table's credentials
-   * were fetched (table-based path) and used for the destination, causing auth failures.
+   * Core regression test: TransactionLogFactory.create() must NOT use the source uc.tableId to resolve credentials for
+   * the destination txlog. Before the fix, the source table's credentials were fetched (table-based path) and used for
+   * the destination, causing auth failures.
    *
-   * After the fix, uc.tableId is stripped before resolveCredentialsOnDriver is called, so
-   * path-based credentials (correct for the destination) are used instead.
+   * After the fix, uc.tableId is stripped before resolveCredentialsOnDriver is called, so path-based credentials
+   * (correct for the destination) are used instead.
    */
   test("TransactionLogFactory.create() does not use source uc.tableId for destination credential resolution") {
     import io.indextables.spark.testutils.MockTableCredentialProvider
@@ -123,9 +122,9 @@ class TransactionLogFactoryCredentialIsolationTest extends TestBase {
       // so Priority 1.5 (table-based) is bypassed and Priority 2 (path-based) is used instead.
       // If the fix is removed, tableCredentialCallCount would be > 0.
       val txlog = TransactionLogFactory.create(new Path(destPath), spark, options)
-      try {
+      try
         txlog.initialize(getTestSchema())
-      } finally
+      finally
         txlog.close()
 
       // Table-based credentials must NOT have been invoked for the destination txlog
@@ -136,12 +135,12 @@ class TransactionLogFactoryCredentialIsolationTest extends TestBase {
   }
 
   /**
-   * Integration-level regression test: TransactionLogFactory.create() must succeed (not throw)
-   * when uc.tableId is present in the options, and must create a usable txlog at the destination.
+   * Integration-level regression test: TransactionLogFactory.create() must succeed (not throw) when uc.tableId is
+   * present in the options, and must create a usable txlog at the destination.
    *
-   * Before the fix, if the table-based credential resolution returned source-scoped credentials
-   * that were incompatible with the destination, the txlog initialization would fail on the first
-   * actual storage operation (e.g., initialize() writing to the destination path).
+   * Before the fix, if the table-based credential resolution returned source-scoped credentials that were incompatible
+   * with the destination, the txlog initialization would fail on the first actual storage operation (e.g., initialize()
+   * writing to the destination path).
    */
   test("TransactionLogFactory.create() succeeds with uc.tableId in configs and produces a writable txlog") {
     withTempPath { destPath =>
@@ -166,12 +165,12 @@ class TransactionLogFactoryCredentialIsolationTest extends TestBase {
   }
 
   /**
-   * Verifies that uc.tableId in the options is still available for SOURCE reads (not stripped
-   * from the configs used to initialize IcebergSourceReader / DeltaSourceReader).
+   * Verifies that uc.tableId in the options is still available for SOURCE reads (not stripped from the configs used to
+   * initialize IcebergSourceReader / DeltaSourceReader).
    *
-   * The fix strips uc.tableId only inside TransactionLogFactory.create() (for destination auth);
-   * the original mergedConfigs in SyncToExternalCommand must retain it for source credential
-   * resolution via resolveCredentials(mergedConfigs, sourcePath).
+   * The fix strips uc.tableId only inside TransactionLogFactory.create() (for destination auth); the original
+   * mergedConfigs in SyncToExternalCommand must retain it for source credential resolution via
+   * resolveCredentials(mergedConfigs, sourcePath).
    */
   test("uc.tableId is still usable for source credential resolution after the fix") {
     val sourceTableId = "source-uc-table-id-for-read"
@@ -192,17 +191,16 @@ class TransactionLogFactoryCredentialIsolationTest extends TestBase {
   }
 
   /**
-   * Regression test: NativeTransactionLog must re-invoke the credential provider before each
-   * write operation, not just once at construction time.
+   * Regression test: NativeTransactionLog must re-invoke the credential provider before each write operation, not just
+   * once at construction time.
    *
    * This matches the old S3CloudStorageProvider behaviour, which wrapped the provider in
-   * V1ToV2CredentialsProviderAdapter so the AWS SDK re-invoked it before every storage call.
-   * Without per-write refresh, credentials (typical UC TTL ~1 hour) expire during long-running
-   * companion builds, causing auth failures.
+   * V1ToV2CredentialsProviderAdapter so the AWS SDK re-invoked it before every storage call. Without per-write refresh,
+   * credentials (typical UC TTL ~1 hour) expire during long-running companion builds, causing auth failures.
    *
-   * We verify by counting how many times MockTableCredentialProvider.getCredentials() is called
-   * across multiple writes. With the fix, the path-based provider must be invoked at least once
-   * per write; without it (static credentials only), the count stays at 0 after construction.
+   * We verify by counting how many times MockTableCredentialProvider.getCredentials() is called across multiple writes.
+   * With the fix, the path-based provider must be invoked at least once per write; without it (static credentials
+   * only), the count stays at 0 after construction.
    */
   test("NativeTransactionLog re-invokes the credential provider on each write (not just at construction)") {
     import io.indextables.spark.testutils.MockTableCredentialProvider
@@ -248,16 +246,15 @@ class TransactionLogFactoryCredentialIsolationTest extends TestBase {
   }
 
   /**
-   * Regression test: NativeTransactionLog must re-invoke the credential provider before each
-   * READ operation (listFiles, getSnapshot), not just before writes.
+   * Regression test: NativeTransactionLog must re-invoke the credential provider before each READ operation (listFiles,
+   * getSnapshot), not just before writes.
    *
-   * The old S3CloudStorageProvider re-invoked the credential provider before every S3 operation,
-   * including reads (listFiles triggered S3 calls on each invocation). Without per-read refresh,
-   * long-running Spark queries against companion tables will fail after ~1 hour when UC
-   * credentials in nativeConfig expire.
+   * The old S3CloudStorageProvider re-invoked the credential provider before every S3 operation, including reads
+   * (listFiles triggered S3 calls on each invocation). Without per-read refresh, long-running Spark queries against
+   * companion tables will fail after ~1 hour when UC credentials in nativeConfig expire.
    *
-   * Both listFilesArrow() and getOrRefreshSnapshot() now call refreshCredentials() at entry,
-   * matching the write-path pattern. This test verifies both paths.
+   * Both listFilesArrow() and getOrRefreshSnapshot() now call refreshCredentials() at entry, matching the write-path
+   * pattern. This test verifies both paths.
    */
   test("NativeTransactionLog re-invokes the credential provider on each read operation") {
     import io.indextables.spark.testutils.MockTableCredentialProvider

--- a/src/test/scala/io/indextables/spark/write/OptimizedWriteIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/write/OptimizedWriteIntegrationTest.scala
@@ -32,9 +32,8 @@ class OptimizedWriteIntegrationTest extends TestBase {
   private val GB     = 1024L * 1024 * 1024
 
   // Helper to create a TransactionLog for direct API testing
-  private def createTxLog(tablePath: Path): TransactionLogInterface = {
+  private def createTxLog(tablePath: Path): TransactionLogInterface =
     TransactionLogFactory.create(tablePath, spark)
-  }
 
   // Helper to create a WriteBuilder for API testing
   private def createWriteBuilder(


### PR DESCRIPTION
## Summary
- Ran `mvn spotless:apply` to format all Scala source files
- 135 files were reformatted, 412 were already clean

## Test plan
- [ ] Verify CI passes (formatting-only change, no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)