### PR TITLE
chore: disable Linux X64 CI pending runner host upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,32 +38,38 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-  build-and-test-linux:
-    name: Build & Test (Linux X64)
-    runs-on: [self-hosted, Linux, X64]
-    environment: test-runners
-    env:
-      JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup dependencies
-        run: ./scripts/setup.sh
-
-      - name: Build
-        run: make compile
-
-      - name: Test
-        id: test-linux
-        run: make test
-
-      - name: Upload test logs
-        if: failure() && steps.test-linux.outputs.log_dir != ''
-        uses: actions/upload-artifact@v7
-        with:
-          name: linux-test-logs
-          path: ${{ steps.test-linux.outputs.log_dir }}/
-          if-no-files-found: warn
-          retention-days: 7
+  # Linux X64 CI is disabled pending a host-OS upgrade on the self-hosted
+  # runner (bluegill, currently Ubuntu 16.04 / runner v2.321.0). The current
+  # runner cannot load actions/checkout@v6 because that action requires
+  # node24, which the runner does not support. Re-enable by uncommenting
+  # the job below once the runner host has been upgraded.
+  #
+  # build-and-test-linux:
+  #   name: Build & Test (Linux X64)
+  #   runs-on: [self-hosted, Linux, X64]
+  #   environment: test-runners
+  #   env:
+  #     JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
+  #
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v6
+  #
+  #     - name: Setup dependencies
+  #       run: ./scripts/setup.sh
+  #
+  #     - name: Build
+  #       run: make compile
+  #
+  #     - name: Test
+  #       id: test-linux
+  #       run: make test
+  #
+  #     - name: Upload test logs
+  #       if: failure() && steps.test-linux.outputs.log_dir != ''
+  #       uses: actions/upload-artifact@v7
+  #       with:
+  #         name: linux-test-logs
+  #         path: ${{ steps.test-linux.outputs.log_dir }}/
+  #         if-no-files-found: warn
+  #         retention-days: 7


### PR DESCRIPTION
## Summary

Comment out the Linux X64 job in `.github/workflows/ci.yml` so PRs no longer show a perpetually-red Linux check.

## Why

The Linux X64 self-hosted runner (bluegill, Ubuntu 16.04 / runner v2.321.0) cannot load `actions/checkout@v6` because v6's `using: node24` is not supported by runners earlier than v2.327. The runner cannot be upgraded in place because Ubuntu 16.04's glibc 2.23 is below the 2.28 floor required by current runner builds. Upgrading the host OS is a multi-hour project on a bare-metal box that also serves a 20T ZFS pool — out of scope for unblocking CI.

Until the runner host is upgraded, every Linux job fails before any project code runs:

\`\`\`
##[error]'using: node24' is not supported, use 'docker', 'node12', 'node16' or 'node20' instead
##[error]Failed to load actions/checkout/v6/action.yml
\`\`\`

The macOS ARM64 self-hosted runner is healthy and serves as the active CI environment.

## Re-enabling

Uncomment the \`build-and-test-linux\` job block in this file. The full job definition is preserved as comments — single-block uncomment restores it.

## Test plan

- [ ] Confirm macOS ARM64 still runs and passes on this PR
- [ ] Confirm Linux X64 no longer appears in the checks list