### PR TITLE
chore: add SECURITY policy and Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      spark-ecosystem:
+        patterns:
+          - "org.apache.spark:*"
+          - "io.delta:*"
+          - "org.apache.iceberg:*"
+      test-dependencies:
+        dependency-type: development
+    labels:
+      - "type: chore"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - "type: chore"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in IndexTables for Spark, please
+report it privately. **Do not file a public issue.**
+
+### Preferred: GitHub Private Vulnerability Reporting
+
+Use GitHub's private vulnerability reporting:
+<https://github.com/indextables/indextables_spark/security/advisories/new>
+
+This routes your report directly to the maintainers and keeps the details
+confidential until a fix is available.
+
+## What to Include
+
+- A description of the issue and its potential impact
+- Steps to reproduce, including affected versions, Spark version, and
+  deployment environment (OSS Spark, Databricks, EMR, etc.)
+- Any proof-of-concept code or test cases (where safe to share)
+- Suggested mitigation, if known
+
+## Response Process
+
+The maintainers will acknowledge receipt of your report and work with you
+on a coordinated disclosure timeline. Fixes are released as patch versions,
+with a security advisory published once the fix is available.
+
+## Supported Versions
+
+Security fixes target the latest minor release line. Older versions are
+supported on a best-effort basis.
+
+## Scope
+
+This policy covers the IndexTables Spark DataSource. Vulnerabilities in
+the underlying tantivy4java library should be reported there:
+<https://github.com/indextables/tantivy4java/security/advisories/new>


### PR DESCRIPTION
## Summary

Adds two governance baseline items:

- **SECURITY.md** — Routes vulnerability reports to GitHub's private vulnerability reporting (already enabled on this repo). Establishes a responsible disclosure path so security issues don't get filed as public issues.
- **.github/dependabot.yml** — Weekly updates for Maven and GitHub Actions. Spark/Delta/Iceberg deps are grouped together; dev/test deps are grouped separately. Labels updates with `type: chore`.

LICENSE is already present.

## Test plan

- [ ] Confirm SECURITY tab appears in the repo navigation
- [ ] Verify Dependabot creates initial PRs after merge (may take ~24h)