### PR TITLE
Support JDK 17 for tests; pin Hadoop to 3.3.4

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,9 @@
 
 ### Build & Test
 ```bash
-export JAVA_HOME=/opt/homebrew/opt/openjdk@11  # Set Java 11
+# JDK 11 is the default build target. JDK 17 is also supported — tests run
+# with the standard Spark `--add-opens` set wired into pom.xml.
+export JAVA_HOME=/opt/homebrew/opt/openjdk@11  # or openjdk@17
 mvn clean compile                              # Build
 
 # Run local tests (excludes cloud tests, uses all CPU cores):

--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,26 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!--
+            JVM module-access flags required to run on JDK 17+ (Spark 4 baseline).
+            Safe under JDK 11: every flag is recognized there, and
+            -XX:+IgnoreUnrecognizedVMOptions guards against any future additions
+            that 11 might not know about. Mirrors Spark's own `extraJavaTestArgs`.
+        -->
+        <extraJavaTestArgs>-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED -Djdk.reflect.useDirectMethodHandle=false</extraJavaTestArgs>
         <scala.version>2.12.20</scala.version>
         <scala.compat.version>2.12</scala.compat.version>
         <spark.version>3.5.3</spark.version>
-        <hadoop.version>3.5.0</hadoop.version>
+        <!--
+            Pin Hadoop to 3.3.4 to match Spark 3.5.x's bundled
+            hadoop-client-api / hadoop-client-runtime (shaded). PR317 bumped
+            this to 3.5.0, which causes hadoop-aws / hadoop-azure to call
+            Configuration.getEnumSet (added in Hadoop 3.4) against Spark's
+            3.3.4 shaded Configuration -> NoSuchMethodError at runtime in
+            S3AFileSystem.initialize.
+        -->
+        <hadoop.version>3.3.4</hadoop.version>
         <aws.sdk.version>2.42.41</aws.sdk.version>
         <scalatest.version>3.2.20</scalatest.version>
         <mockito.version>4.11.0</mockito.version>
@@ -355,7 +371,7 @@
                     <reuseForks>false</reuseForks>
                     <parallel>none</parallel>
                     <!-- JVM settings for forked processes -->
-                    <argLine>-Xmx2g -XX:MaxMetaspaceSize=512m</argLine>
+                    <argLine>-Xmx2g -XX:MaxMetaspaceSize=512m ${extraJavaTestArgs}</argLine>
                     <!-- Environment variables for forked processes -->
                     <environmentVariables>
                         <SPARK_LOCAL_DIRS>/tmp</SPARK_LOCAL_DIRS>
@@ -378,7 +394,7 @@
                     <junitxml>.</junitxml>
                     <filereports>TestSuiteReport.txt</filereports>
                     <!-- Run tests with increased memory; disable SparkUI to avoid port exhaustion under parallel test execution -->
-                    <argLine>-Xmx2g -XX:MaxMetaspaceSize=512m -Dspark.ui.enabled=false</argLine>
+                    <argLine>-Xmx2g -XX:MaxMetaspaceSize=512m -Dspark.ui.enabled=false ${extraJavaTestArgs}</argLine>
                 </configuration>
                 <executions>
                     <execution>

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,7 +13,11 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
+# Minimum supported Java major version. We target JDK 11 bytecode but tests
+# also run cleanly under JDK 17 (Spark 4 baseline) thanks to the --add-opens
+# argLine in pom.xml.
 REQUIRED_JAVA_MAJOR=11
+SUPPORTED_JAVA_MAJORS=(11 17)
 
 # Protoc version to install from GitHub releases (Linux only).
 # Must support --experimental_allow_proto3_optional (used by quickwit proto build).
@@ -156,13 +160,22 @@ get_java_major_version() {
     echo "$major"
 }
 
-# Check if Java 11 is already available
+# Returns 0 if $1 (a Java major version string) is in SUPPORTED_JAVA_MAJORS.
+is_supported_java_major() {
+    local major="$1"
+    for v in "${SUPPORTED_JAVA_MAJORS[@]}"; do
+        [[ "$major" == "$v" ]] && return 0
+    done
+    return 1
+}
+
+# Check if a supported Java is already available (currently 11 or 17).
 check_java() {
     # First check JAVA_HOME if set
     if [[ -n "${JAVA_HOME:-}" ]] && [[ -x "${JAVA_HOME}/bin/java" ]]; then
         local major
         major=$(get_java_major_version "${JAVA_HOME}/bin/java")
-        if [[ "$major" == "$REQUIRED_JAVA_MAJOR" ]]; then
+        if is_supported_java_major "$major"; then
             return 0
         fi
     fi
@@ -170,7 +183,7 @@ check_java() {
     if command -v java &>/dev/null; then
         local major
         major=$(get_java_major_version java)
-        if [[ "$major" == "$REQUIRED_JAVA_MAJOR" ]]; then
+        if is_supported_java_major "$major"; then
             return 0
         fi
     fi
@@ -615,17 +628,18 @@ echo "=================================================================="
 
 ERRORS=0
 
-# Validate Java 11
-# On macOS with Homebrew, set JAVA_HOME hint if not already pointing to Java 11
-if [[ "$PLATFORM" == "macos" ]]; then
-    BREW_JAVA_HOME="/opt/homebrew/opt/openjdk@11"
-    # Fall back to Intel Homebrew path
-    if [[ ! -d "$BREW_JAVA_HOME" ]]; then
-        BREW_JAVA_HOME="/usr/local/opt/openjdk@11"
-    fi
-    if [[ -d "$BREW_JAVA_HOME" ]]; then
-        export JAVA_HOME="$BREW_JAVA_HOME"
-    fi
+# Validate Java
+# On macOS with Homebrew, set JAVA_HOME hint if not already pointing to a
+# supported JDK. Prefer 11 (default build target), fall back to 17.
+if [[ "$PLATFORM" == "macos" ]] && [[ -z "${JAVA_HOME:-}" ]]; then
+    for keg in openjdk@11 openjdk@17; do
+        for brew_prefix in /opt/homebrew /usr/local; do
+            if [[ -d "${brew_prefix}/opt/${keg}" ]]; then
+                export JAVA_HOME="${brew_prefix}/opt/${keg}"
+                break 2
+            fi
+        done
+    done
 fi
 
 if check_java; then
@@ -635,9 +649,9 @@ if check_java; then
     else
         JAVA_VERSION_OUTPUT=$(java -version 2>&1 | head -1)
     fi
-    ok "Java $REQUIRED_JAVA_MAJOR: $JAVA_VERSION_OUTPUT"
+    ok "Java: $JAVA_VERSION_OUTPUT"
 else
-    error "Java $REQUIRED_JAVA_MAJOR not found or wrong version"
+    error "Supported Java not found (need ${SUPPORTED_JAVA_MAJORS[*]})"
     if command -v java &>/dev/null; then
         error "  Found: $(java -version 2>&1 | head -1)"
     fi


### PR DESCRIPTION
## Summary
- Add Spark's standard `--add-opens` set to surefire/scalatest argLines so tests run cleanly under JDK 17 (Spark 4 baseline). Flags are recognized on JDK 11 too, guarded by `-XX:+IgnoreUnrecognizedVMOptions`. Build target stays Java 11 bytecode.
- `scripts/setup.sh` now accepts JDK 11 *or* 17 (`SUPPORTED_JAVA_MAJORS=(11 17)`) and auto-detects either Homebrew keg on macOS.
- Revert PR #317's `hadoop.version` 3.3.4 → 3.5.0 bump. Spark 3.5.x's bundled (shaded) `hadoop-client-api` / `hadoop-client-runtime` are still 3.3.4, so `hadoop-aws:3.5.0` calling `Configuration.getEnumSet` (added in Hadoop 3.4) blew up at runtime in `S3AFileSystem.initialize` whenever Delta touched S3 — breaking ~6 `Cloud*Sync*` tests on both JDK 11 and 17.

## Test plan
- [x] `mvn test-compile` clean on JDK 11 and JDK 17.
- [x] `DateStringFilterValidationTest` 3/3 on JDK 11 and 17.
- [x] `CloudS3DistributedSyncTest` 14/14 on JDK 17 after the Hadoop pin (was failing with `NoSuchMethodError: getEnumSet` before).
- [ ] Full `./scripts/run-tests.sh -j 4` on JDK 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)