### PR TITLE
chore(deps): batch dependabot bumps (spark 3.5.8, scala 2.12.21, aws/azure/jackson)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.indextables</groupId>
     <artifactId>indextables_spark</artifactId>
-    <version>0.5.5_spark_3.5.3</version>
+    <version>0.5.5_spark_3.5.8</version>
     <packaging>jar</packaging>
 
     <name>IndexTables4Spark</name>
@@ -54,9 +54,9 @@
             that 11 might not know about. Mirrors Spark's own `extraJavaTestArgs`.
         -->
         <extraJavaTestArgs>-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED -Djdk.reflect.useDirectMethodHandle=false</extraJavaTestArgs>
-        <scala.version>2.12.20</scala.version>
+        <scala.version>2.12.21</scala.version>
         <scala.compat.version>2.12</scala.compat.version>
-        <spark.version>3.5.3</spark.version>
+        <spark.version>3.5.8</spark.version>
         <!--
             Pin Hadoop to 3.3.4 to match Spark 3.5.x's bundled
             hadoop-client-api / hadoop-client-runtime (shaded). PR317 bumped
@@ -66,7 +66,7 @@
             S3AFileSystem.initialize.
         -->
         <hadoop.version>3.3.4</hadoop.version>
-        <aws.sdk.version>2.42.41</aws.sdk.version>
+        <aws.sdk.version>2.44.4</aws.sdk.version>
         <scalatest.version>3.2.20</scalatest.version>
         <mockito.version>4.11.0</mockito.version>
         <antlr.version>4.9.3</antlr.version>
@@ -171,12 +171,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.2</version>
+            <version>2.21.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${scala.compat.version}</artifactId>
-            <version>2.21.2</version>
+            <version>2.21.3</version>
         </dependency>
 
 
@@ -228,14 +228,14 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <version>12.33.3</version>
+            <version>12.33.4</version>
         </dependency>
 
         <!-- Azure Identity SDK for authentication -->
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.11.0</version>
+            <version>1.18.3</version>
         </dependency>
 
         <!-- Logging -->
@@ -291,7 +291,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-core</artifactId>
-            <version>1.12.565</version>
+            <version>1.12.797</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
## Summary

Combines the safe dependabot updates into a single build/test cycle. Supersedes (and closes on merge) PRs #305, #319, #325, #329, #330, #331, #333, #334.

### Bumps applied

| Dependency | From | To | Source PR |
| --- | --- | --- | --- |
| `org.scala-lang:scala-library` | 2.12.20 | 2.12.21 | (latest 2.12 patch) |
| `org.apache.spark:spark-*_2.12` | 3.5.3 | 3.5.8 | #305, #325 |
| `software.amazon.awssdk:s3` | 2.42.41 | 2.44.4 | #334 |
| `com.amazonaws:aws-java-sdk-core` | 1.12.565 | 1.12.797 | #319 |
| `com.fasterxml.jackson.core:jackson-databind` | 2.21.2 | 2.21.3 | #331 |
| `com.fasterxml.jackson.module:jackson-module-scala_2.12` | 2.21.2 | 2.21.3 | #330 |
| `com.azure:azure-storage-blob` | 12.33.3 | 12.33.4 | #333 |
| `com.azure:azure-identity` | 1.11.0 | 1.18.3 | #329 |

Project version string bumped to `0.5.5_spark_3.5.8` accordingly.

### Bumps rejected

- **Scala 3.8.3** (#322) — Spark 3.5 is built against Scala 2.12; bumped to latest 2.12.x (2.12.21) instead.
- **Hadoop 3.5.0** (part of #325) — explicitly pinned to 3.3.4 in a668f151. Spark 3.5's shaded `hadoop-client-api` is 3.3.4; mixing in 3.5.0 `hadoop-aws`/`hadoop-azure` triggers `NoSuchMethodError: Configuration.getEnumSet` (Hadoop 3.4+) at S3A init.
- **Iceberg 1.10.1** (part of #325) — requires Avro 1.12 (`LogicalTypes.timestampNanos`), but Spark 3.5.x ships Avro 1.11.x. Existing pom comment documents this.
- **ANTLR 4.13.2** (part of #325) — incompatible with Spark 3.5's bundled ANTLR 4.9.3. Verified locally: lexer ATN deserialization fails with `Could not deserialize ATN with version 4 (expected 3)`.

## Test plan

- [ ] `mvn clean compile` succeeds
- [ ] `mvn test-compile` succeeds
- [ ] `make test` — full local suite (320 tests) passes
- [ ] Spot-checked: `DropPartitionsParsingTest` passes (ANTLR-sensitive)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)