### PR TITLE
Add docs/walkthrough covering module structure and relationships

### DIFF
--- a/docs/walkthrough/01-entry-points.md
+++ b/docs/walkthrough/01-entry-points.md
@@ -26,8 +26,8 @@ Configuration merging (Spark session conf → Hadoop conf → write/read options
 The real implementation behind the public alias. As a `SparkSessionExtensions => Unit` function it:
 
 - Injects `sql/IndexTables4SparkSqlParser` so the custom `MERGE SPLITS`, `PURGE INDEXTABLE`, `DESCRIBE INDEXTABLES …` grammar is recognized.
-- Registers the SQL functions `tantivy4spark_indexquery`, `indextables_date_histogram`, `indextables_histogram`, `indextables_range`, and friends via `expressions/BucketFunctionBuilder`.
-- Injects two optimizer rules from `catalyst/`:
+- Registers the SQL functions. The IndexQuery functions (`tantivy4spark_indexquery`, `tantivy4spark_indexqueryall`) are registered with inline lambdas that instantiate `IndexQueryExpression` / `IndexQueryAllExpression` directly. The bucket functions (`indextables_date_histogram`, `indextables_histogram`, `indextables_range`) route through `expressions/BucketFunctionBuilder`.
+- Injects two resolution rules from `catalyst/` (via `injectResolutionRule`, so they run during the analysis phase):
   - `V2IndexQueryExpressionRule` — rewrites IndexQuery expressions into pushdown-friendly V2 filters.
   - `V2BucketExpressionRule` — rewrites bucket aggregation expressions in `GROUP BY` clauses.
 
@@ -48,9 +48,10 @@ user: spark.sql.extensions = "io.indextables.extensions.IndexTablesSparkExtensio
   └─ extensions/IndexTablesSparkExtensions
        └─ spark/extensions/IndexTables4SparkExtensions
             ├─ sql/IndexTables4SparkSqlParser         (chapter 08)
-            ├─ catalyst/V2IndexQueryExpressionRule    (chapter 02)
-            ├─ catalyst/V2BucketExpressionRule        (chapter 02)
-            └─ expressions/BucketFunctionBuilder       (chapter 05)
+            ├─ catalyst/V2IndexQueryExpressionRule    (resolution rule — chapter 02)
+            ├─ catalyst/V2BucketExpressionRule        (resolution rule — chapter 02)
+            ├─ injectFunction(tantivy4spark_indexquery…)     (inline lambdas)
+            └─ expressions/BucketFunctionBuilder       (bucket fns — chapter 05)
 ```
 
 The next chapter follows the read path from `IndexTables4SparkTable.newScanBuilder()` all the way down to the Tantivy split.

--- a/docs/walkthrough/01-entry-points.md
+++ b/docs/walkthrough/01-entry-points.md
@@ -1,0 +1,56 @@
+# 01 — Entry Points
+
+These are the classes Spark discovers first: the `TableProvider` that backs `spark.read.format(...)` and `df.write.format(...)`, and the `SparkSessionExtensions` that registers the custom SQL parser and optimizer rules.
+
+## Public aliases
+
+These classes exist so that user code never has to import the `spark.*` internal packages. They are thin subclasses that add no behavior — everything lives in the internal implementation classes.
+
+### `provider/IndexTablesProvider.scala`
+Public alias for the DataSource V2 `TableProvider`. Users write `df.write.format("io.indextables.provider.IndexTablesProvider")`. It extends `IndexTables4SparkTableProvider` and is otherwise empty. The internal class name (`io.indextables.spark.core.IndexTables4SparkTableProvider`) is still valid and is used extensively in the test suite — the two are interchangeable.
+
+### `extensions/IndexTablesSparkExtensions.scala`
+Public alias for `IndexTables4SparkExtensions`. Used in `spark.sql.extensions` configuration to register the SQL parser, catalyst rules, and bucket functions.
+
+## Internal entry points
+
+### `spark/core/IndexTables4SparkDataSource.scala`
+This is the primary DataSource V2 entry point. It defines:
+
+- **`IndexTables4SparkTableProvider`** — implements `TableProvider` and `DataSourceRegister` (short name `"indextables"`). Responsible for schema inference from the transaction log and delegating table creation.
+- **`IndexTables4SparkTable`** — implements `SupportsRead` and `SupportsWrite`. Holds the table path, schema, and options, and hands off to a `ScanBuilder` or `WriteBuilder`. It also owns the lifecycle of the `TransactionLog` cache for a given logical table.
+
+Configuration merging (Spark session conf → Hadoop conf → write/read options) happens here with well-defined precedence, so downstream code can read from a single `CaseInsensitiveStringMap`.
+
+### `spark/extensions/IndexTables4SparkExtensions.scala`
+The real implementation behind the public alias. As a `SparkSessionExtensions => Unit` function it:
+
+- Injects `sql/IndexTables4SparkSqlParser` so the custom `MERGE SPLITS`, `PURGE INDEXTABLE`, `DESCRIBE INDEXTABLES …` grammar is recognized.
+- Registers the SQL functions `tantivy4spark_indexquery`, `indextables_date_histogram`, `indextables_histogram`, `indextables_range`, and friends via `expressions/BucketFunctionBuilder`.
+- Injects two optimizer rules from `catalyst/`:
+  - `V2IndexQueryExpressionRule` — rewrites IndexQuery expressions into pushdown-friendly V2 filters.
+  - `V2BucketExpressionRule` — rewrites bucket aggregation expressions in `GROUP BY` clauses.
+
+### `spark/sql/IndexTables4SparkSessionExtension.scala`
+A second, narrower `SparkSessionExtensions` hook. It exists so the custom SQL parser can be installed without also registering the Catalyst rules (used in a handful of embedded contexts). The parent extensions class delegates to this for parser installation.
+
+## Relationships
+
+```
+user: spark.read.format("io.indextables.provider.IndexTablesProvider")
+  └─ provider/IndexTablesProvider
+       └─ core/IndexTables4SparkTableProvider     (schema inference)
+            └─ core/IndexTables4SparkTable         (SupportsRead/SupportsWrite)
+                 ├─ core/IndexTables4SparkScanBuilder   (read — chapter 02)
+                 └─ core/IndexTables4SparkWriteBuilder  (write — chapter 03)
+
+user: spark.sql.extensions = "io.indextables.extensions.IndexTablesSparkExtensions"
+  └─ extensions/IndexTablesSparkExtensions
+       └─ spark/extensions/IndexTables4SparkExtensions
+            ├─ sql/IndexTables4SparkSqlParser         (chapter 08)
+            ├─ catalyst/V2IndexQueryExpressionRule    (chapter 02)
+            ├─ catalyst/V2BucketExpressionRule        (chapter 02)
+            └─ expressions/BucketFunctionBuilder       (chapter 05)
+```
+
+The next chapter follows the read path from `IndexTables4SparkTable.newScanBuilder()` all the way down to the Tantivy split.

--- a/docs/walkthrough/02-read-path.md
+++ b/docs/walkthrough/02-read-path.md
@@ -22,13 +22,12 @@ The main scan for row-producing queries. Implements `Scan` and `SupportsReportSt
 - Builds a `PartitionReaderFactory` that dispatches to the right columnar reader.
 
 ### `core/IndexTables4SparkPartitions.scala`
-Defines the `InputPartition` classes that the scan emits:
+Defines the two `InputPartition` classes that the standard-row scan emits:
 
-- `IndexTables4SparkStandardPartition` — rows or projections.
-- `IndexTables4SparkSimpleAggregatePartition` — COUNT/SUM/AVG/MIN/MAX without grouping.
-- `IndexTables4SparkGroupByAggregatePartition` — GROUP BY including bucket aggregations.
+- `IndexTables4SparkInputPartition` — one split per Spark task.
+- `IndexTables4SparkMultiSplitInputPartition` — multiple splits per Spark task (the default on larger tables, so one task can early-terminate across splits when a `LIMIT` is pushed down).
 
-Each partition carries a serialized list of `AddAction`s and enough config to rebuild a `SplitSearchEngine` on the executor.
+Each partition carries a serialized list of `AddAction`s and enough config to rebuild a `SplitSearchEngine` on the executor. Aggregate scans define their own partition classes inside the aggregate scan files rather than here.
 
 ### `core/IndexTables4SparkStatistics.scala`
 Implements Spark's `Statistics` so the optimizer can cost-estimate an IndexTables scan. Numbers come from the `numRecords` and `sizeInBytes` fields of `AddAction` plus per-column min/max stats when present.
@@ -79,7 +78,7 @@ Used by the reader to translate between a Spark `StructType` and the Tantivy sch
 
 ## Catalyst rules
 
-These rules run inside the Spark optimizer after the DataSource V2 logical plan is built and must coordinate with `IndexTables4SparkScanBuilder` via `ThreadLocal`s.
+These rules are injected as *resolution* rules (via `injectResolutionRule`), so they run during the analysis phase — before the logical plan has been fully optimized. That placement matters: resolution rules can still see unresolved attributes and run early enough to shape what the DataSource V2 pushdown machinery later sees. They coordinate with `IndexTables4SparkScanBuilder` via `ThreadLocal`s.
 
 ### `catalyst/V2IndexQueryExpressionRule.scala`
 Finds `IndexQueryExpression` and `IndexQueryAllExpression` nodes in the logical plan and rewrites them as `IndexQueryV2Filter` so Spark pushes them through its filter interfaces. It also clears stale ThreadLocal state between analysis and optimization phases (which is important for multi-statement sessions).
@@ -127,7 +126,7 @@ IndexTables4SparkTable.newScanBuilder
 
 Scan.planInputPartitions()
  → transaction log list + partition pruning
- → IndexTables4SparkPartitions (Standard / SimpleAgg / GroupByAgg)
+ → IndexTables4SparkInputPartition / IndexTables4SparkMultiSplitInputPartition
      └─ on executor: PartitionReader
          ├─ SplitReaderContext            (shared setup)
          ├─ SplitSearchEngine             (search/)

--- a/docs/walkthrough/02-read-path.md
+++ b/docs/walkthrough/02-read-path.md
@@ -1,0 +1,113 @@
+# 02 — Read Path
+
+This chapter covers everything that happens between `spark.read.format(...).load(path)` and a `ColumnarBatch` flowing into Spark. It lives primarily in `spark/core/` and `spark/catalyst/`.
+
+## The scan pipeline
+
+### `core/IndexTables4SparkScanBuilder.scala`
+The first step for a read. Implements `ScanBuilder` plus every `SupportsPushDown*` interface Spark exposes (`SupportsPushDownFilters`, `SupportsPushDownAggregates`, `SupportsPushDownLimit`, and related). Its responsibilities:
+
+- Convert Spark filters to Tantivy queries via `core/FiltersToQueryConverter`.
+- Recognize `IndexQueryFilter` / `IndexQueryAllFilter` wrappers injected by the catalyst rules.
+- Detect aggregation plans (simple aggregate vs GROUP BY) and bucket expressions.
+- Store per-relation pushdown state in a `ThreadLocal` that the catalyst rules also use to coordinate with the optimizer.
+- Decide which `Scan` implementation to build (`IndexTables4SparkScan`, `SimpleAggregateScan`, `GroupByAggregateScan`, or `TransactionLogCountScan`).
+
+### `core/IndexTables4SparkScan.scala`
+The main scan for row-producing queries. Implements `Scan` and `SupportsReportStatistics`. It:
+
+- Uses the transaction log to list `AddAction`s.
+- Applies partition pruning via `transaction/PartitionPredicateUtils` and `transaction/SparkFilterToNativeFilter`.
+- Packs splits into Spark tasks (configurable splits-per-task), reporting locality from `storage/DriverSplitLocalityManager`.
+- Builds a `PartitionReaderFactory` that dispatches to the right columnar reader.
+
+### `core/IndexTables4SparkPartitions.scala`
+Defines the `InputPartition` classes that the scan emits:
+
+- `IndexTables4SparkStandardPartition` — rows or projections.
+- `IndexTables4SparkSimpleAggregatePartition` — COUNT/SUM/AVG/MIN/MAX without grouping.
+- `IndexTables4SparkGroupByAggregatePartition` — GROUP BY including bucket aggregations.
+
+Each partition carries a serialized list of `AddAction`s and enough config to rebuild a `SplitSearchEngine` on the executor.
+
+### `core/IndexTables4SparkStatistics.scala`
+Implements Spark's `Statistics` so the optimizer can cost-estimate an IndexTables scan. Numbers come from the `numRecords` and `sizeInBytes` fields of `AddAction` plus per-column min/max stats when present.
+
+### `core/IndexTablesFileIndex.scala`
+A `FileIndex` backed by the transaction log instead of `FileSystem.listStatus`. Used by callers that need a `FileIndex` (some of the extension paths) without the cost of a directory scan. It also defines `SerializableFileInfo`, a wrapper that avoids serializing Hadoop `FileStatus` objects (which carry a `Configuration`).
+
+## Partition readers
+
+All readers share a setup block factored into `SplitReaderContext`.
+
+### `core/SplitReaderContext.scala`
+Encapsulates path resolution, cache configuration, footer validation, `SplitSearchEngine` construction, partition-filter separation, range optimization, and `IndexQuery` post-processing. Every reader below starts by constructing one.
+
+### `core/CompanionColumnarPartitionReader.scala`
+The standard single-split columnar reader. Implements `PartitionReader[ColumnarBatch]`. For each batch it runs a search through `search/SplitSearchEngine`, imports the result via `arrow/ArrowFfiBridge`, and yields a `ColumnarBatch`. Used for both regular IndexTables tables and companion indexes.
+
+### `core/CompanionColumnarMultiSplitPartitionReader.scala`
+Wraps multiple single-split readers so one Spark task can process several splits sequentially. Supports early termination when a `LIMIT` is pushed down — once the limit is hit the remaining splits are skipped without being opened.
+
+### `core/SimpleAggregateColumnarReader.scala`
+Specialized reader for COUNT/SUM/AVG/MIN/MAX without GROUP BY. Calls `SplitSearcher.aggregateArrowFfi()` once per split, assembles a single-row `ColumnarBatch`, and reports it. Collaborates with `arrow/AggregationArrowFfiHelper`.
+
+### `core/GroupByAggregateColumnarReader.scala`
+Reader for GROUP BY aggregations including `DateHistogram`, `Histogram`, and `Range` bucket aggregations. Builds a `SplitAggregation` tree from the Spark aggregate expressions plus the bucket configs left by `V2BucketExpressionRule`, executes it via Arrow FFI, and assembles result rows.
+
+### `core/GroupByColumnarReaderUtils.scala`
+Object of shared helpers for the GROUP BY readers: empty batch construction, type coercion (terms → `UTF8String`, buckets → appropriate types), partition-column injection. Keeps single-split and multi-split readers in sync.
+
+## Specialized scans
+
+### `core/IndexTables4SparkSimpleAggregateScan.scala`
+Scan variant that produces `SimpleAggregatePartition`s. Builds Tantivy aggregation requests from the Spark aggregate expressions and leaves the heavy lifting to `SimpleAggregateColumnarReader`.
+
+### `core/IndexTables4SparkGroupByAggregateScan.scala`
+Scan variant for GROUP BY. Manages cross-split aggregation result combination and builds the output schema (including bucket buckets and nested aggregations).
+
+### `core/TransactionLogCountScan.scala`
+Ultra-fast `COUNT(*)` and `GROUP BY <partition-col>, COUNT(*)` path. It never opens a split — it sums `numRecords` from `AddAction`s in the transaction log. Used when the scan builder determines that no data-level predicates remain.
+
+## Filter and query translation
+
+### `core/FiltersToQueryConverter.scala`
+Converts a tree of Spark `Filter`s to a Tantivy `SplitQuery`. Handles `EqualTo`, range predicates, `StringContains`/`StartsWith`/`EndsWith`, `IsNull`, `In`, boolean combinators, and the custom `IndexQueryFilter`/`IndexQueryAllFilter`. Also performs range merging (multiple `>`/`<` filters on the same field collapse into a single range query).
+
+### `schema/SchemaMapping.scala`
+Used by the reader to translate between a Spark `StructType` and the Tantivy schema recovered from split metadata. See chapter 05.
+
+## Catalyst rules
+
+These rules run inside the Spark optimizer after the DataSource V2 logical plan is built and must coordinate with `IndexTables4SparkScanBuilder` via `ThreadLocal`s.
+
+### `catalyst/V2IndexQueryExpressionRule.scala`
+Finds `IndexQueryExpression` and `IndexQueryAllExpression` nodes in the logical plan and rewrites them as `IndexQueryV2Filter` so Spark pushes them through its filter interfaces. It also clears stale ThreadLocal state between analysis and optimization phases (which is important for multi-statement sessions).
+
+### `catalyst/V2BucketExpressionRule.scala`
+Detects `DateHistogramExpression` / `HistogramExpression` / `RangeExpression` in `Aggregate` GROUP BY keys and rewrites them as ordinary attribute references, stashing the bucket configs where `IndexTables4SparkScanBuilder` can find them. Without this rule Spark would refuse to push the aggregation down because the group key would be an unknown expression.
+
+## How the pieces connect
+
+```
+IndexTables4SparkTable.newScanBuilder
+ → IndexTables4SparkScanBuilder
+     ├─ FiltersToQueryConverter        (Spark Filter → Tantivy query)
+     ├─ (reads ThreadLocal from V2IndexQueryExpressionRule / V2BucketExpressionRule)
+     └─ build()
+         ├─ IndexTables4SparkScan            (standard rows)
+         ├─ IndexTables4SparkSimpleAggregateScan
+         ├─ IndexTables4SparkGroupByAggregateScan
+         └─ TransactionLogCountScan           (metadata-only COUNT/GROUP BY partition)
+
+Scan.planInputPartitions()
+ → transaction log list + partition pruning
+ → IndexTables4SparkPartitions (Standard / SimpleAgg / GroupByAgg)
+     └─ on executor: PartitionReader
+         ├─ SplitReaderContext            (shared setup)
+         ├─ SplitSearchEngine             (search/)
+         ├─ ArrowFfiBridge                (arrow/)
+         └─ ColumnarBatch → Spark
+```
+
+Write-path chapter next.

--- a/docs/walkthrough/02-read-path.md
+++ b/docs/walkthrough/02-read-path.md
@@ -87,6 +87,31 @@ Finds `IndexQueryExpression` and `IndexQueryAllExpression` nodes in the logical 
 ### `catalyst/V2BucketExpressionRule.scala`
 Detects `DateHistogramExpression` / `HistogramExpression` / `RangeExpression` in `Aggregate` GROUP BY keys and rewrites them as ordinary attribute references, stashing the bucket configs where `IndexTables4SparkScanBuilder` can find them. Without this rule Spark would refuse to push the aggregation down because the group key would be an unknown expression.
 
+## Split locality
+
+Locality matters for read performance: if the same split is consistently read by the same executor host, the Tantivy `SplitCacheManager` and the L2 disk cache on that host stay warm. These modules exist to make that happen.
+
+### `storage/DriverSplitLocalityManager.scala`
+Driver-side sticky split-to-host assignment. Given a list of splits and the set of available executors, it returns stable assignments so the same split is reliably picked up by the same host across queries. Replaces an older broadcast-based approach: persistent assignments live on the driver and feed `IndexTables4SparkScan`'s `InputPartition.preferredLocations()`. Also tracks per-split prewarm state so the prewarm subsystem below knows which splits are already warm on which hosts.
+
+## Cache prewarming
+
+Prewarm is a read-performance subsystem: it warms the Tantivy index components a query will need *before* the query runs, so the first batch of every split is hot. Triggered by the `PREWARM INDEXTABLES CACHE` SQL command (chapter 08) and optionally implicitly before large scans.
+
+### `prewarm/PreWarmManager.scala`
+Two-phase orchestration:
+
+1. **Pre-scan** — using `DriverSplitLocalityManager`, distribute warmup tasks to the executors that already hold the relevant splits in cache.
+2. **Post-warm** — when the main query starts, join on the warmup futures so no split is read cold.
+
+Returns `PreWarmStats` with cache-hit/miss counts for observability.
+
+### `prewarm/AsyncPrewarmJobManager.scala`
+JVM-wide singleton tracking async prewarm jobs on executors. Semaphore-bounded concurrency, a job registry for `DESCRIBE INDEXTABLES PREWARM JOBS`, and auto-cleanup of old completed jobs. Structurally mirrors `AsyncMergeOnWriteManager` (chapter 07) — same pattern, different purpose.
+
+### `prewarm/IndexComponentMapping.scala`
+Maps SQL-level component names (`TERM`, `FASTFIELD`, `POSTINGS`, `POSITIONS`, `FIELDNORM`, `STORE`) to the `tantivy4java` `IndexComponent` enum, and defines the default component set warmed when the user does not specify one.
+
 ## How the pieces connect
 
 ```
@@ -108,6 +133,13 @@ Scan.planInputPartitions()
          ├─ SplitSearchEngine             (search/)
          ├─ ArrowFfiBridge                (arrow/)
          └─ ColumnarBatch → Spark
+
+Locality / prewarm (optional, before the scan):
+  DriverSplitLocalityManager    (sticky split→host assignments)
+        ↓
+  PreWarmManager
+    └─ AsyncPrewarmJobManager (on executors)
+         └─ warms IndexComponentMapping components
 ```
 
 Write-path chapter next.

--- a/docs/walkthrough/03-write-path.md
+++ b/docs/walkthrough/03-write-path.md
@@ -1,0 +1,92 @@
+# 03 — Write Path
+
+This chapter covers the modules that turn a `df.write.save(path)` call into committed `.split` files. Everything here lives in `spark/core/` (write classes), `spark/arrow/` (Arrow FFI), and `spark/write/` (configuration).
+
+## The write pipeline
+
+### `core/IndexTables4SparkWriteBuilder.scala`
+Entry point for writes. Implements `WriteBuilder`, `SupportsOverwrite`, and `SupportsTruncate`. Decides whether to use an optimized write or a standard write based on `spark.indextables.write.optimizeWrite.enabled`, then builds one of the two `Write` implementations below.
+
+### `core/IndexTables4SparkStandardWrite.scala`
+The baseline `Write`/`BatchWrite` implementation. Creates `IndexTables4SparkBatchWrite` to own the executor-side writing and handles driver-side commit. The `commit()` path:
+
+1. Collects `CommitMessage`s from executors.
+2. Builds `AddAction` entries.
+3. Appends a new version to the transaction log via `transaction/NativeTransactionLog`.
+4. Triggers post-commit hooks: `merge/AsyncMergeOnWriteManager` (merge-on-write) and `purge/PurgeOnWriteTransactionCounter` (purge-on-write).
+
+It deliberately avoids broadcasting a `Configuration` to executors — all settings flow as a serializable map.
+
+### `core/IndexTables4SparkOptimizedWrite.scala`
+Extends `StandardWrite` and additionally implements `RequiresDistributionAndOrdering`. This is the Iceberg-style "shuffle before writing" path: it requests a `ClusteredDistribution` on the partition columns plus an advisory partition size (computed by `write/WriteSizeEstimator`) so Spark AQE coalesces input into well-sized splits. All commit logic is inherited from `StandardWrite`.
+
+### `core/IndexTables4SparkBatchWrite.scala`
+Implements `BatchWrite`. On the driver it builds the `DataWriterFactory`; on executors it produces one `IndexTables4SparkArrowDataWriter` per task. It is also where the parallelism and memory settings for Arrow FFI are wired up.
+
+### `core/IndexTables4SparkArrowDataWriter.scala`
+The executor-side `DataWriter[InternalRow]`. The hot path is:
+
+```
+InternalRow
+   └─ ArrowFfiWriteBridge.append()          (spark/arrow)
+        └─ fills VectorSchemaRoot           (Arrow Java)
+             └─ exports via FFI structs     (C Data Interface)
+                  └─ QuickwitSplit.addArrowBatch()   (Rust side, zero-copy)
+```
+
+It also computes per-field min/max/null statistics using `util/StatisticsCalculator`, applies `util/StatisticsTruncation` for long text fields, normalizes the protocol level with `util/ProtocolNormalizer`, and uploads the resulting `.split` file through the appropriate `io/CloudStorageProvider`. The `CommitMessage` it returns carries the uploaded file's metadata so the driver can emit an `AddAction`.
+
+## Arrow FFI bridge (write direction)
+
+### `arrow/ArrowFfiWriteBridge.scala`
+Owns the Arrow `BufferAllocator` and `VectorSchemaRoot` used to marshal rows to Rust. It knows how to write every Spark type into the corresponding Arrow vector, including nested `Struct`/`List`/`Map` for JSON fields. When a batch is full it exports the Arrow buffers via C Data Interface structs and hands them to `QuickwitSplit.addArrowBatch()` without copying.
+
+### `arrow/ArrowFfiBridge.scala`
+The read-direction analogue (imports FFI data back into a `ColumnarBatch`). Written here because the same allocator class is shared between the read and write paths.
+
+### `write/ArrowFfiWriteConfig.scala`
+Batch size (rows) and native heap size (MB) for Arrow FFI writes. Default: 8192 rows per batch, 256 MB per writer task.
+
+### `write/OptimizedWriteConfig.scala`
+Config knobs for the optimized-write path: target split size (default 1 GB), sampling ratio, min rows for history-based estimation, and distribution mode.
+
+### `write/WriteSizeEstimator.scala`
+Computes the advisory partition byte size for Spark AQE. Two strategies:
+
+- **Sampling mode** — estimate bytes-per-row from a sample of the input DataFrame.
+- **History mode** — read prior `AddAction`s from the transaction log and take an average `size / numRecords`.
+
+## Post-commit hooks (referenced here, detailed in chapter 07)
+
+After `StandardWrite.commit()` succeeds, two async subsystems may fire:
+
+- `merge/AsyncMergeOnWriteManager` — launches background merge jobs when the batch-size threshold is reached.
+- `purge/PurgeOnWriteTransactionCounter` — tracks writes per table and triggers a purge of orphaned splits / old txlog versions according to `PurgeOnWriteConfig`.
+
+Both are intentionally out-of-band: the write commit is never blocked on them.
+
+## How the pieces connect
+
+```
+df.write.format("io.indextables.provider.IndexTablesProvider").save(path)
+ → IndexTables4SparkTable.newWriteBuilder
+    → IndexTables4SparkWriteBuilder
+       ├─ IndexTables4SparkStandardWrite              (default)
+       └─ IndexTables4SparkOptimizedWrite             (shuffles for split sizing)
+           └─ WriteSizeEstimator + OptimizedWriteConfig
+                ↓
+        IndexTables4SparkBatchWrite
+          └─ on executor:
+              IndexTables4SparkArrowDataWriter
+               └─ ArrowFfiWriteBridge
+                    └─ QuickwitSplit.addArrowBatch()
+               └─ CloudStorageProvider.upload(.split)
+               └─ returns CommitMessage(AddAction)
+
+  driver commit():
+   └─ NativeTransactionLog.commit(AddActions)
+   └─ AsyncMergeOnWriteManager.maybeTrigger()
+   └─ PurgeOnWriteTransactionCounter.increment()
+```
+
+The next chapter describes the transaction log that both the read and write paths depend on.

--- a/docs/walkthrough/04-transaction-log.md
+++ b/docs/walkthrough/04-transaction-log.md
@@ -1,0 +1,88 @@
+# 04 — Transaction Log
+
+The transaction log is the source of truth for every table's state: what split files exist, what schema they carry, what partitioning is in effect, which versions have been checkpointed, and what protocol features are required to read them. It is a Delta-Lake-compatible format stored under `_transaction_log/` with optional GZIP compression, Avro state files, and checkpoints. All of this lives in `spark/transaction/`.
+
+## Core interfaces and factory
+
+### `transaction/TransactionLogInterface.scala`
+The trait every transaction-log implementation conforms to. Defines the API for initialization, reads (list files, get metadata, get protocol, get schema, get table config), writes (append `Action`s, commit versions, write checkpoints), and lifecycle (close, invalidate). Having a single trait lets the rest of the codebase depend on an interface rather than a concrete implementation.
+
+### `transaction/NativeTransactionLog.scala`
+The production implementation. It is backed by the Rust transaction-log reader/writer in `tantivy4java` via JNI. Features:
+
+- Optimistic concurrency with retries on commit conflict.
+- Avro state format by default (V4 protocol) — ~10x faster than JSON-lines checkpoint reads.
+- Automatic checkpoint creation on configurable thresholds.
+- Internal LRU cache with TTL so repeated reads of the same version are free.
+- Incremental state writes to avoid rewriting the full state on every commit.
+
+### `transaction/TransactionLogFactory.scala`
+The single entry point for constructing a `TransactionLogInterface`. Consumers never instantiate a log directly — they call the factory. It is responsible for:
+
+- Merging credentials across Hadoop conf, Spark session conf, and user options via `transaction/ConfigMapper` and `util/ConfigNormalization`.
+- Enforcing the `allowDirectUsage` safety check that keeps stray code from instantiating a transaction log outside the managed DataSource lifecycle.
+- Returning shared, cached log instances when appropriate.
+
+## Actions and serialization
+
+### `transaction/Actions.scala`
+The Delta-style action hierarchy: `AddAction`, `RemoveAction`, `SkipAction`, `ProtocolAction`, `MetadataAction`, plus supporting case classes. Also defines `DocMappingMetadata`, a cached representation of the Tantivy schema inside the log so it doesn't have to be re-parsed on every read.
+
+### `transaction/ActionJsonSerializer.scala`
+Serializes `Action` objects to the JSON formats consumed by the native `tantivy4java` writer — both JSON-lines and JSON-array shapes, used in different call sites.
+
+### `transaction/ActionsToArrowConverter.scala`
+Alternative serialization: packs actions into an Arrow `RecordBatch` with an `action_type` discriminator column. This is used by the Arrow-FFI commit path, which can append a new version by passing a single batch across FFI instead of a JSON blob per action. Uses `arrow/ArrowFfiBridge`.
+
+### `transaction/ArrowFileEntryExtractor.scala`
+The inverse of the converter above. When the native `listFiles` call returns an Arrow `ColumnarBatch` of file entries, this extractor walks the Arrow vectors and rebuilds `AddAction` objects without going through JSON. It is the reason list operations on large tables are cheap.
+
+### `transaction/NativeListFilesResult.scala`
+Value object returned from the native list call. Holds the file list plus associated metadata (schema, partition schema, protocol, stats) and `NativeFilteringMetrics` (how many files were pruned at which layer). The metrics feed into `stats/DataSkippingMetrics` and the Spark UI.
+
+## Caches
+
+### `transaction/EnhancedTransactionLogCache.scala`
+Global caches for *immutable* metadata that can be safely shared across `TransactionLog` instances — primarily `DocMappingMetadata` and filtered schemas. Also exposes a JSON parse counter used by tests to assert that repeated opens do not re-parse the log. This is separate from the per-instance LRU inside `NativeTransactionLog`.
+
+## Partition and filter support
+
+### `transaction/PartitionPredicateUtils.scala`
+Parses, validates, and evaluates partition predicates. Used by both `IndexTables4SparkScan` (for partition pruning at scan time) and the `MERGE SPLITS` / `DROP PARTITIONS` commands (which need to identify which `AddAction`s a `WHERE` clause targets).
+
+### `transaction/PartitionUtils.scala`
+Runtime helpers for partition extraction during writes: precomputes a `PartitionColumnInfo` once per schema so every row costs O(1) to extract partition values.
+
+### `transaction/SparkFilterToNativeFilter.scala`
+Translates Spark V2 `Filter`s into the `PartitionFilter` JSON format the native reader understands. Used to push partition pruning all the way into the native list call, so the JVM never sees the pruned files.
+
+## Protocol versioning and configuration
+
+### `transaction/ProtocolVersion.scala`
+Constants for reader/writer protocol versions V1 through V4 and the feature flags each version introduced (`skippedFiles`, `extendedMetadata`, `footerOffsets`, `multiPartCheckpoint`, `schemaDeduplication`, `avroState`). Used when writing a new `ProtocolAction` and when a reader must decide whether it can open a given table.
+
+### `transaction/ConfigMapper.scala`
+Centralizes the translation between the `spark.indextables.*` configuration keys understood by the connector and the flat key/value pairs the native layer expects. Every reader that needs credentials goes through this so the mapping is not duplicated.
+
+## How the pieces connect
+
+```
+Read path (chapter 02)                 Write path (chapter 03)
+        │                                      │
+        ▼                                      ▼
+  TransactionLogFactory.getOrCreate(path, options, hadoopConf)
+        │
+        ▼
+  TransactionLogInterface
+        │
+        └── NativeTransactionLog  ──── JNI ────▶  tantivy4java (Rust)
+                 │                                       │
+                 ├─ list()   ── ArrowFileEntryExtractor ──┘
+                 ├─ commit() ── ActionJsonSerializer
+                 │           or ActionsToArrowConverter
+                 ├─ uses ConfigMapper for credentials
+                 └─ shares DocMappingMetadata via
+                    EnhancedTransactionLogCache
+```
+
+With the transaction log in place, the next chapter covers the search engine that actually queries the split files the log points to.

--- a/docs/walkthrough/05-search-engine.md
+++ b/docs/walkthrough/05-search-engine.md
@@ -1,0 +1,131 @@
+# 05 — Search Engine, Filters, Expressions, FFI, JSON
+
+This chapter covers everything under `spark/search/`, `spark/filters/`, `spark/expressions/`, `spark/arrow/`, `spark/json/`, `spark/schema/`, and `spark/exceptions/`. Together these modules turn Spark expressions and `Filter`s into Tantivy queries, execute them against `.split` files, and translate the results back into Spark rows.
+
+## Search façade
+
+### `search/SplitSearchEngine.scala`
+The modern search engine used by every read path. Wraps `tantivy4java`'s `SplitSearcher` and its global `SplitCacheManager`, handling split open/close, footer retrieval, and `SplitQuery` execution. All partition readers instantiate one of these per split (or reuse one via the cache). Replaces an older zip-file-based engine that is no longer used.
+
+### `search/IndexTablesSearchEngine.scala`
+Historical façade around the Tantivy index writer used by the build-side of a few tests. Wraps `TantivyDirectInterface` with `CaseInsensitiveStringMap` options handling and working-directory setup. Kept because the indexing/test harness still references it — the production read path uses `SplitSearchEngine`.
+
+### `search/IndexTablesDirectInterface.scala`
+The core FFI wrapper for a Tantivy `Index` + `IndexWriter` on a single executor. Handles document appending, commit, and the global schema-creation lock that prevents two threads from racing when building a new Tantivy schema. Per-executor lifecycle: one instance per table path.
+
+### `search/IndexTablesJavaInterface.scala`
+Legacy adapter that maps `Long`-handle APIs to `TantivyDirectInterface`. Exists for backward compatibility with older call sites that still assume handle-based interop.
+
+### `search/QueryParser.scala`
+Parses a human query string (supporting wildcards, phrases, field-specific queries, prefix queries) into a Tantivy `Query` object. Used when an `IndexQueryFilter` is pushed down.
+
+### `search/RowConverter.scala`
+Bidirectional JSON ↔ `InternalRow` converter for a given `StructType`. Used on the indexing side (row → JSON document to add to Tantivy) and in a few diagnostic read paths.
+
+### `search/SchemaConverter.scala`
+Converts Spark `StructType` to the Tantivy schema JSON that the native index expects, and back again. Used during write-side schema construction and when reflecting on a split's schema.
+
+## Filters (IndexQuery custom filter types)
+
+These are the "virtual filters" that represent `col indexquery 'q'` syntax. They round-trip through Spark's `SupportsPushDownFilters` machinery.
+
+### `filters/IndexQueryFilter.scala`
+Case class wrapping a column name + Tantivy query string. `references()` returns the column so Spark can reason about it like any other filter. The scan builder recognizes instances of this class.
+
+### `filters/IndexQueryAllFilter.scala`
+Sibling of `IndexQueryFilter` for the `indexqueryall('q')` variant, which searches across every indexed field. `references()` is empty so Spark does not tie it to a specific column.
+
+### `filters/IndexQueryV2Filter.scala`
+A Catalyst `Expression` + `Predicate` bridge. Since Spark V2 pushdown wants expressions, not filters, `V2IndexQueryExpressionRule` rewrites `IndexQueryExpression` into this class, and `IndexTables4SparkScanBuilder` later recovers the underlying `IndexQueryFilter` via `toFilter()`.
+
+### `filters/IndexQueryRegistry.scala`
+Query-scoped registry of IndexQuery metadata keyed by UUID instead of `ThreadLocal`. This is important because Spark's scheduler can run catalyst rules and scan builders on different threads for the same query; the UUID keys let them find each other reliably.
+
+## Expressions (Catalyst expression types)
+
+### `expressions/IndexQueryExpression.scala`
+The `BinaryExpression` implementing the `col indexquery 'query_string'` operator. Non-deterministic so the optimizer never folds it away. The V2 rule rewrites it into an `IndexQueryV2Filter`.
+
+### `expressions/IndexQueryAllExpression.scala`
+The `UnaryExpression` for `indexqueryall('query_string')`. Same machinery, no left-hand column.
+
+### `expressions/BucketExpressions.scala`
+Sealed trait `BucketExpression` plus `DateHistogramExpression`, `HistogramExpression`, `RangeExpression`. These are the expression trees produced by the bucket aggregation SQL functions. They appear inside `Aggregate` GROUP BY keys until `V2BucketExpressionRule` strips them out.
+
+### `expressions/BucketAggregationConfig.scala`
+Serializable config objects (`DateHistogramConfig`, `HistogramConfig`, `RangeConfig`) extracted from the expressions above. These are what the scan builder captures in its `ThreadLocal` and hands to the reader so the aggregation can be executed natively.
+
+### `expressions/BucketFunctionBuilder.scala`
+Builder registered with the SparkSession function registry. Parses the literal arguments of `indextables_date_histogram(...)`, `indextables_histogram(...)`, and `indextables_range(...)` calls into the appropriate `BucketExpression`.
+
+## Arrow FFI bridges
+
+Arrow's C Data Interface is how the connector avoids copying rows between Rust and the JVM.
+
+### `arrow/ArrowFfiBridge.scala`
+Read direction: owns a `RootAllocator`, `CDataDictionaryProvider`, and the `ArrowArray`/`ArrowSchema` C structs used to import data from `tantivy4java`. Reused across batches inside a partition reader to minimize allocation churn.
+
+### `arrow/ArrowFfiWriteBridge.scala`
+Write direction: owns a `BufferAllocator` and `VectorSchemaRoot`, knows how to write every Spark type (including nested `Struct`/`List`/`Map`) into Arrow vectors, and exports them via FFI structs. See chapter 03.
+
+### `arrow/AggregationArrowFfiHelper.scala`
+Higher-level helper for aggregations. Encapsulates the FFI protocol for schema introspection, single-split and multi-split aggregation calls, and Arrow import into `ColumnarBatch`. Used by `SimpleAggregateColumnarReader` and `GroupByAggregateColumnarReader`.
+
+### `arrow/AggregationArrowFfiConfig.scala`
+Config flag controlling whether aggregation uses Arrow FFI or the legacy JSON-based path (default: enabled).
+
+## JSON / struct converters
+
+Used when the table has `StructType`, `ArrayType`, or `MapType` columns that are stored as Tantivy JSON fields.
+
+### `json/SparkSchemaToTantivyMapper.scala`
+Decides whether a given Spark field should map to a Tantivy JSON field. Considers the field's Spark type and any explicit `typemap` configuration.
+
+### `json/SparkToTantivyConverter.scala`
+Converts a Spark `Row` value (including nested structs/arrays/maps) into the Java collection shape that `tantivy4java` expects when indexing.
+
+### `json/TantivyToSparkConverter.scala`
+The inverse: walks a Java `Map`/`List` retrieved from Tantivy and rebuilds a Spark `Row`/`Array`/`Map` with the correct types.
+
+### `json/JsonPredicateTranslator.scala`
+Translates Spark `Filter`s that target nested JSON/array fields into the Tantivy query syntax for JSON fields. This is what makes `filter($"address.city" === "Seattle")` pushdown-eligible.
+
+## Schema mapping
+
+### `schema/SchemaMapping.scala`
+The big orchestrator. On the write side it decides, for each Spark field, what Tantivy field type to create (string, text, JSON, fast, indexed, etc.). On the read side it recovers the original Spark types from the Tantivy schema stored in split metadata. Delegates to the `json/` converters for nested types and to `util/TimestampUtils` for temporal types. Also throws `SchemaConflictException` when mixing incompatible schemas across appends.
+
+## Exceptions
+
+### `exceptions/IndexQueryParseException.scala`
+Raised when a Tantivy query string fails to parse (unbalanced parentheses, unclosed quotes, invalid syntax). Carries the offending query string and field name for good error messages.
+
+## How the pieces connect
+
+```
+Pushdown (logical plan side):
+  user: WHERE content indexquery 'machine learning'
+   └─ IndexQueryExpression        (expressions/)
+       └─ V2IndexQueryExpressionRule (chapter 02)
+            └─ IndexQueryV2Filter   (filters/)
+                 └─ IndexQueryFilter (filters/)
+                      └─ IndexTables4SparkScanBuilder
+
+Aggregation pushdown:
+  user: GROUP BY indextables_date_histogram(ts,'1d')
+   └─ BucketFunctionBuilder → DateHistogramExpression
+        └─ V2BucketExpressionRule → DateHistogramConfig in ScanBuilder ThreadLocal
+
+Execution (on the executor):
+  PartitionReader
+    └─ SplitSearchEngine.openSplit()
+         └─ FiltersToQueryConverter builds SplitQuery
+              ├─ JsonPredicateTranslator  (nested fields)
+              ├─ SchemaMapping            (Spark type ↔ Tantivy type)
+              └─ QueryParser              (IndexQuery)
+         └─ SplitSearcher.searchArrowFfi()
+              └─ ArrowFfiBridge imports ColumnarBatch
+                   └─ TantivyToSparkConverter for JSON columns
+```
+
+The next chapter covers how those `.split` files get in and out of S3/Azure/HDFS in the first place.

--- a/docs/walkthrough/05-search-engine.md
+++ b/docs/walkthrough/05-search-engine.md
@@ -8,13 +8,13 @@ This chapter covers everything under `spark/search/`, `spark/filters/`, `spark/e
 The modern search engine used by every read path. Wraps `tantivy4java`'s `SplitSearcher` and its global `SplitCacheManager`, handling split open/close, footer retrieval, and `SplitQuery` execution. All partition readers instantiate one of these per split (or reuse one via the cache). Replaces an older zip-file-based engine that is no longer used.
 
 ### `search/IndexTablesSearchEngine.scala`
-Historical façade around the Tantivy index writer used by the build-side of a few tests. Wraps `TantivyDirectInterface` with `CaseInsensitiveStringMap` options handling and working-directory setup. Kept because the indexing/test harness still references it — the production read path uses `SplitSearchEngine`.
+Defines `class TantivySearchEngine` (plus companion `object`). Historical façade around the Tantivy index writer used by the build-side of a few tests. Wraps `TantivyDirectInterface` with `CaseInsensitiveStringMap` options handling and working-directory setup. Kept because the indexing/test harness still references it — the production read path uses `SplitSearchEngine`.
 
 ### `search/IndexTablesDirectInterface.scala`
-The core FFI wrapper for a Tantivy `Index` + `IndexWriter` on a single executor. Handles document appending, commit, and the global schema-creation lock that prevents two threads from racing when building a new Tantivy schema. Per-executor lifecycle: one instance per table path.
+Defines `class TantivyDirectInterface` (plus companion `object`). The core FFI wrapper for a Tantivy `Index` + `IndexWriter` on a single executor. Handles document appending, commit, and the global schema-creation lock that prevents two threads from racing when building a new Tantivy schema. Per-executor lifecycle: one instance per table path.
 
 ### `search/IndexTablesJavaInterface.scala`
-Legacy adapter that maps `Long`-handle APIs to `TantivyDirectInterface`. Exists for backward compatibility with older call sites that still assume handle-based interop.
+Contains `object TantivyJavaAdapter` (the actual `Long`-handle → `TantivyDirectInterface` map used when legacy callers pass opaque handles) and `object TantivyNative` (compatibility shim for older call sites). Exists purely for backward compatibility with handle-based interop.
 
 ### `search/QueryParser.scala`
 Parses a human query string (supporting wildcards, phrases, field-specific queries, prefix queries) into a Tantivy `Query` object. Used when an `IndexQueryFilter` is pushed down.

--- a/docs/walkthrough/06-storage-io.md
+++ b/docs/walkthrough/06-storage-io.md
@@ -1,0 +1,86 @@
+# 06 — Storage and Merge I/O
+
+Cloud storage in IndexTables4Spark is deliberately *not* routed through the Hadoop `FileSystem` API for the hot paths. Instead, a lightweight `CloudStorageProvider` abstraction talks directly to the cloud SDKs (AWS SDK v2, Azure SDK) for fast parallel and async operations. Merges add a second layer on top: an async download/upload pipeline that can stream hundreds of GB of splits through a single executor without exhausting the heap.
+
+This chapter covers `spark/io/` and `spark/io/merge/`.
+
+## Cloud storage providers
+
+### `io/CloudStorageProvider.scala`
+The trait every provider implements. Defines upload, download, list, head, delete, and multipart operations on a cloud URI. Also defines `CloudFileInfo` (path, size, last modified). This is the contract that the read/write paths rely on — they never touch an AWS/Azure SDK class directly.
+
+### `io/S3CloudStorageProvider.scala`
+AWS SDK v2 S3 implementation. Uses the async S3 client where it matters and delegates large uploads to `S3MultipartUploader`. Picks up credentials via `utils/CredentialProviderFactory` and `util/ConfigNormalization`, so a single set of `spark.indextables.aws.*` keys reach every call site.
+
+### `io/S3MultipartUploader.scala`
+Helper for multipart S3 uploads. Splits a local file into parts, uploads them in parallel, and retries individual parts on transient failure.
+
+### `io/AzureCloudStorageProvider.scala`
+Azure Blob Storage implementation. Supports multiple authentication strategies (account key, connection string, OAuth/AAD via DefaultAzureCredential). Talks to the Azure SDK directly.
+
+### `io/HadoopCloudStorageProvider.scala`
+Fallback implementation for local filesystems, HDFS, and any other Hadoop-compatible filesystem. Wraps `org.apache.hadoop.fs.FileSystem`. Used for unit tests and HDFS deployments; in cloud environments the S3/Azure providers are used instead for performance.
+
+### `io/ProtocolBasedIOFactory.scala`
+The dispatcher. Looks at the URI scheme (`s3://`, `s3a://`, `s3n://`, `azure://`, `wasb://`, `wasbs://`, `abfs://`, `abfss://`, `hdfs://`, `file://`) and returns the appropriate provider instance. Also defines the `StorageProtocol` sealed trait so other code can pattern-match on the detected protocol.
+
+## Merge I/O pipeline
+
+Merges can touch hundreds of splits. Downloading them sequentially would be too slow, and downloading them all at once could exhaust executor heap or disk. The merge I/O pipeline exists to solve both problems: bounded concurrency, priority batching, and direct-to-disk streaming.
+
+### `io/merge/AsyncDownloader.scala`
+Base trait. Defines `DownloadRequest` (source, destination, priority) and `DownloadResult` (success, failure, retry count). Every protocol-specific downloader implements it.
+
+### `io/merge/S3AsyncDownloader.scala`
+S3 implementation built on `S3AsyncClient` and `AsyncResponseTransformer.toFile()`. The key property is that the data never hits JVM heap — the async client streams from the socket directly into a file on disk.
+
+### `io/merge/AzureAsyncDownloader.scala`
+Azure equivalent, using `BlobServiceAsyncClient` for direct-to-disk streaming. Same heap-avoiding design.
+
+### `io/merge/LocalCopyDownloader.scala`
+"Downloader" for local filesystems and anything already mounted (NFS, FUSE). Just does a `Files.copy()`. Keeps the rest of the pipeline protocol-agnostic.
+
+### `io/merge/CloudDownloadManager.scala`
+The orchestrator. A JVM-wide singleton that:
+
+- Holds a `Semaphore` bounding total concurrent downloads.
+- Accepts batched download requests and hands them off to the right protocol-specific downloader.
+- Retries with exponential backoff on transient errors.
+- Supports cancellation so a failing merge can abort its in-flight downloads.
+- Uses `PriorityDownloadQueue` to ensure batch ordering.
+
+### `io/merge/PriorityDownloadQueue.scala`
+Two-level priority queue. The first level is batch submission order (first-submitted batches finish first), the second level is order within a batch. This stops a second batch from starving the first even under high concurrency.
+
+### `io/merge/MergeIOConfig.scala`
+All tuning knobs for the pipeline: max concurrency per core, total memory budget, per-download retry count, upload concurrency, and exponential backoff parameters. Defaults are conservative for laptops and scale up on cluster hardware.
+
+### `io/merge/MergeIOThreadPools.scala`
+Manages the JVM-wide singleton thread pools: one for download coordination, one for uploads, one for retry scheduling. Threads are daemons so they never block JVM shutdown. Auto-recreates pools if they are torn down (useful in notebooks where Spark contexts come and go).
+
+### `io/merge/MergeUploader.scala`
+The upload side of the merge pipeline. Uploads a locally-merged split back to cloud storage, reusing the same credential resolution as the downloaders. Also used by the post-merge commit step to make the merged split visible before the transaction log commit.
+
+## How the pieces connect
+
+```
+spark/core/*                    spark/merge/*              spark/sync/*
+  (reads/writes)                (merge jobs)               (companion sync)
+      │                              │                         │
+      └──────────────┬───────────────┴───────────┬─────────────┘
+                     ▼                           ▼
+            ProtocolBasedIOFactory      CloudDownloadManager
+                     │                           │
+       ┌────────────┬┴┬────────────┐   ┌─────────┴──────────┐
+       ▼            ▼ ▼            ▼   ▼                    ▼
+    S3Cloud…    Azure…  Hadoop…    PriorityDownloadQueue   MergeUploader
+    Provider                             │
+                                  ┌──────┼──────────┬─────────────┐
+                                  ▼      ▼          ▼             ▼
+                          S3AsyncDownloader  Azure…  LocalCopy…   (…)
+                                  │
+                              AWS SDK v2 async
+                              (direct-to-disk)
+```
+
+The next chapter covers the in-JVM subsystems that drive this pipeline: merge-on-write, purge-on-write, and prewarm.

--- a/docs/walkthrough/07-merge-and-purge.md
+++ b/docs/walkthrough/07-merge-and-purge.md
@@ -1,0 +1,88 @@
+# 07 — Merge, Purge, Prewarm
+
+Three post-commit maintenance subsystems share a common shape: a driver-side singleton plus a configuration object plus some executor-side workers. They are all opt-in or conservative by default so they never block the write commit path.
+
+This chapter covers `spark/merge/`, `spark/purge/`, `spark/prewarm/`, and `spark/storage/`.
+
+## Merge-on-write
+
+### `merge/AsyncMergeOnWriteConfig.scala`
+All knobs for async merge-on-write: batch CPU fraction (fraction of total cluster CPUs that count as one batch), max concurrent merge batches, merge group sizing (how many source splits per merge), target merged split size, graceful shutdown timeout, and a handful of safety thresholds. The batch-size threshold that triggers a merge is `batchSize × minBatchesToTrigger`, where `batchSize = max(1, totalClusterCpus × batchCpuFraction)`.
+
+### `merge/AsyncMergeOnWriteManager.scala`
+The JVM-wide singleton that owns async merge jobs on the driver. Responsibilities:
+
+- A `Semaphore` limits concurrent merges.
+- A job registry tracks active, completed, and failed merges per table (so `DESCRIBE INDEXTABLES MERGE JOBS` has something to report).
+- Deduplicates merges — if one is already running for a table, a second `maybeTrigger()` call is a no-op.
+- Supports graceful shutdown so a Spark session teardown waits for in-flight merges to finish (up to the configured timeout).
+
+Post-commit, `IndexTables4SparkStandardWrite` calls `maybeTrigger()`; the manager checks the threshold and either launches a job or does nothing. This is the entire API surface the rest of the connector sees. Internally the manager follows the same singleton pattern as `AsyncPrewarmJobManager`.
+
+### `merge/WorkerLocalSplitMerger.scala`
+The executor-side worker that actually performs a merge. Runs inside the shuffle-based merge task that the `MERGE SPLITS` SQL command (or the async manager) schedules. Responsibilities:
+
+- Downloads source splits via `io/merge/CloudDownloadManager`.
+- Calls `QuickwitSplit.convert*` to merge them into a new local split.
+- Uploads the merged split via `io/merge/MergeUploader`.
+- Applies gap mitigations: per-worker memory cap, merge timeout, disk-space precheck.
+- Returns a `MergedSplitMetadata` value the driver uses to build the commit message.
+
+## Purge-on-write
+
+### `purge/PurgeOnWriteConfig.scala`
+Configuration: enable/disable, trigger mode (after every merge, or after N writes), retention hours for split files, retention hours for transaction-log versions, and a hard minimum retention of 24 hours to protect against accidental data loss.
+
+### `purge/PurgeOnWriteTransactionCounter.scala`
+Per-session counter. A `ConcurrentHashMap<tablePath, AtomicInteger>` tracks writes per table; when the count crosses the configured threshold the counter fires a purge and resets. Thread-safe and lock-free on the hot path. The purge itself is handled by `sql/PurgeOrphanedSplitsCommand` and `sql/PurgeOrphanedSplitsExecutor` (chapter 08).
+
+## Prewarm
+
+### `prewarm/PreWarmManager.scala`
+Two-phase cache warmup orchestration:
+
+1. **Pre-scan** — distribute warmup tasks to executors that already hold the relevant splits in cache, using `storage/DriverSplitLocalityManager` to target the right host.
+2. **Post-warm** — when the main query runs, join on the warmup futures so no split is accessed cold.
+
+Returns `PreWarmStats` with cache-hit/miss counts for observability. Triggered by `PREWARM INDEXTABLES CACHE` and also implicitly before large read queries.
+
+### `prewarm/AsyncPrewarmJobManager.scala`
+Executor-side singleton analogous to `AsyncMergeOnWriteManager`: a semaphore-bounded registry of async prewarm jobs with auto-cleanup of completed jobs. This is what `DESCRIBE INDEXTABLES PREWARM JOBS` queries.
+
+### `prewarm/IndexComponentMapping.scala`
+Maps the user-friendly names used in SQL (`TERM`, `FASTFIELD`, `POSTINGS`, `POSITIONS`, `FIELDNORM`, `STORE`) to the `tantivy4java` `IndexComponent` enum. Also defines the default set of components that are warmed when the user does not specify one explicitly.
+
+## Split locality and throttling
+
+### `storage/DriverSplitLocalityManager.scala`
+Driver-side sticky split-to-host assignment. Replaces an older broadcast-based approach. Given a list of splits and a set of executors, it returns stable assignments so the same split is reliably read by the same host across queries (improving cache hit rates). It also tracks prewarm state so `PreWarmManager` knows which splits are already warm on which hosts.
+
+### `storage/SplitManager.scala`
+Despite the filename, this file exports `SplitConversionThrottle`: a JVM-wide `Semaphore` limiting concurrent `QuickwitSplit.convertIndexFromPath` operations. Split conversion is CPU and disk heavy, and running too many in parallel causes thrashing — this throttle is the safety valve.
+
+## How the pieces connect
+
+```
+Write commit (chapter 03)
+      │
+      ├─ AsyncMergeOnWriteManager.maybeTrigger()
+      │     └─ (if threshold) launch merge job
+      │         └─ WorkerLocalSplitMerger on executors
+      │             ├─ io/merge/CloudDownloadManager  (chapter 06)
+      │             ├─ storage/SplitConversionThrottle (protect CPU/disk)
+      │             └─ io/merge/MergeUploader
+      │         └─ NativeTransactionLog.commit(Add+Remove)
+      │
+      └─ PurgeOnWriteTransactionCounter.increment()
+            └─ (if threshold) PurgeOrphanedSplitsCommand (chapter 08)
+
+SQL PREWARM INDEXTABLES CACHE:
+  PreWarmManager
+    ├─ DriverSplitLocalityManager.assign(splits)
+    └─ AsyncPrewarmJobManager on executors
+         └─ (warms components from IndexComponentMapping)
+```
+
+All three subsystems are designed so that failure is tolerable: a missed merge, a deferred purge, or a cold prewarm just degrades performance, never correctness.
+
+The next chapter covers the SQL commands that drive these subsystems from user code.

--- a/docs/walkthrough/07-merge-and-purge.md
+++ b/docs/walkthrough/07-merge-and-purge.md
@@ -1,8 +1,8 @@
-# 07 — Merge, Purge, Prewarm
+# 07 — Merge and Purge
 
-Three post-commit maintenance subsystems share a common shape: a driver-side singleton plus a configuration object plus some executor-side workers. They are all opt-in or conservative by default so they never block the write commit path.
+Two post-commit maintenance subsystems share a common shape: a driver-side singleton plus a configuration object plus executor-side workers. They are intentionally out-of-band — the write commit path in chapter 03 is never blocked on them. Plus one small but important throttle that keeps merges from trampling each other.
 
-This chapter covers `spark/merge/`, `spark/purge/`, `spark/prewarm/`, and `spark/storage/`.
+This chapter covers `spark/merge/`, `spark/purge/`, and `spark/storage/SplitManager.scala`. (Cache prewarming and `DriverSplitLocalityManager` moved to chapter 02, since they are read-path concerns.)
 
 ## Merge-on-write
 
@@ -17,7 +17,7 @@ The JVM-wide singleton that owns async merge jobs on the driver. Responsibilitie
 - Deduplicates merges — if one is already running for a table, a second `maybeTrigger()` call is a no-op.
 - Supports graceful shutdown so a Spark session teardown waits for in-flight merges to finish (up to the configured timeout).
 
-Post-commit, `IndexTables4SparkStandardWrite` calls `maybeTrigger()`; the manager checks the threshold and either launches a job or does nothing. This is the entire API surface the rest of the connector sees. Internally the manager follows the same singleton pattern as `AsyncPrewarmJobManager`.
+Post-commit, `IndexTables4SparkStandardWrite` calls `maybeTrigger()`; the manager checks the threshold and either launches a job or does nothing. This is the entire API surface the rest of the connector sees.
 
 ### `merge/WorkerLocalSplitMerger.scala`
 The executor-side worker that actually performs a merge. Runs inside the shuffle-based merge task that the `MERGE SPLITS` SQL command (or the async manager) schedules. Responsibilities:
@@ -36,29 +36,10 @@ Configuration: enable/disable, trigger mode (after every merge, or after N write
 ### `purge/PurgeOnWriteTransactionCounter.scala`
 Per-session counter. A `ConcurrentHashMap<tablePath, AtomicInteger>` tracks writes per table; when the count crosses the configured threshold the counter fires a purge and resets. Thread-safe and lock-free on the hot path. The purge itself is handled by `sql/PurgeOrphanedSplitsCommand` and `sql/PurgeOrphanedSplitsExecutor` (chapter 08).
 
-## Prewarm
-
-### `prewarm/PreWarmManager.scala`
-Two-phase cache warmup orchestration:
-
-1. **Pre-scan** — distribute warmup tasks to executors that already hold the relevant splits in cache, using `storage/DriverSplitLocalityManager` to target the right host.
-2. **Post-warm** — when the main query runs, join on the warmup futures so no split is accessed cold.
-
-Returns `PreWarmStats` with cache-hit/miss counts for observability. Triggered by `PREWARM INDEXTABLES CACHE` and also implicitly before large read queries.
-
-### `prewarm/AsyncPrewarmJobManager.scala`
-Executor-side singleton analogous to `AsyncMergeOnWriteManager`: a semaphore-bounded registry of async prewarm jobs with auto-cleanup of completed jobs. This is what `DESCRIBE INDEXTABLES PREWARM JOBS` queries.
-
-### `prewarm/IndexComponentMapping.scala`
-Maps the user-friendly names used in SQL (`TERM`, `FASTFIELD`, `POSTINGS`, `POSITIONS`, `FIELDNORM`, `STORE`) to the `tantivy4java` `IndexComponent` enum. Also defines the default set of components that are warmed when the user does not specify one explicitly.
-
-## Split locality and throttling
-
-### `storage/DriverSplitLocalityManager.scala`
-Driver-side sticky split-to-host assignment. Replaces an older broadcast-based approach. Given a list of splits and a set of executors, it returns stable assignments so the same split is reliably read by the same host across queries (improving cache hit rates). It also tracks prewarm state so `PreWarmManager` knows which splits are already warm on which hosts.
+## Split conversion throttle
 
 ### `storage/SplitManager.scala`
-Despite the filename, this file exports `SplitConversionThrottle`: a JVM-wide `Semaphore` limiting concurrent `QuickwitSplit.convertIndexFromPath` operations. Split conversion is CPU and disk heavy, and running too many in parallel causes thrashing — this throttle is the safety valve.
+Despite the filename, this file exports `SplitConversionThrottle`: a JVM-wide `Semaphore` limiting concurrent `QuickwitSplit.convertIndexFromPath` operations. Split conversion is CPU-heavy and disk-heavy, and running too many in parallel causes thrashing. Both `WorkerLocalSplitMerger` and the write path acquire from this throttle before kicking off a conversion, so it is the one choke point that keeps the box healthy when many tasks are writing or merging at once.
 
 ## How the pieces connect
 
@@ -66,23 +47,17 @@ Despite the filename, this file exports `SplitConversionThrottle`: a JVM-wide `S
 Write commit (chapter 03)
       │
       ├─ AsyncMergeOnWriteManager.maybeTrigger()
-      │     └─ (if threshold) launch merge job
+      │     └─ (if threshold crossed) launch merge job
       │         └─ WorkerLocalSplitMerger on executors
       │             ├─ io/merge/CloudDownloadManager  (chapter 06)
-      │             ├─ storage/SplitConversionThrottle (protect CPU/disk)
+      │             ├─ storage/SplitConversionThrottle
       │             └─ io/merge/MergeUploader
       │         └─ NativeTransactionLog.commit(Add+Remove)
       │
       └─ PurgeOnWriteTransactionCounter.increment()
-            └─ (if threshold) PurgeOrphanedSplitsCommand (chapter 08)
-
-SQL PREWARM INDEXTABLES CACHE:
-  PreWarmManager
-    ├─ DriverSplitLocalityManager.assign(splits)
-    └─ AsyncPrewarmJobManager on executors
-         └─ (warms components from IndexComponentMapping)
+            └─ (if threshold crossed) PurgeOrphanedSplitsCommand (chapter 08)
 ```
 
-All three subsystems are designed so that failure is tolerable: a missed merge, a deferred purge, or a cold prewarm just degrades performance, never correctness.
+Both subsystems are designed so that failure is tolerable: a missed merge or a deferred purge just degrades performance, never correctness.
 
-The next chapter covers the SQL commands that drive these subsystems from user code.
+The next chapter covers the SQL commands that drive these subsystems (and the read-path prewarm subsystem in chapter 02) from user code.

--- a/docs/walkthrough/08-sql-commands.md
+++ b/docs/walkthrough/08-sql-commands.md
@@ -1,0 +1,126 @@
+# 08 — SQL Commands
+
+Registering `io.indextables.extensions.IndexTablesSparkExtensions` in `spark.sql.extensions` unlocks a family of custom SQL commands. Every command is in `spark/sql/` and extends one of Spark's `RunnableCommand` / `LeafRunnableCommand` classes. Both `INDEXTABLES` and `TANTIVY4SPARK` keywords are accepted; every command listed here supports both.
+
+## Parser and extension plumbing
+
+### `sql/IndexTables4SparkSessionExtension.scala`
+Thin `SparkSessionExtensions` hook that installs only the custom SQL parser. Used by embedding contexts that want the SQL grammar without the Catalyst rules.
+
+### `sql/IndexTables4SparkSqlParser.scala`
+Subclass of Spark's parser that recognizes the custom grammar. Falls back to the default parser for standard SQL. Uses an ANTLR lexer/parser for the IndexTables grammar and delegates tree building to the AST builder.
+
+### `sql/parser/IndexTables4SparkSqlAstBuilder.scala`
+ANTLR parse-tree visitor. Converts each grammar rule into the corresponding command case class from `sql/`. This is where new grammar productions get wired up.
+
+### `sql/TableRootUtils.scala`
+Shared utility for the commands that need to resolve, validate, or mutate named table roots (used by multi-region companion indexing). Provides builders, validators, and credential scope helpers.
+
+## Split and table maintenance
+
+### `sql/MergeSplitsCommand.scala`
+`MERGE SPLITS` — consolidates small splits into larger ones within each partition. Follows the Delta `OPTIMIZE` pattern: reads the current transaction log, groups eligible splits, schedules merge tasks (which run through `merge/WorkerLocalSplitMerger`), and commits a single new transaction containing both `Add` and `Remove` actions.
+
+### `sql/PurgeOrphanedSplitsCommand.scala`
+`PURGE INDEXTABLE` — removes split files that exist in storage but are no longer referenced by any version of the transaction log. Anti-joins the storage listing against the txlog. Applies a retention threshold so recently orphaned files (potentially still in-flight) are never touched.
+
+### `sql/PurgeOrphanedSplitsExecutor.scala`
+Executor-side logic for the purge command. Distributed file listing (to avoid driver OOM on huge tables), distributed anti-join between listing and referenced files, batched deletes with retry on transient cloud errors. Also defines `FileInfo`.
+
+### `sql/DropPartitionsCommand.scala`
+`DROP INDEXTABLES PARTITIONS` — adds `RemoveAction` entries for every file matching a partition predicate. Validates that the `WHERE` clause touches only partition columns (no data predicates allowed) so the drop is safe without opening splits.
+
+### `sql/TruncateTimeTravelCommand.scala`
+`TRUNCATE INDEXTABLES TIME TRAVEL` — deletes all historical transaction-log versions except the current one. Data files are left alone. Used to reclaim metadata space on tables with long commit histories.
+
+### `sql/CheckpointCommand.scala`
+`CHECKPOINT INDEXTABLES` / `COMPACT INDEXTABLES` — forces checkpoint creation on the transaction log. Delegates to the native checkpoint implementation.
+
+### `sql/RepairIndexFilesTransactionLogCommand.scala`
+`REPAIR INDEXFILES TRANSACTION LOG` — rebuilds a corrupted transaction log from the set of valid split files still in storage. Read-only with respect to data; applies `util/StatisticsTruncation` so the rebuilt log stays small.
+
+## Cache and prewarm commands
+
+### `sql/PrewarmCacheCommand.scala`
+`PREWARM INDEXTABLES CACHE` — warms selected index components on selected splits across executors. Translates user-friendly component names through `prewarm/IndexComponentMapping` and hands the job to `prewarm/PreWarmManager` / `prewarm/AsyncPrewarmJobManager`.
+
+### `sql/FlushIndexTablesCacheCommand.scala`
+`FLUSH INDEXTABLES SEARCHER CACHE` — invalidates the native-side `SplitCacheManager`.
+
+### `sql/FlushDiskCacheCommand.scala`
+`FLUSH INDEXTABLES DISK CACHE` — deletes the on-disk L2 cache across executors and clears any split-to-host locality assignments.
+
+### `sql/InvalidateTransactionLogCacheCommand.scala`
+`INVALIDATE INDEXTABLES TRANSACTION LOG CACHE` — invalidates the process-level transaction log cache either globally or per table. Reports cache hit/miss rates before and after so users can see the effect.
+
+## Describe / introspection commands
+
+These commands never mutate state. Every one of them returns a DataFrame with a well-defined schema; see `docs/reference/sql-commands.md` for the column definitions.
+
+### `sql/DescribeStateCommand.scala`
+`DESCRIBE INDEXTABLES STATE` — transaction log format version, compression, checkpoint age, whether compaction is recommended.
+
+### `sql/DescribeStorageStatsCommand.scala`
+`DESCRIBE INDEXTABLES STORAGE STATS` — per-executor bytes/requests metrics collected from `SplitCacheManager` counters.
+
+### `sql/DescribeDiskCacheCommand.scala`
+`DESCRIBE INDEXTABLES DISK CACHE` — per-executor L2 cache statistics.
+
+### `sql/DescribeEnvironmentCommand.scala`
+`DESCRIBE INDEXTABLES ENVIRONMENT` — Spark and Hadoop config values from the driver and every worker. Runs credential redaction so values matching `key`, `secret`, `token`, `credential`, or `password` are masked.
+
+### `sql/DescribeComponentSizesCommand.scala`
+`DESCRIBE INDEXTABLES COMPONENT SIZES` — per-component (fastfield/term/postings/…) sizes for each split, computed by reading split footers.
+
+### `sql/DescribeMergeJobsCommand.scala`
+`DESCRIBE INDEXTABLES MERGE JOBS` — dumps the `AsyncMergeOnWriteManager` registry (active, completed, failed).
+
+### `sql/DescribePrewarmJobsCommand.scala`
+`DESCRIBE INDEXTABLES PREWARM JOBS` — same, for `AsyncPrewarmJobManager`.
+
+### `sql/DescribeTransactionLogCommand.scala`
+`DESCRIBE INDEXTABLES TRANSACTION LOG` — dumps the contents of the transaction log, optionally including historical versions.
+
+### `sql/DescribeTransactionLogExecutor.scala`
+Shared helper used by the describe-transaction-log command to iterate versions from the latest checkpoint forward.
+
+### `sql/DescribeTableRootsCommand.scala`
+`DESCRIBE INDEXTABLES TABLE ROOTS` — lists the registered named table roots (used in multi-region companion setups).
+
+### `sql/SetTableRootCommand.scala`
+`SET TABLE ROOT …` — adds or updates a named root. Uses the transaction log's metadata update API for concurrent safety.
+
+### `sql/FfiProfilerCommands.scala`
+`ENABLE / DISABLE / RESET / DESCRIBE INDEXTABLES PROFILER` — drives the FFI read-path profiler that lives inside `tantivy4java`. Useful for diagnosing which component of a read is hot.
+
+## Wait commands
+
+### `sql/WaitForPrewarmJobsCommand.scala`
+(File lives alongside the prewarm command.) Blocks until every pending prewarm job either completes or times out. Lets scripts issue `PREWARM …` followed by `WAIT FOR INDEXTABLES PREWARM JOBS` to guarantee warm caches before the workload starts.
+
+## Companion sync command
+
+### `sql/SyncToExternalCommand.scala`
+`BUILD INDEXTABLES COMPANION …` — builds a companion search index on top of an external Delta, Parquet, or Iceberg table. Supports full and incremental modes. Uses everything in `spark/sync/` (next chapter) plus the credential resolution machinery in chapter 10.
+
+### `sql/StreamingCompanionManager.scala`
+Manages a long-running streaming companion. Polls the source version and only fires a sync if something changed. Applies exponential backoff when idle.
+
+### `sql/StreamingCompanionMetrics.scala`
+Metric objects reported by the streaming companion to Spark UI and logs.
+
+## How the pieces connect
+
+```
+SQL text
+  └─ IndexTables4SparkSqlParser                  (parser/)
+        └─ IndexTables4SparkSqlAstBuilder         (parser/)
+             └─ RunnableCommand case class        (one per file above)
+                 ├─ TransactionLog (chapter 04)
+                 ├─ AsyncMergeOnWriteManager      (chapter 07)
+                 ├─ PreWarmManager                (chapter 07)
+                 ├─ PurgeOrphanedSplitsExecutor
+                 └─ sync/*                        (chapter 09)
+```
+
+The next chapter covers the sync package, which powers `BUILD INDEXTABLES COMPANION`.

--- a/docs/walkthrough/09-sync-companion.md
+++ b/docs/walkthrough/09-sync-companion.md
@@ -1,0 +1,80 @@
+# 09 — Companion Sync
+
+A *companion index* is an IndexTables4Spark table that mirrors an external Delta, Parquet, or Iceberg table purely for full-text search. The original data is not moved or copied; only the indexed columns are extracted, tokenized, and written as `.split` files keyed to the same file identity as the source. The `BUILD INDEXTABLES COMPANION` command (chapter 08) drives this subsystem. Everything described here lives in `spark/sync/`.
+
+## Reader abstraction
+
+### `sync/CompanionSourceReader.scala`
+The trait every companion source implements. Exposes the source version (used to detect changes), the list of source files, the partition schema, and the data schema. Also defines `CompanionSourceFile`, the per-file metadata value used downstream.
+
+### `sync/DeltaSourceReader.scala`
+`CompanionSourceReader` implementation for Delta Lake. Delegates the heavy lifting to `DeltaLogReader`.
+
+### `sync/DeltaLogReader.scala`
+Wraps `tantivy4java`'s `delta-kernel-rs` binding — a Rust-based Delta reader embedded in the same native library. Translates `spark.indextables.*` credential keys into the flat key/value pairs `delta-kernel-rs` expects. Reading Delta through this path is much faster than going through the JVM Delta client.
+
+### `sync/IcebergSourceReader.scala`
+Iceberg implementation. Uses the Iceberg Java API to enumerate the latest snapshot's files, handles both Spark-style and Iceberg-style schema JSON formats, and translates credentials. Also supports incremental snapshots so repeated syncs only index what changed.
+
+### `sync/ParquetDirectoryReader.scala`
+Reader for bare Parquet directories (no metadata layer). Lists files, reads the Parquet footer of a representative file for schema inference, and translates credentials the same way the Delta/Iceberg readers do.
+
+## Distributed file handling
+
+Source tables can be huge. All sync operations that scale with file count run as distributed Spark jobs to avoid driver OOM.
+
+### `sync/DistributedSourceScanner.scala`
+Runs file listing as a Spark RDD transformation. Returns a `DistributedScanResult` containing an `RDD[CompanionSourceFile]` plus scan metadata (source version, schema, partition columns, whether the result is incremental, list of removed files). Works identically for Delta, Parquet, and Iceberg.
+
+### `sync/DistributedAntiJoin.scala`
+The change-detection heart of the sync. Given the set of source files and the set of already-indexed files from the companion's own transaction log, it computes:
+
+- **new** — files in source, not in companion → need to be indexed.
+- **gone** — files in companion, not in source → need `RemoveAction`s.
+- **unchanged** — files in both → no work.
+
+The anti-join runs as a Spark shuffle so it scales to tens of millions of files.
+
+### `sync/SparkPredicateToPartitionFilter.scala`
+Translates Spark SQL `WHERE` predicates into the `tantivy4java` `PartitionFilter` JSON. Lets the sync command filter source files natively (inside Rust) rather than shipping the full file listing to the JVM.
+
+## Execution
+
+### `sync/SyncTaskExecutor.scala`
+Executor-side task: takes a `SyncIndexingGroup` (a batch of Parquet files to turn into one `.split`), reads the Parquet data, indexes it, and returns a `SyncResult` containing the resulting `AddAction` and metrics. `SyncConfig` carries all driver-decided settings.
+
+### `sync/SyncMetrics.scala`
+`SyncMetricsAccumulator` and related metric objects. Tracks bytes read from Parquet, splits written, file counts, and timings. Aggregates via Spark accumulators so the Spark UI shows progress during a long sync.
+
+## How the pieces connect
+
+```
+BUILD INDEXTABLES COMPANION FOR '<delta | iceberg | parquet source>'
+  └─ sql/SyncToExternalCommand                       (chapter 08)
+       ├─ select CompanionSourceReader:
+       │    DeltaSourceReader   → DeltaLogReader   → delta-kernel-rs (Rust)
+       │    IcebergSourceReader → Iceberg Java API
+       │    ParquetDirectoryReader → Parquet footer read
+       │
+       ├─ DistributedSourceScanner
+       │     └─ DistributedScanResult(RDD[CompanionSourceFile], metadata)
+       │
+       ├─ DistributedAntiJoin(source files, companion txlog)
+       │     └─ (new, gone, unchanged)
+       │
+       ├─ SparkPredicateToPartitionFilter
+       │     └─ (native-side pruning)
+       │
+       └─ SyncTaskExecutor (per SyncIndexingGroup, on executors)
+             ├─ reads Parquet
+             ├─ indexes via search/IndexTablesDirectInterface
+             │     (chapter 05)
+             ├─ uploads via io/CloudStorageProvider      (chapter 06)
+             └─ returns SyncResult(AddAction, SyncMetrics)
+        ↓
+   NativeTransactionLog.commit(Adds + Removes)         (chapter 04)
+```
+
+For streaming companions, `sql/StreamingCompanionManager` (chapter 08) wraps this whole pipeline in a polling loop that skips work when the source version has not changed.
+
+The final chapter covers the cross-cutting infrastructure — config, auth, metrics, and the general-purpose utilities under `spark/util/`.

--- a/docs/walkthrough/10-config-auth-util.md
+++ b/docs/walkthrough/10-config-auth-util.md
@@ -1,0 +1,109 @@
+# 10 — Config, Auth, Metrics, Memory, Utilities
+
+The remaining packages are cross-cutting infrastructure: they don't define their own execution path but are used from every other chapter. This chapter covers `spark/config/`, `spark/auth/`, `spark/utils/`, `spark/metrics/`, `spark/stats/`, `spark/memory/`, `spark/write/`, and `spark/util/`.
+
+## Configuration
+
+### `config/IndexTables4SparkConfig.scala`
+Table-level config entries stored *inside* the transaction log metadata (so they travel with the table). Defines a type-safe `ConfigEntry` trait plus `BooleanConfigEntry`, `LongConfigEntry`, `StringConfigEntry`. Each entry knows how to serialize and deserialize itself from the flat string map the transaction log uses.
+
+### `config/IndexTables4SparkSQLConf.scala`
+Every `spark.indextables.*` and legacy `spark.tantivy4spark.*` config key the connector understands — AWS credentials, Azure credentials, merge settings, cache settings, writer settings, companion settings, and so on. The constants defined here are referenced from across the codebase so there is a single source of truth for key names.
+
+## Authentication and credentials
+
+### `auth/unity/UnityCatalogAWSCredentialProvider.scala`
+AWS credential provider that calls the Databricks Unity Catalog HTTP API to mint scoped, short-lived credentials. Features:
+
+- Intelligent caching with expiration tracking and a pre-expiry refresh buffer.
+- Fallback from `PATH_READ_WRITE` to `PATH_READ` scope when write access is not needed.
+- Used automatically when a table resides in a Unity-Catalog-managed location.
+
+### `auth/V1ToV2CredentialsProviderAdapter.scala`
+Adapter that wraps an AWS SDK v1 `AWSCredentialsProvider` for use with the AWS SDK v2 `S3Client`. Crucially, `resolveCredentials()` is called on every request, so long-running Spark jobs pick up rotated credentials without reopening the S3 client.
+
+### `utils/CredentialProviderFactory.scala`
+Reflection-based factory for instantiating AWS credential providers without compile-time dependencies on the AWS SDK version. Caches instantiated providers and detects whether a class implements `TableCredentialProvider`. Also defines the simple `BasicAWSCredentials` value class used when the user passes keys explicitly.
+
+### `utils/TableCredentialProvider.scala`
+Trait for *table-scoped* credential resolution — catalog systems (Unity Catalog is the prototype) that mint different credentials per table. Also defines `TableInfo`. When a provider implements this trait, the factory passes it the table name so it can fetch per-table temporary credentials.
+
+## Metrics and stats
+
+### `metrics/ReadPipelineMetrics.scala`
+Per-split granular timing collected during reads: split engine creation, query build, session start, batch retrieval, batch assembly. Nanosecond precision. `ReadPipelineMetrics` instances are mergeable so the driver can aggregate per-split numbers into per-task and per-query totals.
+
+### `metrics/ReadPipelineSparkUIMetrics.scala`
+The Spark UI custom metrics (`CustomSumMetric` / `CustomTaskMetric`) that expose the timing fields above in the SQL tab. One metric per pipeline stage.
+
+### `metrics/DataSkippingSparkUIMetrics.scala`
+Spark UI metrics for data skipping: total files considered, partition-pruned files, data-skipped files, per-filter-type breakdowns. Mixes `SumMetric` (aggregated across tasks) and `MaxMetric` (reported once from the driver) depending on the metric's semantics.
+
+### `stats/DataSkippingMetrics.scala`
+Process-level counters for data skipping effectiveness. Per-table stats kept in a `ConcurrentHashMap`, plus global counters via `AtomicLong`. Used as the data source for the Spark UI metrics above and for logging.
+
+## Memory
+
+### `memory/NativeMemoryInitializer.scala`
+Initializes `tantivy4java`'s native memory pool and links it to Spark's unified memory manager via `TaskContext`. Idempotent: safe to call on every task. Without this, native allocations would be invisible to Spark's memory accounting and could OOM a container.
+
+## Write configuration
+
+### `write/OptimizedWriteConfig.scala`
+Target split size, sampling ratio, min rows for history-based estimation, and distribution mode for the optimized-write path. See chapter 03.
+
+### `write/WriteSizeEstimator.scala`
+Computes the advisory partition size for Spark AQE during optimized writes. Sampling mode or history mode.
+
+### `write/ArrowFfiWriteConfig.scala`
+Arrow FFI write tunables: batch size (rows) and native heap size (MB).
+
+## General utilities (`spark/util/`)
+
+This is the grab-bag. Each file is small and does one thing — listed here so a reader can find the right helper quickly.
+
+- **`CloudPathUtils.scala`** — parses S3 (`s3://`, `s3a://`) and Azure (`wasb`, `abfs`, `azure://`) URIs into bucket/container + key pairs.
+- **`ConfigNormalization.scala`** — canonicalizes `spark.indextables.*` config keys (including legacy `tantivy4spark.*` aliases). Used by every reader and writer to look up settings consistently.
+- **`ConfigParsingUtils.scala`** — typed parsing (`Int`, `Long`, `Boolean`, size string, …) out of `CaseInsensitiveStringMap`.
+- **`ConfigurationResolver.scala`** — multi-source config resolution (Spark session → Hadoop → options → overrides) with well-defined precedence. Defines the `ConfigSource` trait used for custom sources.
+- **`ConfigUtils.scala`** — convenience accessors that read `spark.indextables.*` values directly from a `SparkSession`.
+- **`CredentialRedaction.scala`** — masks config values whose keys match `secret`, `key`, `token`, `credential`, or `password`. Used by `DESCRIBE INDEXTABLES ENVIRONMENT` and log statements.
+- **`ErrorUtil.scala`** — error message construction and exception chaining.
+- **`ExpressionUtils.scala`** — helpers for parsing and manipulating Spark Catalyst expressions (used by the `WHERE` clause support in SQL commands).
+- **`FilterUtils.scala`** — walks a Spark V1 `Filter` tree to extract referenced field names. Used by filter analysis and pushdown decisions.
+- **`IndexingModes.scala`** — enum handling for indexing modes (`FULL`, `NONE`, `NGRAM`, `PHRASE`, …). Mode parsing and validation for `BUILD COMPANION`.
+- **`JsonUtil.scala`** — shared JSON serialization/deserialization helpers (backed by Jackson).
+- **`PartitionUtils.scala`** — partition column and value handling on the write path.
+- **`ProtocolNormalizer.scala`** — normalizes cloud protocol schemes (`s3a` → `s3`, etc.) so downstream code only has to handle one form.
+- **`SchemaValidator.scala`** — validates Spark schemas against IndexTables requirements (no unsupported types, no duplicate field names, etc.).
+- **`SizeParser.scala`** — parses human-readable sizes like `1G`, `512M`, `100KB`.
+- **`SplitMetadataFactory.scala`** — constructs split metadata objects used in transaction log actions.
+- **`StatisticsCalculator.scala`** — computes min/max/null/histogram statistics for data skipping during writes.
+- **`StatisticsTruncation.scala`** — truncates statistics to keep the transaction log small (up to 98% savings on wide tables with long text fields).
+- **`TablePathNormalizer.scala`** — normalizes table paths, resolving catalog names and URIs.
+- **`TimestampUtils.scala`** — timestamp parsing and unit conversion (second / millisecond / microsecond / nanosecond precision).
+- **`TimingUtils.scala`** — lightweight timing helpers (stopwatch-style).
+- **`TypeConversionUtil.scala`** — converts between Java/Scala primitive types and Spark Catalyst types.
+
+## How the pieces connect
+
+Cross-cutting modules don't form a pipeline, but they do follow a few consistent patterns:
+
+```
+Every read/write/command:
+  ├─ Credentials
+  │     ConfigNormalization → CredentialProviderFactory
+  │        ├─ UnityCatalogAWSCredentialProvider  (if Unity Catalog)
+  │        └─ V1ToV2CredentialsProviderAdapter   (if legacy v1 provider)
+  ├─ Configuration
+  │     ConfigurationResolver + IndexTables4SparkSQLConf keys
+  ├─ Paths and protocols
+  │     CloudPathUtils + ProtocolNormalizer
+  ├─ Observability
+  │     ReadPipelineMetrics → ReadPipelineSparkUIMetrics
+  │     DataSkippingMetrics → DataSkippingSparkUIMetrics
+  └─ Native memory
+        NativeMemoryInitializer (once per task)
+```
+
+That completes the walkthrough. The [README](README.md) has the chapter index and a one-paragraph mental model; each chapter above zooms into one slice of the tree. When adding a new module, pick the chapter it belongs in and extend the relevant section — and update the index if you introduce a new top-level package.

--- a/docs/walkthrough/README.md
+++ b/docs/walkthrough/README.md
@@ -46,12 +46,12 @@ src/main/scala/io/indextables/
 Each chapter is self-contained but they build on each other:
 
 1. [01 — Entry Points](01-entry-points.md) — the public provider and extension classes Spark loads first.
-2. [02 — Read Path](02-read-path.md) — how a `spark.read` call becomes a scan, gets pushdown, and returns `ColumnarBatch`es.
+2. [02 — Read Path](02-read-path.md) — how a `spark.read` call becomes a scan, gets pushdown, and returns `ColumnarBatch`es; also covers split locality and cache prewarming.
 3. [03 — Write Path](03-write-path.md) — how a `df.write.save()` call becomes split files and a committed transaction.
 4. [04 — Transaction Log](04-transaction-log.md) — the Delta-style log that is the source of truth for table state.
 5. [05 — Search Engine](05-search-engine.md) — the Tantivy facade, query parsing, filters, and FFI bridges.
 6. [06 — Storage and Merge I/O](06-storage-io.md) — cloud storage abstraction and the async merge I/O pipeline.
-7. [07 — Merge, Purge, Prewarm](07-merge-and-purge.md) — post-commit maintenance subsystems.
+7. [07 — Merge and Purge](07-merge-and-purge.md) — post-commit maintenance subsystems (merge-on-write and purge-on-write).
 8. [08 — SQL Commands](08-sql-commands.md) — the `INDEXTABLES`/`TANTIVY4SPARK` SQL extension.
 9. [09 — Companion Sync](09-sync-companion.md) — building search companions for external Delta/Parquet/Iceberg tables.
 10. [10 — Config, Auth, Utilities](10-config-auth-util.md) — cross-cutting infrastructure.
@@ -60,6 +60,6 @@ Each chapter is self-contained but they build on each other:
 
 A one-paragraph mental model:
 
-> When Spark loads the data source, `provider/IndexTablesProvider` is instantiated. Reads flow through `core/IndexTables4SparkScanBuilder` → `core/IndexTables4SparkScan` → one of the columnar `*PartitionReader`s, which use `search/SplitSearchEngine` to query `.split` files and return data via `arrow/ArrowFfiBridge`. Writes flow through `core/IndexTables4SparkWriteBuilder` → `IndexTables4SparkOptimizedWrite`/`StandardWrite` → `IndexTables4SparkArrowDataWriter`, which exports rows via `arrow/ArrowFfiWriteBridge` into Tantivy. Every read and write consults the `transaction/` log for file listings and commits. Filter and aggregation pushdown is coordinated by `catalyst/` rules plus `filters/`, `expressions/`, and `json/JsonPredicateTranslator`. Storage is abstracted behind `io/CloudStorageProvider`. Post-commit maintenance (merge-on-write, purge-on-write, prewarm) runs through singletons in `merge/`, `purge/`, and `prewarm/`. SQL extensions in `sql/` add operational commands, and `sync/` builds companion indexes over foreign Delta/Parquet/Iceberg tables.
+> When Spark loads the data source, `provider/IndexTablesProvider` is instantiated. Reads flow through `core/IndexTables4SparkScanBuilder` → `core/IndexTables4SparkScan` → one of the columnar `*PartitionReader`s, which use `search/SplitSearchEngine` to query `.split` files and return data via `arrow/ArrowFfiBridge`. The read path is assisted by `storage/DriverSplitLocalityManager` (sticky split→host assignments) and `prewarm/` (cache warming). Writes flow through `core/IndexTables4SparkWriteBuilder` → `IndexTables4SparkOptimizedWrite`/`StandardWrite` → `IndexTables4SparkArrowDataWriter`, which exports rows via `arrow/ArrowFfiWriteBridge` into Tantivy. Every read and write consults the `transaction/` log for file listings and commits. Filter and aggregation pushdown is coordinated by `catalyst/` rules plus `filters/`, `expressions/`, and `json/JsonPredicateTranslator`. Storage is abstracted behind `io/CloudStorageProvider`. Post-commit maintenance (merge-on-write, purge-on-write) runs through singletons in `merge/` and `purge/`. SQL extensions in `sql/` add operational commands, and `sync/` builds companion indexes over foreign Delta/Parquet/Iceberg tables.
 
 Subsequent chapters zoom in on each of those responsibilities.

--- a/docs/walkthrough/README.md
+++ b/docs/walkthrough/README.md
@@ -1,0 +1,65 @@
+# IndexTables4Spark Code Walkthrough
+
+This walkthrough describes the structure of the IndexTables4Spark source tree and the purpose of each module. It is written to orient a new reader: it explains what each package is for, what the individual source files inside it do, and how the modules connect to each other.
+
+IndexTables4Spark is an Apache Spark DataSource V2 connector that turns a Spark table into a high-performance, full-text-searchable index backed by [Tantivy](https://github.com/quickwit-oss/tantivy) (via the `tantivy4java` JNI binding). A table is stored as a collection of immutable Quickwit `.split` files plus a Delta-Lake-style `_transaction_log/`. Read and write paths run entirely inside Spark executors — there is no server process.
+
+## Top-level package layout
+
+```
+src/main/scala/io/indextables/
+├── provider/          — Public TableProvider alias
+├── extensions/        — Public SparkSessionExtensions alias
+└── spark/
+    ├── core/          — DataSource V2 entry points, scans, writes, partition readers
+    ├── catalyst/      — Logical-plan optimizer rules for pushdown
+    ├── extensions/    — Internal SparkSessionExtensions implementation
+    ├── sql/           — Custom SQL commands (MERGE, PURGE, PREWARM, DESCRIBE …)
+    │   └── parser/    — ANTLR AST builder for the SQL extensions
+    ├── transaction/   — Delta-Lake-style transaction log (native + Scala layers)
+    ├── io/            — Cloud storage providers
+    │   └── merge/     — Async download/upload pipeline for merge jobs
+    ├── merge/         — Async merge-on-write system
+    ├── purge/         — Purge-on-write config and counters
+    ├── prewarm/       — Cache prewarming
+    ├── storage/       — Split locality / conversion throttling
+    ├── search/        — Tantivy search facade and query building
+    ├── filters/       — Custom IndexQuery filter types
+    ├── expressions/   — IndexQuery and bucket aggregation Catalyst expressions
+    ├── arrow/         — Arrow FFI bridges (read + write)
+    ├── json/          — Spark ↔ Tantivy JSON/struct converters
+    ├── schema/        — SchemaMapping (write/read schema orchestration)
+    ├── exceptions/    — Public exception types
+    ├── sync/          — Companion sync readers (Delta/Iceberg/Parquet)
+    ├── auth/          — Credential providers (Unity Catalog, SDK adapters)
+    ├── utils/         — Credential provider factory
+    ├── config/        — Config entries and SQLConf keys
+    ├── write/         — Write-path config (optimized write, arrow sizing)
+    ├── metrics/       — Spark UI custom metrics (read pipeline, data skipping)
+    ├── stats/         — Data skipping effectiveness counters
+    ├── memory/        — Native memory pool initialization
+    └── util/          — Shared helpers (paths, filters, configs, sizes, …)
+```
+
+## Reading order
+
+Each chapter is self-contained but they build on each other:
+
+1. [01 — Entry Points](01-entry-points.md) — the public provider and extension classes Spark loads first.
+2. [02 — Read Path](02-read-path.md) — how a `spark.read` call becomes a scan, gets pushdown, and returns `ColumnarBatch`es.
+3. [03 — Write Path](03-write-path.md) — how a `df.write.save()` call becomes split files and a committed transaction.
+4. [04 — Transaction Log](04-transaction-log.md) — the Delta-style log that is the source of truth for table state.
+5. [05 — Search Engine](05-search-engine.md) — the Tantivy facade, query parsing, filters, and FFI bridges.
+6. [06 — Storage and Merge I/O](06-storage-io.md) — cloud storage abstraction and the async merge I/O pipeline.
+7. [07 — Merge, Purge, Prewarm](07-merge-and-purge.md) — post-commit maintenance subsystems.
+8. [08 — SQL Commands](08-sql-commands.md) — the `INDEXTABLES`/`TANTIVY4SPARK` SQL extension.
+9. [09 — Companion Sync](09-sync-companion.md) — building search companions for external Delta/Parquet/Iceberg tables.
+10. [10 — Config, Auth, Utilities](10-config-auth-util.md) — cross-cutting infrastructure.
+
+## How the pieces fit together
+
+A one-paragraph mental model:
+
+> When Spark loads the data source, `provider/IndexTablesProvider` is instantiated. Reads flow through `core/IndexTables4SparkScanBuilder` → `core/IndexTables4SparkScan` → one of the columnar `*PartitionReader`s, which use `search/SplitSearchEngine` to query `.split` files and return data via `arrow/ArrowFfiBridge`. Writes flow through `core/IndexTables4SparkWriteBuilder` → `IndexTables4SparkOptimizedWrite`/`StandardWrite` → `IndexTables4SparkArrowDataWriter`, which exports rows via `arrow/ArrowFfiWriteBridge` into Tantivy. Every read and write consults the `transaction/` log for file listings and commits. Filter and aggregation pushdown is coordinated by `catalyst/` rules plus `filters/`, `expressions/`, and `json/JsonPredicateTranslator`. Storage is abstracted behind `io/CloudStorageProvider`. Post-commit maintenance (merge-on-write, purge-on-write, prewarm) runs through singletons in `merge/`, `purge/`, and `prewarm/`. SQL extensions in `sql/` add operational commands, and `sync/` builds companion indexes over foreign Delta/Parquet/Iceberg tables.
+
+Subsequent chapters zoom in on each of those responsibilities.


### PR DESCRIPTION
## Summary
- Adds an 11-chapter code walkthrough under `docs/walkthrough/` that orients new readers to the IndexTables4Spark source tree.
- Each chapter documents the purpose of every source file in a package and explains how the modules connect across read, write, transaction log, search, storage, maintenance, SQL, companion sync, and cross-cutting layers.
- `docs/walkthrough/README.md` is the index and includes a package tree plus a one-paragraph mental model.

## Chapters
1. Entry points (`provider/`, `extensions/`, DataSource V2)
2. Read path (ScanBuilder, Scan variants, partition readers, catalyst rules)
3. Write path (WriteBuilder, standard/optimized write, Arrow data writer)
4. Transaction log (`NativeTransactionLog`, actions, protocol, caches)
5. Search engine (filters, expressions, Arrow FFI, JSON, schema)
6. Storage and merge I/O (cloud providers, async download pipeline)
7. Merge, purge, prewarm (post-commit maintenance subsystems)
8. SQL commands (parser + every `INDEXTABLES`/`TANTIVY4SPARK` command)
9. Companion sync (Delta/Iceberg/Parquet)
10. Config, auth, metrics, memory, utilities

## Test plan
- [ ] Render each markdown file on GitHub and confirm headings, code blocks, and ASCII diagrams display correctly
- [ ] Spot-check a handful of referenced source file paths still exist (e.g. `spark/core/IndexTables4SparkScan.scala`, `spark/transaction/NativeTransactionLog.scala`, `spark/io/merge/CloudDownloadManager.scala`)
- [ ] Confirm no source files were modified (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)