### PR TITLE
Refactor SearchType to sealed trait + case objects (closes #295)

### DIFF
--- a/src/main/scala/io/indextables/spark/catalyst/V2IndexQueryExpressionRule.scala
+++ b/src/main/scala/io/indextables/spark/catalyst/V2IndexQueryExpressionRule.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Subquer
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 
-import io.indextables.spark.expressions.{IndexQueryAllExpression, IndexQueryExpression}
+import io.indextables.spark.expressions.{AllFieldSearchType, IndexQueryAllExpression, IndexQueryExpression, SearchType}
 import io.indextables.spark.filters._
 import org.slf4j.LoggerFactory
 
@@ -306,7 +306,16 @@ object V2IndexQueryExpressionRule extends Rule[LogicalPlan] {
               case (Some(columnName), Some(queryString)) =>
                 if (columnName == "_indexall") {
                   logger.debug(s"V2IndexQueryExpressionRule: Storing _indexall IndexQuery")
-                  indexQueries += IndexQueryAllFilter(queryString, indexQuery.searchType)
+                  // Widen the single-field searchType to its all-field counterpart. The conversion is
+                  // total today because every SingleFieldSearchType case object also extends
+                  // AllFieldSearchType; the compiler will flag this match if a single-field-only case
+                  // is added.
+                  val asAllField: AllFieldSearchType = indexQuery.searchType match {
+                    case SearchType.IndexQuery => SearchType.IndexQuery
+                    case SearchType.TextSearch => SearchType.TextSearch
+                    case SearchType.FieldMatch => SearchType.FieldMatch
+                  }
+                  indexQueries += IndexQueryAllFilter(queryString, asAllField)
                 } else {
                   logger.debug(s"V2IndexQueryExpressionRule: Storing IndexQuery")
                   indexQueries += IndexQueryFilter(columnName, queryString, indexQuery.searchType)
@@ -361,7 +370,14 @@ object V2IndexQueryExpressionRule extends Rule[LogicalPlan] {
         (extractColumnNameForV2(indexQuery), extractQueryStringForV2(indexQuery)) match {
           case (Some(columnName), Some(queryString)) =>
             if (columnName == "_indexall") {
-              Some(MixedIndexQueryAll(IndexQueryAllFilter(queryString, indexQuery.searchType)))
+              // Widen the single-field searchType to its all-field counterpart. See the matching
+              // conversion in transformExpression for the rationale (total today; compiler-checked).
+              val asAllField: AllFieldSearchType = indexQuery.searchType match {
+                case SearchType.IndexQuery => SearchType.IndexQuery
+                case SearchType.TextSearch => SearchType.TextSearch
+                case SearchType.FieldMatch => SearchType.FieldMatch
+              }
+              Some(MixedIndexQueryAll(IndexQueryAllFilter(queryString, asAllField)))
             } else {
               Some(MixedIndexQuery(IndexQueryFilter(columnName, queryString, indexQuery.searchType)))
             }

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkScanBuilder.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkScanBuilder.scala
@@ -2183,7 +2183,7 @@ class IndexTables4SparkScanBuilder(
                 )
               case None =>
                 logger.warn(
-                  s"Cannot validate ${filter.searchType.toUpperCase} on field '${filter.columnName}': " +
+                  s"Cannot validate ${filter.searchType.value.toUpperCase} on field '${filter.columnName}': " +
                     s"field not found in docMapping. This may occur with tables created before docMapping was available."
                 )
             }
@@ -2212,7 +2212,7 @@ class IndexTables4SparkScanBuilder(
       // No text-type fields at all — TEXTSEARCH/FIELDMATCH on * is meaningless
       allQueryAllFilters.foreach { filter =>
         if (filter.searchType == SearchType.TextSearch || filter.searchType == SearchType.FieldMatch) {
-          val searchOp = filter.searchType.toUpperCase
+          val searchOp = filter.searchType.value.toUpperCase
           val nonTextTypes = docMapping.fieldTypes.values.toSet - "text"
           throw new IllegalArgumentException(
             s"Cannot use * $searchOp: table has no text-type fields in docMapping. " +
@@ -2224,7 +2224,7 @@ class IndexTables4SparkScanBuilder(
     } else {
       allQueryAllFilters.foreach { filter =>
         if (filter.searchType == SearchType.TextSearch || filter.searchType == SearchType.FieldMatch) {
-          val searchOp = filter.searchType.toUpperCase
+          val searchOp = filter.searchType.value.toUpperCase
 
           // Classify text fields by tokenization status
           val (tokenizedFields, nonTokenizedFields) = textFields.keys.toSeq.sorted.partition { field =>

--- a/src/main/scala/io/indextables/spark/expressions/IndexQueryAllExpression.scala
+++ b/src/main/scala/io/indextables/spark/expressions/IndexQueryAllExpression.scala
@@ -34,13 +34,8 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 case class IndexQueryAllExpression(
   child: Expression,
-  searchType: String = SearchType.IndexQueryAll // "indexqueryall", "textsearch", or "fieldmatch"
+  searchType: SearchType = SearchType.IndexQueryAll
 ) extends UnaryExpression with Predicate {
-
-  require(
-    SearchType.validAllFields.contains(searchType),
-    s"Invalid searchType '$searchType'. Must be one of: ${SearchType.validAllFields.mkString(", ")}"
-  )
 
   override def dataType: DataType = BooleanType
 

--- a/src/main/scala/io/indextables/spark/expressions/IndexQueryAllExpression.scala
+++ b/src/main/scala/io/indextables/spark/expressions/IndexQueryAllExpression.scala
@@ -34,8 +34,9 @@ import org.apache.spark.unsafe.types.UTF8String
  */
 case class IndexQueryAllExpression(
   child: Expression,
-  searchType: SearchType = SearchType.IndexQueryAll
-) extends UnaryExpression with Predicate {
+  searchType: AllFieldSearchType = SearchType.IndexQueryAll)
+    extends UnaryExpression
+    with Predicate {
 
   override def dataType: DataType = BooleanType
 

--- a/src/main/scala/io/indextables/spark/expressions/IndexQueryExpression.scala
+++ b/src/main/scala/io/indextables/spark/expressions/IndexQueryExpression.scala
@@ -34,14 +34,9 @@ import org.apache.spark.unsafe.types.UTF8String
 case class IndexQueryExpression(
   left: Expression, // Column reference
   right: Expression, // Query string literal
-  searchType: String = SearchType.IndexQuery // "indexquery", "textsearch", or "fieldmatch"
+  searchType: SearchType = SearchType.IndexQuery
 ) extends BinaryExpression
     with Predicate {
-
-  require(
-    SearchType.validSingleField.contains(searchType),
-    s"Invalid searchType '$searchType'. Must be one of: ${SearchType.validSingleField.mkString(", ")}"
-  )
 
   override def dataType: DataType = BooleanType
 
@@ -52,15 +47,15 @@ case class IndexQueryExpression(
   override lazy val deterministic: Boolean = false
 
   override def prettyName: String = searchType match {
-    case SearchType.TextSearch => "textsearch"
-    case SearchType.FieldMatch => "fieldmatch"
-    case _                     => "indexquery"
+    case SearchType.TextSearch                            => "textsearch"
+    case SearchType.FieldMatch                            => "fieldmatch"
+    case SearchType.IndexQuery | SearchType.IndexQueryAll => "indexquery"
   }
 
   private def displayKeyword: String = searchType match {
-    case SearchType.TextSearch => "TEXTSEARCH"
-    case SearchType.FieldMatch => "FIELDMATCH"
-    case _                     => "indexquery"
+    case SearchType.TextSearch                            => "TEXTSEARCH"
+    case SearchType.FieldMatch                            => "FIELDMATCH"
+    case SearchType.IndexQuery | SearchType.IndexQueryAll => "indexquery"
   }
 
   override def sql: String = s"(${left.sql} $displayKeyword ${right.sql})"

--- a/src/main/scala/io/indextables/spark/expressions/IndexQueryExpression.scala
+++ b/src/main/scala/io/indextables/spark/expressions/IndexQueryExpression.scala
@@ -32,10 +32,10 @@ import org.apache.spark.unsafe.types.UTF8String
  * returns true for all rows since the actual filtering should happen at the data source level.
  */
 case class IndexQueryExpression(
-  left: Expression, // Column reference
+  left: Expression,  // Column reference
   right: Expression, // Query string literal
-  searchType: SearchType = SearchType.IndexQuery
-) extends BinaryExpression
+  searchType: SingleFieldSearchType = SearchType.IndexQuery)
+    extends BinaryExpression
     with Predicate {
 
   override def dataType: DataType = BooleanType
@@ -47,15 +47,15 @@ case class IndexQueryExpression(
   override lazy val deterministic: Boolean = false
 
   override def prettyName: String = searchType match {
-    case SearchType.TextSearch                            => "textsearch"
-    case SearchType.FieldMatch                            => "fieldmatch"
-    case SearchType.IndexQuery | SearchType.IndexQueryAll => "indexquery"
+    case SearchType.TextSearch => "textsearch"
+    case SearchType.FieldMatch => "fieldmatch"
+    case SearchType.IndexQuery => "indexquery"
   }
 
   private def displayKeyword: String = searchType match {
-    case SearchType.TextSearch                            => "TEXTSEARCH"
-    case SearchType.FieldMatch                            => "FIELDMATCH"
-    case SearchType.IndexQuery | SearchType.IndexQueryAll => "indexquery"
+    case SearchType.TextSearch => "TEXTSEARCH"
+    case SearchType.FieldMatch => "FIELDMATCH"
+    case SearchType.IndexQuery => "indexquery"
   }
 
   override def sql: String = s"(${left.sql} $displayKeyword ${right.sql})"
@@ -101,7 +101,9 @@ case class IndexQueryExpression(
     val rightCheck = right.dataType match {
       case StringType => TypeCheckResult.TypeCheckSuccess
       case _ =>
-        TypeCheckResult.TypeCheckFailure(s"Right side of $displayKeyword must be a string literal, got ${right.dataType}")
+        TypeCheckResult.TypeCheckFailure(
+          s"Right side of $displayKeyword must be a string literal, got ${right.dataType}"
+        )
     }
 
     rightCheck

--- a/src/main/scala/io/indextables/spark/expressions/SearchType.scala
+++ b/src/main/scala/io/indextables/spark/expressions/SearchType.scala
@@ -20,11 +20,14 @@ package io.indextables.spark.expressions
 /**
  * Type identifier for search expressions and filters.
  *
- * Implemented as a sealed trait with case objects so that:
- *   - Pattern matches on search types can be proven exhaustive at compile time — adding a new search type causes the
+ * Implemented as a sealed trait hierarchy with case objects so that:
+ *   - Pattern matches on search types can be proven exhaustive at compile time. Adding a new search type causes the
  *     compiler to flag every non-exhaustive match site.
  *   - Construction sites are type-checked, eliminating the runtime `require()` guards that previously validated raw
  *     string inputs.
+ *   - The subset invariant (single-field expressions accept only single-field types; all-fields expressions accept
+ *     all-fields types) is encoded in the type system via [[SingleFieldSearchType]] and [[AllFieldSearchType]]
+ *     sub-traits. No runtime check needed; no nonsensical case branches in pattern matches.
  *   - IDE "find all usages" works per case object instead of conflating literal string occurrences.
  *
  * The `value` field preserves the wire-format string for serialization, SQL display, and external integrations.
@@ -33,16 +36,31 @@ sealed trait SearchType {
   def value: String
 }
 
+/** Search types valid for single-field expressions and filters (`IndexQueryExpression`, `IndexQueryFilter`). */
+sealed trait SingleFieldSearchType extends SearchType
+
+/** Search types valid for all-fields expressions and filters (`IndexQueryAllExpression`, `IndexQueryAllFilter`). */
+sealed trait AllFieldSearchType extends SearchType
+
 object SearchType {
-  case object IndexQuery extends SearchType { val value = "indexquery" }
-  case object IndexQueryAll extends SearchType { val value = "indexqueryall" }
-  case object TextSearch extends SearchType { val value = "textsearch" }
-  case object FieldMatch extends SearchType { val value = "fieldmatch" }
+  case object IndexQuery extends SingleFieldSearchType with AllFieldSearchType {
+    override val value: String = "indexquery"
+  }
+  case object IndexQueryAll extends AllFieldSearchType {
+    override val value: String = "indexqueryall"
+  }
+  case object TextSearch extends SingleFieldSearchType with AllFieldSearchType {
+    override val value: String = "textsearch"
+  }
+  case object FieldMatch extends SingleFieldSearchType with AllFieldSearchType {
+    override val value: String = "fieldmatch"
+  }
 
   /**
    * Parse a raw string (typically from the SQL parser or external input) into a typed [[SearchType]].
    *
-   * @throws IllegalArgumentException if the input does not match any known search type
+   * @throws IllegalArgumentException
+   *   if the input does not match any known search type
    */
   def fromString(s: String): SearchType = s.toLowerCase match {
     case "indexquery"    => IndexQuery

--- a/src/main/scala/io/indextables/spark/expressions/SearchType.scala
+++ b/src/main/scala/io/indextables/spark/expressions/SearchType.scala
@@ -18,24 +18,40 @@
 package io.indextables.spark.expressions
 
 /**
- * Constants for search type identifiers used by IndexQuery expressions and filters.
+ * Type identifier for search expressions and filters.
  *
- * These constants eliminate magic strings and enable `require()` validation in constructors to catch
- * typos at construction time rather than silently bypassing type validation.
+ * Implemented as a sealed trait with case objects so that:
+ *   - Pattern matches on search types can be proven exhaustive at compile time — adding a new search type causes the
+ *     compiler to flag every non-exhaustive match site.
+ *   - Construction sites are type-checked, eliminating the runtime `require()` guards that previously validated raw
+ *     string inputs.
+ *   - IDE "find all usages" works per case object instead of conflating literal string occurrences.
+ *
+ * The `value` field preserves the wire-format string for serialization, SQL display, and external integrations.
  */
+sealed trait SearchType {
+  def value: String
+}
+
 object SearchType {
-  val IndexQuery    = "indexquery"
-  val IndexQueryAll = "indexqueryall"
-  val TextSearch    = "textsearch"
-  val FieldMatch    = "fieldmatch"
+  case object IndexQuery extends SearchType { val value = "indexquery" }
+  case object IndexQueryAll extends SearchType { val value = "indexqueryall" }
+  case object TextSearch extends SearchType { val value = "textsearch" }
+  case object FieldMatch extends SearchType { val value = "fieldmatch" }
 
-  /** Valid search types for single-field expressions (IndexQueryExpression, IndexQueryFilter). */
-  val validSingleField: Set[String] = Set(IndexQuery, TextSearch, FieldMatch)
-
-  /** Valid search types for all-fields expressions (IndexQueryAllExpression, IndexQueryAllFilter).
-    * Both IndexQuery and IndexQueryAll are needed because two code paths produce IndexQueryAllExpression:
-    * - parseExpression: `* indexquery 'q'` → IndexQueryAllExpression(_, SearchType.IndexQuery)
-    * - preprocessor: `indexqueryall('q')` → IndexQueryAllExpression(_, SearchType.IndexQueryAll)
-    * Both are semantically identical but arrive via different parser paths. */
-  val validAllFields: Set[String] = Set(IndexQuery, IndexQueryAll, TextSearch, FieldMatch)
+  /**
+   * Parse a raw string (typically from the SQL parser or external input) into a typed [[SearchType]].
+   *
+   * @throws IllegalArgumentException if the input does not match any known search type
+   */
+  def fromString(s: String): SearchType = s.toLowerCase match {
+    case "indexquery"    => IndexQuery
+    case "indexqueryall" => IndexQueryAll
+    case "textsearch"    => TextSearch
+    case "fieldmatch"    => FieldMatch
+    case other =>
+      throw new IllegalArgumentException(
+        s"Unknown search type '$other'. Must be one of: indexquery, indexqueryall, textsearch, fieldmatch"
+      )
+  }
 }

--- a/src/main/scala/io/indextables/spark/filters/IndexQueryAllFilter.scala
+++ b/src/main/scala/io/indextables/spark/filters/IndexQueryAllFilter.scala
@@ -17,7 +17,7 @@
 
 package io.indextables.spark.filters
 
-import io.indextables.spark.expressions.SearchType
+import io.indextables.spark.expressions.{AllFieldSearchType, SearchType}
 
 /**
  * Custom filter for IndexQueryAll pushdown operations.
@@ -31,7 +31,7 @@ import io.indextables.spark.expressions.SearchType
  * @param queryString
  *   The Tantivy query string to search across all fields
  */
-case class IndexQueryAllFilter(queryString: String, searchType: SearchType = SearchType.IndexQueryAll) {
+case class IndexQueryAllFilter(queryString: String, searchType: AllFieldSearchType = SearchType.IndexQueryAll) {
 
   /**
    * Returns an empty array since this filter doesn't reference specific columns. The search operates across all

--- a/src/main/scala/io/indextables/spark/filters/IndexQueryAllFilter.scala
+++ b/src/main/scala/io/indextables/spark/filters/IndexQueryAllFilter.scala
@@ -31,12 +31,7 @@ import io.indextables.spark.expressions.SearchType
  * @param queryString
  *   The Tantivy query string to search across all fields
  */
-case class IndexQueryAllFilter(queryString: String, searchType: String = SearchType.IndexQueryAll) {
-
-  require(
-    SearchType.validAllFields.contains(searchType),
-    s"Invalid searchType '$searchType'. Must be one of: ${SearchType.validAllFields.mkString(", ")}"
-  )
+case class IndexQueryAllFilter(queryString: String, searchType: SearchType = SearchType.IndexQueryAll) {
 
   /**
    * Returns an empty array since this filter doesn't reference specific columns. The search operates across all
@@ -63,7 +58,7 @@ case class IndexQueryAllFilter(queryString: String, searchType: String = SearchT
    */
   override def toString: String =
     if (searchType == SearchType.IndexQueryAll) s"IndexQueryAllFilter($queryString)"
-    else s"IndexQueryAllFilter[$searchType]($queryString)"
+    else s"IndexQueryAllFilter[${searchType.value}]($queryString)"
 
   /**
    * Checks if this filter is compatible with another filter for combining.

--- a/src/main/scala/io/indextables/spark/filters/IndexQueryFilter.scala
+++ b/src/main/scala/io/indextables/spark/filters/IndexQueryFilter.scala
@@ -41,16 +41,11 @@ import io.indextables.spark.expressions.SearchType
 case class IndexQueryFilter(
   columnName: String,
   queryString: String,
-  searchType: String = SearchType.IndexQuery) {
-
-  require(
-    SearchType.validSingleField.contains(searchType),
-    s"Invalid searchType '$searchType'. Must be one of: ${SearchType.validSingleField.mkString(", ")}"
-  )
+  searchType: SearchType = SearchType.IndexQuery) {
 
   override def toString: String =
     if (searchType == SearchType.IndexQuery) s"IndexQuery($columnName, '$queryString')"
-    else s"IndexQuery[$searchType]($columnName, '$queryString')"
+    else s"IndexQuery[${searchType.value}]($columnName, '$queryString')"
 
   /** References returns the set of column names that this filter references. */
   def references: Array[String] = Array(columnName)

--- a/src/main/scala/io/indextables/spark/filters/IndexQueryFilter.scala
+++ b/src/main/scala/io/indextables/spark/filters/IndexQueryFilter.scala
@@ -17,7 +17,7 @@
 
 package io.indextables.spark.filters
 
-import io.indextables.spark.expressions.SearchType
+import io.indextables.spark.expressions.{SearchType, SingleFieldSearchType}
 
 /**
  * Custom filter representing an indexquery operation for pushdown to Tantivy data source.
@@ -41,7 +41,7 @@ import io.indextables.spark.expressions.SearchType
 case class IndexQueryFilter(
   columnName: String,
   queryString: String,
-  searchType: SearchType = SearchType.IndexQuery) {
+  searchType: SingleFieldSearchType = SearchType.IndexQuery) {
 
   override def toString: String =
     if (searchType == SearchType.IndexQuery) s"IndexQuery($columnName, '$queryString')"

--- a/src/main/scala/io/indextables/spark/sql/IndexTables4SparkSqlParser.scala
+++ b/src/main/scala/io/indextables/spark/sql/IndexTables4SparkSqlParser.scala
@@ -24,7 +24,13 @@ import org.apache.spark.sql.catalyst.parser.ParseErrorListener
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.types.{DataType, StructType}
 
-import io.indextables.spark.expressions.{IndexQueryAllExpression, IndexQueryExpression, SearchType}
+import io.indextables.spark.expressions.{
+  AllFieldSearchType,
+  IndexQueryAllExpression,
+  IndexQueryExpression,
+  SearchType,
+  SingleFieldSearchType
+}
 import io.indextables.spark.sql.parser.{
   IndexTables4SparkSqlAstBuilder,
   IndexTables4SparkSqlBaseLexer,
@@ -155,7 +161,10 @@ class IndexTables4SparkSqlParser(delegate: ParserInterface) extends ParserInterf
         try {
           val trimmedLeft  = leftExpr.trim
           val lowerKeyword = keyword.toLowerCase
-          val searchType = lowerKeyword match {
+          // Explicit type annotation: the result is used in BOTH a single-field expression
+          // (IndexQueryExpression) and an all-fields expression (IndexQueryAllExpression), so the
+          // value must satisfy both sub-traits. Each of the three case objects below extends both.
+          val searchType: SingleFieldSearchType with AllFieldSearchType = lowerKeyword match {
             case "textsearch" => SearchType.TextSearch
             case "fieldmatch" => SearchType.FieldMatch
             case _            => SearchType.IndexQuery
@@ -228,8 +237,8 @@ class IndexTables4SparkSqlParser(delegate: ParserInterface) extends ParserInterf
     }
 
   /**
-   * Preprocess SQL text to convert search operators to function calls that Spark can parse.
-   * Uses a single combined regex pass for all operator variants:
+   * Preprocess SQL text to convert search operators to function calls that Spark can parse. Uses a single combined
+   * regex pass for all operator variants:
    *   - TEXTSEARCH / FIELDMATCH / indexquery (column and * forms)
    *   - indexqueryall() function
    *   - _indexall indexquery form

--- a/src/test/scala/io/indextables/spark/expressions/IndexQueryAllExpressionTest.scala
+++ b/src/test/scala/io/indextables/spark/expressions/IndexQueryAllExpressionTest.scala
@@ -62,9 +62,9 @@ class IndexQueryAllExpressionTest extends AnyFunSuite {
     val query = Literal(UTF8String.fromString("test"), StringType)
 
     assert(IndexQueryAllExpression(query).prettyName == "indexqueryall")
-    assert(IndexQueryAllExpression(query, "textsearch").prettyName == "textsearch_all")
-    assert(IndexQueryAllExpression(query, "fieldmatch").prettyName == "fieldmatch_all")
-    assert(IndexQueryAllExpression(query, "indexqueryall").prettyName == "indexqueryall")
+    assert(IndexQueryAllExpression(query, SearchType.TextSearch).prettyName == "textsearch_all")
+    assert(IndexQueryAllExpression(query, SearchType.FieldMatch).prettyName == "fieldmatch_all")
+    assert(IndexQueryAllExpression(query, SearchType.IndexQueryAll).prettyName == "indexqueryall")
   }
 
   test("IndexQueryAllExpression should generate correct SQL representation for each searchType") {
@@ -73,10 +73,10 @@ class IndexQueryAllExpressionTest extends AnyFunSuite {
     val defaultExpr = IndexQueryAllExpression(query)
     assert(defaultExpr.sql.contains("indexqueryall"))
 
-    val textsearchExpr = IndexQueryAllExpression(query, "textsearch")
+    val textsearchExpr = IndexQueryAllExpression(query, SearchType.TextSearch)
     assert(textsearchExpr.sql.contains("TEXTSEARCH"))
 
-    val fieldmatchExpr = IndexQueryAllExpression(query, "fieldmatch")
+    val fieldmatchExpr = IndexQueryAllExpression(query, SearchType.FieldMatch)
     assert(fieldmatchExpr.sql.contains("FIELDMATCH"))
   }
 
@@ -84,10 +84,10 @@ class IndexQueryAllExpressionTest extends AnyFunSuite {
     val query    = Literal(UTF8String.fromString("test"), StringType)
     val newQuery = Literal(UTF8String.fromString("updated"), StringType)
 
-    val textsearchExpr = IndexQueryAllExpression(query, "textsearch")
+    val textsearchExpr = IndexQueryAllExpression(query, SearchType.TextSearch)
     val updated        = textsearchExpr.copy(child = newQuery)
 
-    assert(updated.searchType == "textsearch")
+    assert(updated.searchType == SearchType.TextSearch)
     assert(updated.getQueryString.contains("updated"))
   }
 
@@ -146,10 +146,10 @@ class IndexQueryAllExpressionTest extends AnyFunSuite {
     assert(defaultExpr.toString.contains("indexqueryall"))
     assert(defaultExpr.toString.contains("test query"))
 
-    val textsearchExpr = IndexQueryAllExpression(query, "textsearch")
+    val textsearchExpr = IndexQueryAllExpression(query, SearchType.TextSearch)
     assert(textsearchExpr.toString.contains("TEXTSEARCH"))
 
-    val fieldmatchExpr = IndexQueryAllExpression(query, "fieldmatch")
+    val fieldmatchExpr = IndexQueryAllExpression(query, SearchType.FieldMatch)
     assert(fieldmatchExpr.toString.contains("FIELDMATCH"))
   }
 

--- a/src/test/scala/io/indextables/spark/expressions/IndexQueryExpressionTest.scala
+++ b/src/test/scala/io/indextables/spark/expressions/IndexQueryExpressionTest.scala
@@ -90,9 +90,9 @@ class IndexQueryExpressionTest extends AnyFunSuite {
     val query  = Literal(UTF8String.fromString("test"), StringType)
 
     assert(IndexQueryExpression(column, query).prettyName == "indexquery")
-    assert(IndexQueryExpression(column, query, "textsearch").prettyName == "textsearch")
-    assert(IndexQueryExpression(column, query, "fieldmatch").prettyName == "fieldmatch")
-    assert(IndexQueryExpression(column, query, "indexquery").prettyName == "indexquery")
+    assert(IndexQueryExpression(column, query, SearchType.TextSearch).prettyName == "textsearch")
+    assert(IndexQueryExpression(column, query, SearchType.FieldMatch).prettyName == "fieldmatch")
+    assert(IndexQueryExpression(column, query, SearchType.IndexQuery).prettyName == "indexquery")
   }
 
   test("IndexQueryExpression should generate correct SQL representation for each searchType") {
@@ -102,10 +102,10 @@ class IndexQueryExpressionTest extends AnyFunSuite {
     val defaultExpr = IndexQueryExpression(column, query)
     assert(defaultExpr.sql.contains("indexquery"))
 
-    val textsearchExpr = IndexQueryExpression(column, query, "textsearch")
+    val textsearchExpr = IndexQueryExpression(column, query, SearchType.TextSearch)
     assert(textsearchExpr.sql.contains("TEXTSEARCH"))
 
-    val fieldmatchExpr = IndexQueryExpression(column, query, "fieldmatch")
+    val fieldmatchExpr = IndexQueryExpression(column, query, SearchType.FieldMatch)
     assert(fieldmatchExpr.sql.contains("FIELDMATCH"))
   }
 
@@ -115,10 +115,10 @@ class IndexQueryExpressionTest extends AnyFunSuite {
     val newColumn = AttributeReference("content", StringType, nullable = true)()
     val newQuery  = Literal(UTF8String.fromString("updated"), StringType)
 
-    val textsearchExpr = IndexQueryExpression(column, query, "textsearch")
+    val textsearchExpr = IndexQueryExpression(column, query, SearchType.TextSearch)
     val updated        = textsearchExpr.copy(left = newColumn, right = newQuery)
 
-    assert(updated.searchType == "textsearch")
+    assert(updated.searchType == SearchType.TextSearch)
     assert(updated.getColumnName.contains("content"))
     assert(updated.getQueryString.contains("updated"))
   }
@@ -188,10 +188,10 @@ class IndexQueryExpressionTest extends AnyFunSuite {
     assert(defaultExpr.toString.contains("title"))
     assert(defaultExpr.toString.contains("test query"))
 
-    val textsearchExpr = IndexQueryExpression(column, query, "textsearch")
+    val textsearchExpr = IndexQueryExpression(column, query, SearchType.TextSearch)
     assert(textsearchExpr.toString.contains("TEXTSEARCH"))
 
-    val fieldmatchExpr = IndexQueryExpression(column, query, "fieldmatch")
+    val fieldmatchExpr = IndexQueryExpression(column, query, SearchType.FieldMatch)
     assert(fieldmatchExpr.toString.contains("FIELDMATCH"))
   }
 }

--- a/src/test/scala/io/indextables/spark/expressions/SearchTypeTypeSafetyTest.scala
+++ b/src/test/scala/io/indextables/spark/expressions/SearchTypeTypeSafetyTest.scala
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.expressions
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+/**
+ * Compile-time tests for the [[SearchType]] sub-trait hierarchy.
+ *
+ * The subset invariant that single-field expressions/filters must not accept the `IndexQueryAll` mode is enforced at
+ * compile time via the [[SingleFieldSearchType]] and [[AllFieldSearchType]] sub-traits. These tests pin that contract:
+ * valid combinations must compile, and invalid combinations must fail to compile.
+ *
+ * If any of these assertions stops behaving as written, the type-safety guarantee has regressed and needs to be
+ * restored (or the test updated to match new intent).
+ */
+class SearchTypeTypeSafetyTest extends AnyFunSuite with Matchers {
+
+  // ----------------------------------------------------------------------------
+  // Positive cases: valid combinations compile cleanly
+  // ----------------------------------------------------------------------------
+
+  test("SingleFieldSearchType ascription accepts IndexQuery, TextSearch, FieldMatch") {
+    """
+      import io.indextables.spark.expressions.{SearchType, SingleFieldSearchType}
+      val a: SingleFieldSearchType = SearchType.IndexQuery
+      val b: SingleFieldSearchType = SearchType.TextSearch
+      val c: SingleFieldSearchType = SearchType.FieldMatch
+    """ should compile
+  }
+
+  test("AllFieldSearchType ascription accepts all four search types") {
+    """
+      import io.indextables.spark.expressions.{SearchType, AllFieldSearchType}
+      val a: AllFieldSearchType = SearchType.IndexQuery
+      val b: AllFieldSearchType = SearchType.IndexQueryAll
+      val c: AllFieldSearchType = SearchType.TextSearch
+      val d: AllFieldSearchType = SearchType.FieldMatch
+    """ should compile
+  }
+
+  test("IndexQueryFilter accepts SingleFieldSearchType case objects (IndexQuery, TextSearch, FieldMatch)") {
+    """
+      import io.indextables.spark.expressions.SearchType
+      import io.indextables.spark.filters.IndexQueryFilter
+      IndexQueryFilter("col", "q", SearchType.IndexQuery)
+      IndexQueryFilter("col", "q", SearchType.TextSearch)
+      IndexQueryFilter("col", "q", SearchType.FieldMatch)
+    """ should compile
+  }
+
+  test("IndexQueryAllFilter accepts all four SearchType case objects") {
+    """
+      import io.indextables.spark.expressions.SearchType
+      import io.indextables.spark.filters.IndexQueryAllFilter
+      IndexQueryAllFilter("q", SearchType.IndexQuery)
+      IndexQueryAllFilter("q", SearchType.IndexQueryAll)
+      IndexQueryAllFilter("q", SearchType.TextSearch)
+      IndexQueryAllFilter("q", SearchType.FieldMatch)
+    """ should compile
+  }
+
+  // ----------------------------------------------------------------------------
+  // Negative cases: the type system blocks the nonsensical combinations
+  // ----------------------------------------------------------------------------
+
+  test("SingleFieldSearchType ascription rejects IndexQueryAll") {
+    """
+      import io.indextables.spark.expressions.{SearchType, SingleFieldSearchType}
+      val bad: SingleFieldSearchType = SearchType.IndexQueryAll
+    """ shouldNot compile
+  }
+
+  test("IndexQueryFilter rejects IndexQueryAll at the call site") {
+    """
+      import io.indextables.spark.expressions.SearchType
+      import io.indextables.spark.filters.IndexQueryFilter
+      IndexQueryFilter("col", "q", SearchType.IndexQueryAll)
+    """ shouldNot compile
+  }
+
+  test("IndexQueryExpression rejects IndexQueryAll at the call site") {
+    """
+      import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Literal}
+      import org.apache.spark.sql.types.StringType
+      import org.apache.spark.unsafe.types.UTF8String
+      import io.indextables.spark.expressions.{IndexQueryExpression, SearchType}
+      val column = AttributeReference("col", StringType, nullable = true)()
+      val query = Literal(UTF8String.fromString("q"), StringType)
+      IndexQueryExpression(column, query, SearchType.IndexQueryAll)
+    """ shouldNot compile
+  }
+}

--- a/src/test/scala/io/indextables/spark/sql/SearchOperatorBehaviors.scala
+++ b/src/test/scala/io/indextables/spark/sql/SearchOperatorBehaviors.scala
@@ -20,7 +20,7 @@ package io.indextables.spark.sql
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 
 import io.indextables.spark.TestBase
-import io.indextables.spark.expressions.{IndexQueryAllExpression, IndexQueryExpression}
+import io.indextables.spark.expressions.{IndexQueryAllExpression, IndexQueryExpression, SearchType}
 
 // --- Valid condition keys (closed sets for excludes validation) ---
 
@@ -82,7 +82,7 @@ object ConditionKeys {
 case class SingleFieldSpec(
     name: String,
     keyword: String,
-    searchType: String,
+    searchType: SearchType,
     requiresTokenized: Option[Boolean],
     matchingColumn: String,
     wrongColumn: String,
@@ -112,7 +112,7 @@ case class AllFieldsSpec(
     name: String,
     keyword: Option[String],
     sqlTemplate: String => String,
-    searchType: String,
+    searchType: SearchType,
     requiresTokenized: Option[Boolean],
     isFunctionSyntax: Boolean = false,
     excludes: Set[String] = Set.empty

--- a/src/test/scala/io/indextables/spark/sql/SearchOperatorBehaviors.scala
+++ b/src/test/scala/io/indextables/spark/sql/SearchOperatorBehaviors.scala
@@ -19,8 +19,14 @@ package io.indextables.spark.sql
 
 import org.apache.spark.sql.catalyst.parser.CatalystSqlParser
 
+import io.indextables.spark.expressions.{
+  AllFieldSearchType,
+  IndexQueryAllExpression,
+  IndexQueryExpression,
+  SearchType,
+  SingleFieldSearchType
+}
 import io.indextables.spark.TestBase
-import io.indextables.spark.expressions.{IndexQueryAllExpression, IndexQueryExpression, SearchType}
 
 // --- Valid condition keys (closed sets for excludes validation) ---
 
@@ -63,66 +69,86 @@ object ConditionKeys {
 /**
  * Spec for a single-field search operator (e.g., `title TEXTSEARCH 'query'`).
  *
- * @param name              Display name for test output (e.g., "TEXTSEARCH")
- * @param keyword           SQL keyword used in queries (e.g., "TEXTSEARCH")
- * @param searchType        Expected SearchType constant value (e.g., "textsearch")
- * @param requiresTokenized Some(true) for TEXTSEARCH, Some(false) for FIELDMATCH, None for indexquery
- * @param matchingColumn    Column in the shared table that matches this operator's type requirement
- * @param wrongColumn       Column in the shared table that mismatches (for type-wrong-throws tests)
- * @param sampleQuery       Query string that returns results on the matching column
- * @param sampleQuery2      Second query string for OR tests
- * @param expectedCount     Expected row count for sampleQuery on the shared table
- * @param expectedIds       Expected row IDs for sampleQuery on the shared table (sorted)
- * @param expectedAndIds    Expected row IDs for sampleQuery AND category='technology' (sorted)
- * @param expectedOrIds     Expected row IDs for sampleQuery OR sampleQuery2 (sorted)
- * @param errorSubstrings   Expected substrings in type validation error messages
- * @param scaleExpectedCount Expected row count for sampleQuery on the 100k-row scale table
- * @param excludes          Condition keys to skip for this operator
+ * @param name
+ *   Display name for test output (e.g., "TEXTSEARCH")
+ * @param keyword
+ *   SQL keyword used in queries (e.g., "TEXTSEARCH")
+ * @param searchType
+ *   Expected SearchType constant value (e.g., "textsearch")
+ * @param requiresTokenized
+ *   Some(true) for TEXTSEARCH, Some(false) for FIELDMATCH, None for indexquery
+ * @param matchingColumn
+ *   Column in the shared table that matches this operator's type requirement
+ * @param wrongColumn
+ *   Column in the shared table that mismatches (for type-wrong-throws tests)
+ * @param sampleQuery
+ *   Query string that returns results on the matching column
+ * @param sampleQuery2
+ *   Second query string for OR tests
+ * @param expectedCount
+ *   Expected row count for sampleQuery on the shared table
+ * @param expectedIds
+ *   Expected row IDs for sampleQuery on the shared table (sorted)
+ * @param expectedAndIds
+ *   Expected row IDs for sampleQuery AND category='technology' (sorted)
+ * @param expectedOrIds
+ *   Expected row IDs for sampleQuery OR sampleQuery2 (sorted)
+ * @param errorSubstrings
+ *   Expected substrings in type validation error messages
+ * @param scaleExpectedCount
+ *   Expected row count for sampleQuery on the 100k-row scale table
+ * @param excludes
+ *   Condition keys to skip for this operator
  */
 case class SingleFieldSpec(
-    name: String,
-    keyword: String,
-    searchType: SearchType,
-    requiresTokenized: Option[Boolean],
-    matchingColumn: String,
-    wrongColumn: String,
-    sampleQuery: String,
-    sampleQuery2: String,
-    expectedCount: Int,
-    expectedIds: Seq[Int],
-    expectedAndIds: Seq[Int],
-    expectedOrIds: Seq[Int],
-    errorSubstrings: Seq[String] = Seq.empty,
-    scaleExpectedCount: Int = 0,
-    excludes: Set[String] = Set.empty
-)
+  name: String,
+  keyword: String,
+  searchType: SingleFieldSearchType,
+  requiresTokenized: Option[Boolean],
+  matchingColumn: String,
+  wrongColumn: String,
+  sampleQuery: String,
+  sampleQuery2: String,
+  expectedCount: Int,
+  expectedIds: Seq[Int],
+  expectedAndIds: Seq[Int],
+  expectedOrIds: Seq[Int],
+  errorSubstrings: Seq[String] = Seq.empty,
+  scaleExpectedCount: Int = 0,
+  excludes: Set[String] = Set.empty)
 
 /**
  * Spec for an all-fields search operator (e.g., `* TEXTSEARCH 'query'` or `indexqueryall('query')`).
  *
- * @param name             Display name for test output (e.g., "* TEXTSEARCH")
- * @param keyword          The infix keyword (e.g., "TEXTSEARCH"); None for function syntax
- * @param sqlTemplate      Function from query string to SQL WHERE fragment
- * @param searchType       Expected SearchType constant value
- * @param requiresTokenized Type validation requirement (same as SingleFieldSpec)
- * @param isFunctionSyntax true for indexqueryall('q') which has no keyword to vary case on
- * @param excludes         Condition keys to skip
+ * @param name
+ *   Display name for test output (e.g., "* TEXTSEARCH")
+ * @param keyword
+ *   The infix keyword (e.g., "TEXTSEARCH"); None for function syntax
+ * @param sqlTemplate
+ *   Function from query string to SQL WHERE fragment
+ * @param searchType
+ *   Expected SearchType constant value
+ * @param requiresTokenized
+ *   Type validation requirement (same as SingleFieldSpec)
+ * @param isFunctionSyntax
+ *   true for indexqueryall('q') which has no keyword to vary case on
+ * @param excludes
+ *   Condition keys to skip
  */
 case class AllFieldsSpec(
-    name: String,
-    keyword: Option[String],
-    sqlTemplate: String => String,
-    searchType: SearchType,
-    requiresTokenized: Option[Boolean],
-    isFunctionSyntax: Boolean = false,
-    excludes: Set[String] = Set.empty
-)
+  name: String,
+  keyword: Option[String],
+  sqlTemplate: String => String,
+  searchType: AllFieldSearchType,
+  requiresTokenized: Option[Boolean],
+  isFunctionSyntax: Boolean = false,
+  excludes: Set[String] = Set.empty)
 
 // --- Behavior traits ---
 
 /**
- * Parameterized test conditions for single-field search operators.
- * Mix into a concrete test class and call `registerSingleFieldTests`.
+ * Parameterized test conditions for single-field search operators. Mix into a concrete test class and call
+ * `registerSingleFieldTests`.
  */
 trait SingleFieldSearchBehaviors { self: TestBase =>
 
@@ -141,8 +167,8 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     spark.read.format(INDEXTABLES_FORMAT).load(path).createOrReplaceTempView(name)
     name
   }
-  private def freshSharedView(): String = freshSfView("shared", sharedTablePath)
-  private def freshEdgeCaseView(): String = freshSfView("edge", edgeCasePath)
+  private def freshSharedView(): String     = freshSfView("shared", sharedTablePath)
+  private def freshEdgeCaseView(): String   = freshSfView("edge", edgeCasePath)
   private def freshColKeywordView(): String = freshSfView("colkw", colKeywordPath)
 
   protected def registerSingleFieldTests(specs: Seq[SingleFieldSpec]): Unit =
@@ -182,7 +208,7 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("basic-parsing")) return
     test(s"${spec.name}: parse simple expression") {
       val parser = new IndexTables4SparkSqlParser(CatalystSqlParser)
-      val expr = parser.parseExpression(s"title ${spec.keyword} 'spark AND sql'")
+      val expr   = parser.parseExpression(s"title ${spec.keyword} 'spark AND sql'")
       assert(expr.isInstanceOf[IndexQueryExpression])
       val iqe = expr.asInstanceOf[IndexQueryExpression]
       assert(iqe.getColumnName.contains("title"))
@@ -215,7 +241,7 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("backtick-columns")) return
     test(s"${spec.name}: backtick-quoted column") {
       val parser = new IndexTables4SparkSqlParser(CatalystSqlParser)
-      val expr = parser.parseExpression(s"`my column` ${spec.keyword} 'test'")
+      val expr   = parser.parseExpression(s"`my column` ${spec.keyword} 'test'")
       assert(expr.isInstanceOf[IndexQueryExpression])
       val iqe = expr.asInstanceOf[IndexQueryExpression]
       assert(iqe.getQueryString.contains("test"))
@@ -227,7 +253,7 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("qualified-columns")) return
     test(s"${spec.name}: qualified column name") {
       val parser = new IndexTables4SparkSqlParser(CatalystSqlParser)
-      val expr = parser.parseExpression(s"table.columnName ${spec.keyword} 'search term'")
+      val expr   = parser.parseExpression(s"table.columnName ${spec.keyword} 'search term'")
       assert(expr.isInstanceOf[IndexQueryExpression])
       val iqe = expr.asInstanceOf[IndexQueryExpression]
       assert(iqe.getQueryString.contains("search term"))
@@ -239,8 +265,8 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("complex-tantivy-syntax")) return
     test(s"${spec.name}: complex Tantivy syntax preserved") {
       val parser = new IndexTables4SparkSqlParser(CatalystSqlParser)
-      val query = "(apache AND spark) OR (hadoop AND mapreduce)"
-      val expr = parser.parseExpression(s"content ${spec.keyword} '$query'")
+      val query  = "(apache AND spark) OR (hadoop AND mapreduce)"
+      val expr   = parser.parseExpression(s"content ${spec.keyword} '$query'")
       assert(expr.isInstanceOf[IndexQueryExpression])
       assert(expr.asInstanceOf[IndexQueryExpression].getQueryString.contains(query))
     }
@@ -250,7 +276,7 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("phrase-queries")) return
     test(s"${spec.name}: phrase query preserved") {
       val parser = new IndexTables4SparkSqlParser(CatalystSqlParser)
-      val expr = parser.parseExpression(s"""content ${spec.keyword} '"exact phrase match"'""")
+      val expr   = parser.parseExpression(s"""content ${spec.keyword} '"exact phrase match"'""")
       assert(expr.isInstanceOf[IndexQueryExpression])
       assert(expr.asInstanceOf[IndexQueryExpression].getQueryString.contains("\"exact phrase match\""))
     }
@@ -260,7 +286,7 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("wildcard-queries")) return
     test(s"${spec.name}: wildcard query preserved") {
       val parser = new IndexTables4SparkSqlParser(CatalystSqlParser)
-      val expr = parser.parseExpression(s"title ${spec.keyword} 'prefix* AND *suffix'")
+      val expr   = parser.parseExpression(s"title ${spec.keyword} 'prefix* AND *suffix'")
       assert(expr.isInstanceOf[IndexQueryExpression])
       assert(expr.asInstanceOf[IndexQueryExpression].getQueryString.contains("prefix* AND *suffix"))
     }
@@ -272,9 +298,11 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("e2e-sql")) return
     test(s"${spec.name}: e2e SQL query returns exact expected results") {
       val view = freshSharedView()
-      val results = spark.sql(
-        s"SELECT id FROM $view WHERE ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery}' ORDER BY id"
-      ).collect()
+      val results = spark
+        .sql(
+          s"SELECT id FROM $view WHERE ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery}' ORDER BY id"
+        )
+        .collect()
       val resultIds = results.map(_.getInt(0)).toSeq
       assert(
         resultIds == spec.expectedIds,
@@ -287,12 +315,14 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("e2e-compound-and")) return
     test(s"${spec.name}: compound AND with standard filter") {
       val view = freshSharedView()
-      val results = spark.sql(
-        s"""SELECT id, category FROM $view
-           |WHERE ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery}'
-           |AND category = 'technology'
-           |ORDER BY id""".stripMargin
-      ).collect()
+      val results = spark
+        .sql(
+          s"""SELECT id, category FROM $view
+             |WHERE ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery}'
+             |AND category = 'technology'
+             |ORDER BY id""".stripMargin
+        )
+        .collect()
       val resultIds = results.map(_.getInt(0)).toSeq
       assert(
         resultIds == spec.expectedAndIds,
@@ -306,12 +336,14 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("e2e-compound-or")) return
     test(s"${spec.name}: compound OR returns union of both queries") {
       val view = freshSharedView()
-      val orResults = spark.sql(
-        s"""SELECT id FROM $view
-           |WHERE ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery}'
-           |OR ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery2}'
-           |ORDER BY id""".stripMargin
-      ).collect()
+      val orResults = spark
+        .sql(
+          s"""SELECT id FROM $view
+             |WHERE ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery}'
+             |OR ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery2}'
+             |ORDER BY id""".stripMargin
+        )
+        .collect()
       val resultIds = orResults.map(_.getInt(0)).toSeq
       assert(
         resultIds == spec.expectedOrIds,
@@ -324,9 +356,11 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("type-correct")) return
     test(s"${spec.name}: correct field type succeeds with exact count") {
       val view = freshSharedView()
-      val results = spark.sql(
-        s"SELECT id FROM $view WHERE ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery}'"
-      ).collect()
+      val results = spark
+        .sql(
+          s"SELECT id FROM $view WHERE ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery}'"
+        )
+        .collect()
       assert(
         results.length == spec.expectedCount,
         s"${spec.name} expected ${spec.expectedCount} rows, got ${results.length}"
@@ -345,18 +379,19 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     test(s"${spec.name}: wrong field type throws IllegalArgumentException") {
       val view = freshSharedView()
       val ex = intercept[IllegalArgumentException] {
-        spark.sql(
-          s"SELECT id FROM $view WHERE ${spec.wrongColumn} ${spec.keyword} '${spec.sampleQuery}'"
-        ).collect()
+        spark
+          .sql(
+            s"SELECT id FROM $view WHERE ${spec.wrongColumn} ${spec.keyword} '${spec.sampleQuery}'"
+          )
+          .collect()
       }
       assert(
         ex.getMessage.contains(s"Cannot use ${spec.keyword.toUpperCase}"),
         s"Expected 'Cannot use ${spec.keyword.toUpperCase}' in error, got: ${ex.getMessage}"
       )
       assert(ex.getMessage.contains(spec.wrongColumn), s"Expected column name in error, got: ${ex.getMessage}")
-      for (substring <- spec.errorSubstrings) {
+      for (substring <- spec.errorSubstrings)
         assert(ex.getMessage.contains(substring), s"Expected '$substring' in error, got: ${ex.getMessage}")
-      }
     }
   }
 
@@ -371,9 +406,11 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     test(s"${spec.name}: wrong field type in compound WHERE still throws") {
       val view = freshSharedView()
       val ex = intercept[IllegalArgumentException] {
-        spark.sql(
-          s"SELECT id FROM $view WHERE ${spec.wrongColumn} ${spec.keyword} '${spec.sampleQuery}' AND id > 0"
-        ).collect()
+        spark
+          .sql(
+            s"SELECT id FROM $view WHERE ${spec.wrongColumn} ${spec.keyword} '${spec.sampleQuery}' AND id > 0"
+          )
+          .collect()
       }
       assert(
         ex.getMessage.contains(s"Cannot use ${spec.keyword.toUpperCase}"),
@@ -391,16 +428,18 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
   private def testColumnNamedAsKeyword(spec: SingleFieldSpec): Unit = {
     if (spec.excludes.contains("column-named-as-keyword")) return
     test(s"${spec.name}: column named '${spec.keyword.toLowerCase}' with ${spec.name} operator") {
-      val view = freshColKeywordView()
-      val colName = spec.keyword.toLowerCase
-      val query = if (spec.requiresTokenized.contains(false)) "active" else "spark"
+      val view          = freshColKeywordView()
+      val colName       = spec.keyword.toLowerCase
+      val query         = if (spec.requiresTokenized.contains(false)) "active" else "spark"
       val expectedCount = if (spec.requiresTokenized.contains(false)) 2 else 1
-      val results = spark.sql(
-        s"SELECT id FROM $view WHERE $colName ${spec.keyword} '$query' ORDER BY id"
-      ).collect()
+      val results = spark
+        .sql(
+          s"SELECT id FROM $view WHERE $colName ${spec.keyword} '$query' ORDER BY id"
+        )
+        .collect()
       assert(
         results.length == expectedCount,
-        s"Column named '${colName}' with ${spec.name} operator: expected $expectedCount rows, got ${results.length}"
+        s"Column named '$colName' with ${spec.name} operator: expected $expectedCount rows, got ${results.length}"
       )
     }
   }
@@ -421,12 +460,14 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
   private def testEmptyQuery(spec: SingleFieldSpec): Unit = {
     if (spec.excludes.contains("empty-query")) return
     test(s"${spec.name}: empty query string should not crash") {
-      val view = freshEdgeCaseView()
-      val col = edgeCaseColumn(spec)
+      val view    = freshEdgeCaseView()
+      val col     = edgeCaseColumn(spec)
       val results = spark.sql(s"SELECT id FROM $view WHERE $col ${spec.keyword} ''").collect()
       // Empty query should not crash. Tantivy may return all rows (match-all) or zero.
-      assert(results.length >= 0 && results.length <= 5,
-        s"${spec.name} with empty query returned unexpected count: ${results.length}")
+      assert(
+        results.length >= 0 && results.length <= 5,
+        s"${spec.name} with empty query returned unexpected count: ${results.length}"
+      )
     }
   }
 
@@ -434,10 +475,12 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("unicode-query")) return
     test(s"${spec.name}: unicode characters return correct results") {
       val view = freshEdgeCaseView()
-      val col = edgeCaseColumn(spec)
-      val results = spark.sql(
-        s"SELECT id FROM $view WHERE $col ${spec.keyword} '日本語' ORDER BY id"
-      ).collect()
+      val col  = edgeCaseColumn(spec)
+      val results = spark
+        .sql(
+          s"SELECT id FROM $view WHERE $col ${spec.keyword} '日本語' ORDER BY id"
+        )
+        .collect()
       if (spec.requiresTokenized.contains(false)) {
         // FIELDMATCH exact match on label: "日本語" matches id=1
         assert(results.length == 1, s"${spec.name} exact match on unicode should return 1 row, got ${results.length}")
@@ -453,19 +496,23 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("special-chars-query")) return
     test(s"${spec.name}: special characters return correct results") {
       val view = freshEdgeCaseView()
-      val col = edgeCaseColumn(spec)
+      val col  = edgeCaseColumn(spec)
       if (spec.requiresTokenized.contains(false)) {
         // FIELDMATCH exact match on label: "user@example.com" matches ids 3, 5
-        val results = spark.sql(
-          s"SELECT id FROM $view WHERE $col ${spec.keyword} 'user@example.com' ORDER BY id"
-        ).collect()
+        val results = spark
+          .sql(
+            s"SELECT id FROM $view WHERE $col ${spec.keyword} 'user@example.com' ORDER BY id"
+          )
+          .collect()
         assert(results.length == 2, s"${spec.name} on 'user@example.com' should return 2 rows, got ${results.length}")
         assert(results.map(_.getInt(0)).toSeq == Seq(3, 5), s"Expected ids Seq(3, 5)")
       } else {
         // TEXTSEARCH/indexquery: "user" tokenized from email content — depends on tokenizer
-        val results = spark.sql(
-          s"SELECT id FROM $view WHERE $col ${spec.keyword} 'user' ORDER BY id"
-        ).collect()
+        val results = spark
+          .sql(
+            s"SELECT id FROM $view WHERE $col ${spec.keyword} 'user' ORDER BY id"
+          )
+          .collect()
         assert(results.length > 0, s"${spec.name} on 'user' should return results")
         assert(results.length < 5, s"${spec.name} on 'user' should not return all rows (got ${results.length})")
       }
@@ -483,31 +530,34 @@ trait SingleFieldSearchBehaviors { self: TestBase =>
       spark.conf.set("spark.indextables.read.defaultLimit", "200000")
       try {
         val view = freshSfView("scale", scalePath)
-        val results = spark.sql(
-          s"SELECT id FROM $view WHERE ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery}' ORDER BY id"
-        ).collect()
+        val results = spark
+          .sql(
+            s"SELECT id FROM $view WHERE ${spec.matchingColumn} ${spec.keyword} '${spec.sampleQuery}' ORDER BY id"
+          )
+          .collect()
         assert(
           results.length == spec.scaleExpectedCount,
           s"${spec.name} at 100k scale: expected ${spec.scaleExpectedCount} rows, got ${results.length}"
         )
         assert(results.length < 100000, s"${spec.name} returned all rows — operator not filtering")
-      } finally {
+      } finally
         spark.conf.set("spark.indextables.read.defaultLimit", "250")
-      }
     }
   }
 }
 
 /**
- * Parameterized test conditions for all-fields search operators.
- * Mix into a concrete test class and call `registerAllFieldsTests`.
+ * Parameterized test conditions for all-fields search operators. Mix into a concrete test class and call
+ * `registerAllFieldsTests`.
  */
 trait AllFieldsSearchBehaviors { self: TestBase =>
 
   /** Path to the shared mixed-type table. */
   protected def sharedTablePath: String
 
-  /** Paths to shared tables (written once in beforeAll). Each test registers a unique view to avoid ThreadLocal leakage. */
+  /**
+   * Paths to shared tables (written once in beforeAll). Each test registers a unique view to avoid ThreadLocal leakage.
+   */
   protected def allTextPath: String
   protected def allStringPath: String
   protected def intOnlyPath: String
@@ -542,9 +592,9 @@ trait AllFieldsSearchBehaviors { self: TestBase =>
   private def testAllFieldsBasicParsing(spec: AllFieldsSpec): Unit = {
     if (spec.excludes.contains("basic-parsing")) return
     test(s"${spec.name}: parse expression") {
-      val parser = new IndexTables4SparkSqlParser(CatalystSqlParser)
+      val parser      = new IndexTables4SparkSqlParser(CatalystSqlParser)
       val sqlFragment = spec.sqlTemplate("spark AND sql")
-      val expr = parser.parseExpression(sqlFragment)
+      val expr        = parser.parseExpression(sqlFragment)
       assert(expr.isInstanceOf[IndexQueryAllExpression], s"Expected IndexQueryAllExpression, got ${expr.getClass}")
       val allExpr = expr.asInstanceOf[IndexQueryAllExpression]
       assert(allExpr.getQueryString.contains("spark AND sql"))
@@ -562,7 +612,7 @@ trait AllFieldsSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("case-insensitivity")) return
     test(s"${spec.name}: case-insensitive keyword") {
       val parser = new IndexTables4SparkSqlParser(CatalystSqlParser)
-      val kw = spec.keyword.get
+      val kw     = spec.keyword.get
       val variants = Seq(
         s"* ${kw.toUpperCase} 'query'",
         s"* ${kw.toLowerCase} 'query'",
@@ -595,25 +645,23 @@ trait AllFieldsSearchBehaviors { self: TestBase =>
     if (spec.excludes.contains("e2e-sql")) return
     test(s"${spec.name}: e2e SQL query returns correct results") {
       if (spec.requiresTokenized.isDefined) {
-        val view = uniformView(spec)
+        val view  = uniformView(spec)
         val query = if (spec.requiresTokenized.contains(true)) "spark" else "active"
         // text: "spark" matches row 1 only (content col); string: "active" matches rows 1, 3 (status col)
         val expectedIds = if (spec.requiresTokenized.contains(true)) Seq(1) else Seq(1, 3)
         val whereClause = spec.sqlTemplate(query)
-        val results = spark.sql(s"SELECT id FROM $view WHERE $whereClause ORDER BY id").collect()
-        val resultIds = results.map(_.getInt(0)).toSeq
-        assert(resultIds == expectedIds,
-          s"${spec.name} on uniform table: expected $expectedIds, got $resultIds")
+        val results     = spark.sql(s"SELECT id FROM $view WHERE $whereClause ORDER BY id").collect()
+        val resultIds   = results.map(_.getInt(0)).toSeq
+        assert(resultIds == expectedIds, s"${spec.name} on uniform table: expected $expectedIds, got $resultIds")
       } else {
         // indexquery/indexqueryall with no type validation: searches all fields on the mixed table.
         // "spark" matches tokenized content in rows 1, 3. No false positives from exact-match
         // fields (status="active"/"inactive") because "spark" doesn't match those values.
-        val view = freshView("mixed", sharedTablePath)
+        val view        = freshView("mixed", sharedTablePath)
         val whereClause = spec.sqlTemplate("spark")
-        val results = spark.sql(s"SELECT id FROM $view WHERE $whereClause ORDER BY id").collect()
-        val resultIds = results.map(_.getInt(0)).toSeq
-        assert(resultIds == Seq(1, 3),
-          s"${spec.name} on shared mixed table: expected Seq(1, 3), got $resultIds")
+        val results     = spark.sql(s"SELECT id FROM $view WHERE $whereClause ORDER BY id").collect()
+        val resultIds   = results.map(_.getInt(0)).toSeq
+        assert(resultIds == Seq(1, 3), s"${spec.name} on shared mixed table: expected Seq(1, 3), got $resultIds")
       }
     }
   }
@@ -623,25 +671,28 @@ trait AllFieldsSearchBehaviors { self: TestBase =>
     test(s"${spec.name}: compound AND with standard filter") {
       if (spec.requiresTokenized.isDefined) {
         // Use shared uniform table + integer filter (id < 3) so * operator doesn't hit the filter column
-        val view = uniformView(spec)
-        val query = if (spec.requiresTokenized.contains(true)) "spark" else "active"
+        val view        = uniformView(spec)
+        val query       = if (spec.requiresTokenized.contains(true)) "spark" else "active"
         val whereClause = spec.sqlTemplate(query)
         // text: "spark" matches id=1 only, AND id < 3 → Seq(1)
         // string: "active" matches ids 1, 3, AND id < 3 → Seq(1)
         val expectedIds = Seq(1)
-        val results = spark.sql(
-          s"SELECT id FROM $view WHERE $whereClause AND id < 3 ORDER BY id"
-        ).collect()
+        val results = spark
+          .sql(
+            s"SELECT id FROM $view WHERE $whereClause AND id < 3 ORDER BY id"
+          )
+          .collect()
         val resultIds = results.map(_.getInt(0)).toSeq
-        assert(resultIds == expectedIds,
-          s"${spec.name} AND: expected $expectedIds, got $resultIds")
+        assert(resultIds == expectedIds, s"${spec.name} AND: expected $expectedIds, got $resultIds")
       } else {
         // "spark" matches content in rows 1, 3; AND category='technology' → ids 1, 3
-        val view = freshView("mixed", sharedTablePath)
+        val view        = freshView("mixed", sharedTablePath)
         val whereClause = spec.sqlTemplate("spark")
-        val results = spark.sql(
-          s"SELECT id FROM $view WHERE $whereClause AND category = 'technology' ORDER BY id"
-        ).collect()
+        val results = spark
+          .sql(
+            s"SELECT id FROM $view WHERE $whereClause AND category = 'technology' ORDER BY id"
+          )
+          .collect()
         val resultIds = results.map(_.getInt(0)).toSeq
         assert(resultIds == Seq(1, 3), s"${spec.name} AND on mixed table: expected Seq(1, 3), got $resultIds")
       }
@@ -659,13 +710,13 @@ trait AllFieldsSearchBehaviors { self: TestBase =>
     }
     if (spec.excludes.contains("type-correct-uniform")) return
     test(s"${spec.name}: all fields correct type succeeds") {
-      val view = uniformView(spec)
+      val view  = uniformView(spec)
       val query = if (spec.requiresTokenized.contains(true)) "spark" else "active"
       // text: "spark" matches row 1 only; string: "active" matches rows 1, 3
       val expectedIds = if (spec.requiresTokenized.contains(true)) Seq(1) else Seq(1, 3)
       val whereClause = spec.sqlTemplate(query)
-      val results = spark.sql(s"SELECT id FROM $view WHERE $whereClause ORDER BY id").collect()
-      val resultIds = results.map(_.getInt(0)).toSeq
+      val results     = spark.sql(s"SELECT id FROM $view WHERE $whereClause ORDER BY id").collect()
+      val resultIds   = results.map(_.getInt(0)).toSeq
       assert(resultIds == expectedIds, s"${spec.name} on uniform table: expected $expectedIds, got $resultIds")
     }
   }
@@ -679,7 +730,7 @@ trait AllFieldsSearchBehaviors { self: TestBase =>
     }
     if (spec.excludes.contains("type-mixed-throws")) return
     test(s"${spec.name}: mixed field types throws") {
-      val view = freshView("mixed", sharedTablePath)
+      val view        = freshView("mixed", sharedTablePath)
       val whereClause = spec.sqlTemplate("spark")
       val ex = intercept[IllegalArgumentException] {
         spark.sql(s"SELECT id FROM $view WHERE $whereClause").collect()
@@ -703,9 +754,10 @@ trait AllFieldsSearchBehaviors { self: TestBase =>
     test(s"${spec.name}: all fields wrong type throws") {
       // * TEXTSEARCH on all-string = wrong; * FIELDMATCH on all-text = wrong
       val (prefix, path) =
-        if (spec.requiresTokenized.contains(true)) ("allstring_wrong", allStringPath) else ("alltext_wrong", allTextPath)
-      val view = freshView(prefix, path)
-      val query = if (spec.requiresTokenized.contains(true)) "active" else "spark"
+        if (spec.requiresTokenized.contains(true)) ("allstring_wrong", allStringPath)
+        else ("alltext_wrong", allTextPath)
+      val view        = freshView(prefix, path)
+      val query       = if (spec.requiresTokenized.contains(true)) "active" else "spark"
       val whereClause = spec.sqlTemplate(query)
       val ex = intercept[IllegalArgumentException] {
         spark.sql(s"SELECT id FROM $view WHERE $whereClause").collect()
@@ -727,7 +779,7 @@ trait AllFieldsSearchBehaviors { self: TestBase =>
     }
     if (spec.excludes.contains("type-no-text-fields-throws")) return
     test(s"${spec.name}: integer-only table (no text/string fields) throws") {
-      val view = freshView("intonly", intOnlyPath)
+      val view        = freshView("intonly", intOnlyPath)
       val whereClause = spec.sqlTemplate("something")
       val ex = intercept[IllegalArgumentException] {
         spark.sql(s"SELECT id FROM $view WHERE $whereClause").collect()

--- a/src/test/scala/io/indextables/spark/sql/SearchOperatorTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/SearchOperatorTest.scala
@@ -455,23 +455,16 @@ class SearchOperatorTest
   // Restored tests from old file — distinct code paths not in the matrix
   // ========================================================================
 
-  // --- Invalid searchType constructor validation ---
+  // --- SearchType parser validation ---
+  // Constructor-level validation is now enforced by the type system (searchType: SearchType
+  // cannot accept arbitrary strings). Invalid raw-string input is rejected at the boundary
+  // where strings cross into the typed domain — SearchType.fromString.
 
-  test("invalid searchType should throw IllegalArgumentException on IndexQueryExpression") {
-    val column = org.apache.spark.sql.catalyst.expressions.AttributeReference("title", StringType, nullable = true)()
-    val query = Literal(UTF8String.fromString("test"), StringType)
+  test("SearchType.fromString should reject unknown values with IllegalArgumentException") {
     val ex = intercept[IllegalArgumentException] {
-      IndexQueryExpression(column, query, "invalid_type")
+      SearchType.fromString("invalid_type")
     }
-    assert(ex.getMessage.contains("invalid_type") || ex.getMessage.contains("requirement failed"))
-  }
-
-  test("invalid searchType should throw IllegalArgumentException on IndexQueryAllExpression") {
-    val query = Literal(UTF8String.fromString("test"), StringType)
-    val ex = intercept[IllegalArgumentException] {
-      IndexQueryAllExpression(query, "invalid_type")
-    }
-    assert(ex.getMessage.contains("invalid_type") || ex.getMessage.contains("requirement failed"))
+    assert(ex.getMessage.contains("invalid_type"))
   }
 
   // --- DocMapping-based validation (read without typemap options) ---


### PR DESCRIPTION
Origin: @schenksj 's review suggestion #9 on PR #287.

Replace the SearchType object's String constants with a sealed trait and case objects, so that:

- Pattern matches on search types are exhaustive at compile time — adding a new search type causes the compiler to flag every non-exhaustive match site, rather than the previous `case _ =>` silently absorbing missing branches.
- Construction sites are type-checked — invalid raw strings can no longer reach IndexQueryExpression / IndexQueryAllExpression / IndexQueryFilter / IndexQueryAllFilter constructors, so the runtime `require()` guards are dropped.
- IDE "find all usages" works per case object.

The `value` field on each case object preserves the wire-format string for serialization, SQL display, and external integration. A `SearchType.fromString` helper provides the single boundary where untrusted strings cross into the typed domain.

Files updated beyond the original issue's listed 8:

- IndexQueryExpressionTest.scala, IndexQueryAllExpressionTest.scala — existing unit tests passed String literals as the searchType argument; updated to use SearchType case objects.
- SearchOperatorBehaviors.scala — shared test helper had `searchType: String` fields on SingleFieldSpec / AllFieldsSpec case classes; updated to SearchType.
- IndexTables4SparkExtensions.scala — already passed SearchType.X case-object values, no source change needed; compiles unchanged.
- TextSearchFieldMatchParserTest.scala does not exist in the tree; the equivalent coverage lives in SearchOperatorTest.scala, which previously had two "invalid String" constructor tests that are no longer reachable (the type system now prevents the input from compiling). Replaced with a single SearchType.fromString rejection test at the parser boundary.

Verified locally: 124/124 tests passing across IndexQueryExpressionTest, IndexQueryAllExpressionTest, SearchOperatorTest, and V2IndexQueryAllValidationTest.

