### PR TITLE
Bump JAR URL version to 0.5.5 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ IndexTables runs entirely within your existing Spark cluster with no additional 
 
 ### Installation
 
-1. Add the [IndexTables JAR](https://repo1.maven.org/maven2/io/indextables/indextables_spark/0.5.4_spark_3.5.3/indextables_spark-0.5.4_spark_3.5.3-linux-x86_64-shaded.jar) to your Spark classpath
+1. Add the [IndexTables JAR](https://repo1.maven.org/maven2/io/indextables/indextables_spark/0.5.5_spark_3.5.3/indextables_spark-0.5.5_spark_3.5.3-linux-x86_64-shaded.jar) to your Spark classpath
 2. Set `spark.sql.extensions=io.indextables.extensions.IndexTablesSparkExtensions`
 3. Requires Java 11+
 


### PR DESCRIPTION
## Summary
- Updates the Quick Start installation JAR URL from `0.5.4_spark_3.5.3` to `0.5.5_spark_3.5.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)