### PR TITLE
Upgrade to Spark 4.1.0 / Scala 2.13 / JDK 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.indextables</groupId>
     <artifactId>indextables_spark</artifactId>
-    <version>0.5.5_spark_3.5.8</version>
+    <version>0.6.0_spark_4.1.0</version>
     <packaging>jar</packaging>
 
     <name>IndexTables4Spark</name>
@@ -43,8 +43,9 @@
     </distributionManagement>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!--
@@ -54,23 +55,17 @@
             that 11 might not know about. Mirrors Spark's own `extraJavaTestArgs`.
         -->
         <extraJavaTestArgs>-XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.cs=ALL-UNNAMED --add-opens=java.base/sun.security.action=ALL-UNNAMED --add-opens=java.base/sun.util.calendar=ALL-UNNAMED -Djdk.reflect.useDirectMethodHandle=false</extraJavaTestArgs>
-        <scala.version>2.12.21</scala.version>
-        <scala.compat.version>2.12</scala.compat.version>
-        <spark.version>3.5.8</spark.version>
-        <!--
-            Pin Hadoop to 3.3.4 to match Spark 3.5.x's bundled
-            hadoop-client-api / hadoop-client-runtime (shaded). PR317 bumped
-            this to 3.5.0, which causes hadoop-aws / hadoop-azure to call
-            Configuration.getEnumSet (added in Hadoop 3.4) against Spark's
-            3.3.4 shaded Configuration -> NoSuchMethodError at runtime in
-            S3AFileSystem.initialize.
-        -->
-        <hadoop.version>3.3.4</hadoop.version>
+        <scala.version>2.13.17</scala.version>
+        <scala.compat.version>2.13</scala.compat.version>
+        <spark.version>4.1.0</spark.version>
+        <!-- Spark 4.1.x bundles Hadoop 3.4.x; keep aligned to avoid shaded Configuration drift. -->
+        <hadoop.version>3.4.1</hadoop.version>
         <aws.sdk.version>2.44.4</aws.sdk.version>
         <scalatest.version>3.2.20</scalatest.version>
         <mockito.version>4.11.0</mockito.version>
-        <antlr.version>4.9.3</antlr.version>
-        <arrow.version>12.0.1</arrow.version>
+        <antlr.version>4.13.1</antlr.version>
+        <!-- Spark 4.1.x bundles Arrow 18.x. -->
+        <arrow.version>18.3.0</arrow.version>
     </properties>
 
     <dependencyManagement>
@@ -90,6 +85,13 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>
+        </dependency>
+
+        <!-- Parallel collections removed from stdlib in Scala 2.13 -->
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-parallel-collections_${scala.compat.version}</artifactId>
+            <version>1.0.4</version>
         </dependency>
 
         <!-- Spark -->
@@ -171,12 +173,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.21.3</version>
+            <version>2.20.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${scala.compat.version}</artifactId>
-            <version>2.21.3</version>
+            <version>2.20.0</version>
         </dependency>
 
 
@@ -202,7 +204,7 @@
         <dependency>
             <groupId>io.delta</groupId>
             <artifactId>delta-spark_${scala.compat.version}</artifactId>
-            <version>3.3.2</version>
+            <version>4.0.0</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -282,7 +284,7 @@
         <!-- Findify S3Mock for testing S3 functionality - stable, no logging conflicts -->
         <dependency>
             <groupId>io.findify</groupId>
-            <artifactId>s3mock_2.12</artifactId>
+            <artifactId>s3mock_${scala.compat.version}</artifactId>
             <version>0.2.6</version>
             <scope>test</scope>
         </dependency>
@@ -299,8 +301,8 @@
         <dependency>
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-core</artifactId>
-            <!-- 1.10.1 requires Avro 1.12 (LogicalTypes.timestampNanos), but Spark 3.5.x ships Avro 1.11.x. -->
-            <version>1.6.1</version>
+            <!-- Spark 4 builds use Iceberg 1.9+ which ships Avro 1.12 alignment. -->
+            <version>1.9.0</version>
             <scope>test</scope>
             <exclusions>
                 <!-- Let Spark's bundled Guava win on the test classpath -->
@@ -338,6 +340,8 @@
                         <arg>-feature</arg>
                         <arg>-unchecked</arg>
                         <arg>-Xlint</arg>
+                        <arg>-release</arg>
+                        <arg>17</arg>
                     </args>
                 </configuration>
             </plugin>

--- a/src/main/scala/io/indextables/spark/arrow/ArrowFfiWriteBridge.scala
+++ b/src/main/scala/io/indextables/spark/arrow/ArrowFfiWriteBridge.scala
@@ -19,7 +19,7 @@ package io.indextables.spark.arrow
 
 import java.nio.charset.StandardCharsets
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.catalyst.InternalRow

--- a/src/main/scala/io/indextables/spark/catalyst/V2BucketExpressionRule.scala
+++ b/src/main/scala/io/indextables/spark/catalyst/V2BucketExpressionRule.scala
@@ -102,7 +102,7 @@ object V2BucketExpressionRule extends Rule[LogicalPlan] {
     logger.debug(s"V2BucketExpressionRule: Processing plan: ${plan.getClass.getSimpleName}")
 
     plan.transformUp {
-      case agg @ Aggregate(groupingExpressions, aggregateExpressions, child) =>
+      case agg @ Aggregate(groupingExpressions, aggregateExpressions, child, _) =>
         logger.debug(s"V2BucketExpressionRule: Found Aggregate node")
         logger.debug(
           s"V2BucketExpressionRule: Grouping expressions: ${groupingExpressions.map(_.toString).mkString(", ")}"

--- a/src/main/scala/io/indextables/spark/core/FiltersToQueryConverter.scala
+++ b/src/main/scala/io/indextables/spark/core/FiltersToQueryConverter.scala
@@ -1986,7 +1986,7 @@ object FiltersToQueryConverter {
 
         // Parse the custom IndexQueryAll using the split searcher with ALL fields
         // Note: Driver-side validation should have already caught syntax errors
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         val allFieldNames = schema.getFieldNames
         queryLog(s"Converting IndexQueryAllFilter to search across ${allFieldNames.size()} fields: ${allFieldNames.asScala.mkString(", ")}")
         try {
@@ -2106,7 +2106,7 @@ object FiltersToQueryConverter {
         validateIndexQueryAllSafety(indexQueryAllFilter.queryString, schema, options)
 
         // Delegate to existing IndexQueryAllFilter handling - search across ALL fields
-        import scala.collection.JavaConverters._
+        import scala.jdk.CollectionConverters._
         val allFieldNames = schema.getFieldNames
         queryLog(s"MixedBooleanFilter: Converting MixedIndexQueryAll: '${indexQueryAllFilter.queryString}' across ${allFieldNames.size()} fields: ${allFieldNames.asScala.mkString(", ")}")
         try {

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkDataSource.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkDataSource.scala
@@ -19,7 +19,7 @@ package io.indextables.spark.core
 
 import java.util
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.connector.catalog.{SupportsRead, SupportsWrite, TableCapability}
 import org.apache.spark.sql.connector.expressions.Transform

--- a/src/main/scala/io/indextables/spark/core/IndexTables4SparkGroupByAggregateScan.scala
+++ b/src/main/scala/io/indextables/spark/core/IndexTables4SparkGroupByAggregateScan.scala
@@ -885,7 +885,7 @@ class IndexTables4SparkGroupByAggregateReader(
         val splitFieldNames = {
           var schema: io.indextables.tantivy4java.core.Schema = null
           try {
-            import scala.collection.JavaConverters._
+            import scala.jdk.CollectionConverters._
             schema = splitSearchEngine.getSchema()
             if (schema != null) {
               Some(schema.getFieldNames().asScala.toSet)
@@ -1429,7 +1429,7 @@ class IndexTables4SparkGroupByAggregateReader(
     : Option[Set[String]] = {
     var schema: io.indextables.tantivy4java.core.Schema = null
     try {
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       schema = splitSearchEngine.getSchema()
       if (schema != null) Some(schema.getFieldNames().asScala.toSet) else None
     } catch {

--- a/src/main/scala/io/indextables/spark/sql/IndexTables4SparkSqlParser.scala
+++ b/src/main/scala/io/indextables/spark/sql/IndexTables4SparkSqlParser.scala
@@ -217,6 +217,9 @@ class IndexTables4SparkSqlParser(delegate: ParserInterface) extends ParserInterf
   override def parseDataType(sqlText: String): DataType =
     delegate.parseDataType(sqlText)
 
+  override def parseRoutineParam(sqlText: String): StructType =
+    delegate.parseRoutineParam(sqlText)
+
   override def parseQuery(sqlText: String): LogicalPlan =
     try
       parse(sqlText) { parser =>

--- a/src/main/scala/io/indextables/spark/sql/MergeSplitsCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/MergeSplitsCommand.scala
@@ -18,6 +18,7 @@
 package io.indextables.spark.sql
 
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.parallel.CollectionConverters._
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.{Row, SparkSession}
@@ -1151,7 +1152,7 @@ class MergeSplitsExecutor(
                     val txnStartTime = System.currentTimeMillis()
                     logger.info(s"[Batch $batchNum] Committing batch transaction with ${batchRemoveActions.length} removes and ${batchAddActions.length} adds")
 
-                    val version = transactionLog.commitMergeSplits(batchRemoveActions, batchAddActions)
+                    val version = transactionLog.commitMergeSplits(batchRemoveActions.toSeq, batchAddActions.toSeq)
                     transactionLog.invalidateCache() // Ensure cache is updated
 
                     val txnElapsed = System.currentTimeMillis() - txnStartTime

--- a/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
@@ -17,6 +17,7 @@
 
 package io.indextables.spark.sql
 
+import scala.collection.parallel.CollectionConverters._
 import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.{Row, SparkSession}

--- a/src/main/scala/io/indextables/spark/util/ConfigNormalization.scala
+++ b/src/main/scala/io/indextables/spark/util/ConfigNormalization.scala
@@ -18,7 +18,7 @@
 package io.indextables.spark.util
 
 import scala.collection.mutable
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.apache.spark.sql.SparkSession

--- a/src/main/scala/org/apache/spark/sql/IndexTablesColumnBridge.scala
+++ b/src/main/scala/org/apache/spark/sql/IndexTablesColumnBridge.scala
@@ -1,0 +1,16 @@
+/*
+ * Bridge to Spark 4's package-private classic.ExpressionUtils.
+ *
+ * Spark 4 reworked Column to wrap a ColumnNode rather than an Expression, and
+ * relegated the Expression<->Column converters to classic.ExpressionUtils
+ * which is private[sql]. Tests and integration code that build Columns from
+ * Catalyst Expression instances go through this object instead.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.expressions.Expression
+
+object IndexTablesColumnBridge {
+  def column(expr: Expression): Column = classic.ExpressionUtils.column(expr)
+  def expression(col: Column): Expression = classic.ExpressionUtils.expression(col)
+}

--- a/src/test/scala/io/indextables/spark/auth/unity/UnityCatalogAWSCredentialProviderTest.scala
+++ b/src/test/scala/io/indextables/spark/auth/unity/UnityCatalogAWSCredentialProviderTest.scala
@@ -21,6 +21,7 @@ import java.net.{InetSocketAddress, URI}
 import java.util.concurrent.atomic.AtomicInteger
 
 import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
 
 import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
@@ -98,9 +99,7 @@ class UnityCatalogAWSCredentialProviderTest
         val method = exchange.getRequestMethod
         val path   = exchange.getRequestURI.getPath
         val body   = new String(exchange.getRequestBody.readAllBytes())
-        val headers = scala.jdk.CollectionConverters
-          .mapAsScalaMapConverter(exchange.getRequestHeaders)
-          .asScala
+        val headers = exchange.getRequestHeaders.asScala
           .map { case (k, v) => k -> v.get(0) }
           .toMap
 
@@ -128,9 +127,7 @@ class UnityCatalogAWSCredentialProviderTest
         val method = exchange.getRequestMethod
         val path   = exchange.getRequestURI.getPath
         val body   = new String(exchange.getRequestBody.readAllBytes())
-        val headers = scala.jdk.CollectionConverters
-          .mapAsScalaMapConverter(exchange.getRequestHeaders)
-          .asScala
+        val headers = exchange.getRequestHeaders.asScala
           .map { case (k, v) => k -> v.get(0) }
           .toMap
 
@@ -545,9 +542,7 @@ class UnityCatalogAWSCredentialProviderTest
         val method = exchange.getRequestMethod
         val path   = exchange.getRequestURI.getPath
         val body   = new String(exchange.getRequestBody.readAllBytes())
-        val headers = scala.jdk.CollectionConverters
-          .mapAsScalaMapConverter(exchange.getRequestHeaders)
-          .asScala
+        val headers = exchange.getRequestHeaders.asScala
           .map { case (k, v) => k -> v.get(0) }
           .toMap
         requestLog += MockRequest(method, path, body, headers)
@@ -681,9 +676,7 @@ class UnityCatalogAWSCredentialProviderTest
         val method = exchange.getRequestMethod
         val path   = exchange.getRequestURI.getPath
         val body   = new String(exchange.getRequestBody.readAllBytes())
-        val headers = scala.jdk.CollectionConverters
-          .mapAsScalaMapConverter(exchange.getRequestHeaders)
-          .asScala
+        val headers = exchange.getRequestHeaders.asScala
           .map { case (k, v) => k -> v.get(0) }
           .toMap
         requestLog += MockRequest(method, path, body, headers)
@@ -820,9 +813,7 @@ class UnityCatalogAWSCredentialProviderTest
       path,
       (exchange: com.sun.net.httpserver.HttpExchange) => {
         val body = new String(exchange.getRequestBody.readAllBytes())
-        val headers = scala.jdk.CollectionConverters
-          .mapAsScalaMapConverter(exchange.getRequestHeaders)
-          .asScala
+        val headers = exchange.getRequestHeaders.asScala
           .map { case (k, v) => k -> v.get(0) }
           .toMap
         requestLog += MockRequest(exchange.getRequestMethod, exchange.getRequestURI.getPath, body, headers)
@@ -908,9 +899,7 @@ class UnityCatalogAWSCredentialProviderTest
       (exchange: com.sun.net.httpserver.HttpExchange) => {
         callCount += 1
         val body = new String(exchange.getRequestBody.readAllBytes())
-        val headers = scala.jdk.CollectionConverters
-          .mapAsScalaMapConverter(exchange.getRequestHeaders)
-          .asScala
+        val headers = exchange.getRequestHeaders.asScala
           .map { case (k, v) => k -> v.get(0) }
           .toMap
         requestLog += MockRequest(exchange.getRequestMethod, exchange.getRequestURI.getPath, body, headers)

--- a/src/test/scala/io/indextables/spark/catalog/IndexTablesCatalogTest.scala
+++ b/src/test/scala/io/indextables/spark/catalog/IndexTablesCatalogTest.scala
@@ -549,9 +549,7 @@ class CountingTableCatalog(
     counter.incrementAndGet()
     val props = tables.getOrElse(
       ident.name(),
-      throw new org.apache.spark.sql.catalyst.analysis.NoSuchTableException(
-        s"Table '${ident.name()}' not found"
-      )
+      throw new org.apache.spark.sql.catalyst.analysis.NoSuchTableException(ident)
     )
     new PropertiesOnlyTable(props)
   }

--- a/src/test/scala/io/indextables/spark/debug/IndexQueryPushdownDebugTest.scala
+++ b/src/test/scala/io/indextables/spark/debug/IndexQueryPushdownDebugTest.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.{IndexTablesColumnBridge => SparkExprUtils}
 import org.apache.spark.unsafe.types.UTF8String
 
 import io.indextables.spark.expressions.IndexQueryExpression
@@ -79,7 +80,7 @@ class IndexQueryPushdownDebugTest extends AnyFunSuite with TestBase with BeforeA
 
     // Test 1: Create IndexQueryExpression manually (programmatic way)
     println("\n=== Test 1: Programmatic IndexQueryExpression ===")
-    val columnRef      = col("review_text").expr
+    val columnRef      = SparkExprUtils.expression(col("review_text"))
     val queryLiteral   = Literal(UTF8String.fromString("engine"), StringType)
     val indexQueryExpr = IndexQueryExpression(columnRef, queryLiteral)
 
@@ -88,7 +89,7 @@ class IndexQueryPushdownDebugTest extends AnyFunSuite with TestBase with BeforeA
     println(s"Query string: ${indexQueryExpr.getQueryString}")
 
     // Apply the filter
-    val programmaticResult = tantivyDF.filter(new Column(indexQueryExpr))
+    val programmaticResult = tantivyDF.filter(SparkExprUtils.column(indexQueryExpr))
     println("Results with programmatic IndexQueryExpression:")
     programmaticResult.show(false)
 
@@ -145,7 +146,7 @@ class IndexQueryPushdownDebugTest extends AnyFunSuite with TestBase with BeforeA
 
     // Create IndexQueryExpression
     val expr = IndexQueryExpression(
-      col("content").expr,
+      SparkExprUtils.expression(col("content")),
       Literal(UTF8String.fromString("engine"), StringType)
     )
 
@@ -157,7 +158,7 @@ class IndexQueryPushdownDebugTest extends AnyFunSuite with TestBase with BeforeA
     println(s"Filter references: ${filter.get.references.mkString(", ")}")
 
     // Apply and see what happens
-    val result = tantivyDF.filter(new Column(expr))
+    val result = tantivyDF.filter(SparkExprUtils.column(expr))
     println(s"Filtered result count: ${result.count()}")
     result.show(false)
   }

--- a/src/test/scala/io/indextables/spark/debug/V2IndexQueryPushdownTest.scala
+++ b/src/test/scala/io/indextables/spark/debug/V2IndexQueryPushdownTest.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.Literal
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.{IndexTablesColumnBridge => SparkExprUtils}
 import org.apache.spark.unsafe.types.UTF8String
 
 import io.indextables.spark.expressions.IndexQueryExpression
@@ -71,14 +72,14 @@ class V2IndexQueryPushdownTest extends AnyFunSuite with TestBase with BeforeAndA
 
     // Test 1: Programmatic IndexQueryExpression with V2
     println("\n=== Test 1: V2 Programmatic IndexQueryExpression ===")
-    val columnRef      = col("review_text").expr
+    val columnRef      = SparkExprUtils.expression(col("review_text"))
     val queryLiteral   = Literal(UTF8String.fromString("engine"), StringType)
     val indexQueryExpr = IndexQueryExpression(columnRef, queryLiteral)
     println(s"IndexQueryExpression: $indexQueryExpr")
     println(s"Before filter - logical plan:")
     println(tantivyDF.queryExecution.logical.toString)
 
-    val filtered = tantivyDF.filter(new Column(indexQueryExpr))
+    val filtered = tantivyDF.filter(SparkExprUtils.column(indexQueryExpr))
 
     println(s"After filter - logical plan:")
     println(filtered.queryExecution.logical.toString)
@@ -132,7 +133,7 @@ class V2IndexQueryPushdownTest extends AnyFunSuite with TestBase with BeforeAndA
     println(s"IndexQueryAllExpression: $indexQueryAllExpr")
 
     println("Results with V2 programmatic IndexQueryAllExpression:")
-    val indexQueryAllResult = tantivyDF.filter(new Column(indexQueryAllExpr))
+    val indexQueryAllResult = tantivyDF.filter(SparkExprUtils.column(indexQueryAllExpr))
     val indexQueryAllCount  = indexQueryAllResult.collect().length
     indexQueryAllResult.show(truncate = false)
     println(s"IndexQueryAll row count: $indexQueryAllCount")

--- a/src/test/scala/io/indextables/spark/integration/IndexQueryAllIntegrationTest.scala
+++ b/src/test/scala/io/indextables/spark/integration/IndexQueryAllIntegrationTest.scala
@@ -76,7 +76,7 @@ class IndexQueryAllIntegrationTest extends AnyFunSuite with TestBase with Before
     assert(!indexQueryAllExpr.nullable)
 
     // Test with Column wrapper
-    val columnExpr = new org.apache.spark.sql.Column(indexQueryAllExpr)
+    val columnExpr = org.apache.spark.sql.IndexTablesColumnBridge.column(indexQueryAllExpr)
 
     // Since IndexQueryAll returns true in fallback mode, we can test the expression is created
     val filteredDf = df.filter(columnExpr)
@@ -370,7 +370,7 @@ class IndexQueryAllIntegrationTest extends AnyFunSuite with TestBase with Before
           assert(indexQueryAllExpr.dataType.typeName == "boolean")
 
           // Test programmatic usage with Column wrapper
-          val column = new org.apache.spark.sql.Column(indexQueryAllExpr)
+          val column = org.apache.spark.sql.IndexTablesColumnBridge.column(indexQueryAllExpr)
 
           // Read the IndexTables4Spark data and apply the IndexQueryAll filter
           val tantivyDF =
@@ -432,8 +432,8 @@ class IndexQueryAllIntegrationTest extends AnyFunSuite with TestBase with Before
     assert(query2.canPushDown)
 
     // Test combining expressions
-    val column1 = new org.apache.spark.sql.Column(query1)
-    val column2 = new org.apache.spark.sql.Column(query2)
+    val column1 = org.apache.spark.sql.IndexTablesColumnBridge.column(query1)
+    val column2 = org.apache.spark.sql.IndexTablesColumnBridge.column(query2)
 
     // Since IndexQueryAll returns true in fallback, we combine with real filters
     val combinedDf = df.filter(column1 && column2 && col("category") === "tech")

--- a/src/test/scala/io/indextables/spark/integration/TransactionLogStatisticsTest.scala
+++ b/src/test/scala/io/indextables/spark/integration/TransactionLogStatisticsTest.scala
@@ -362,7 +362,7 @@ class TransactionLogStatisticsTest extends TestBase with BeforeAndAfterEach {
     val data = ArrayBuffer[(Long, String, Int, String)]()
     for (id <- idStart.to(idEnd))
       data += ((id, s"User$id", (20 + id % 30).toInt, batchName))
-    data.toDF("id", "name", "age", "batch")
+    data.toSeq.toDF("id", "name", "age", "batch")
   }
 
   private def verifyBatchStatistics(

--- a/src/test/scala/io/indextables/spark/sql/CloudS3PurgeBugReproTest.scala
+++ b/src/test/scala/io/indextables/spark/sql/CloudS3PurgeBugReproTest.scala
@@ -626,8 +626,8 @@ class CloudS3PurgeBugReproTest extends CloudS3TestBase {
           override def accept(path: Path): Boolean = path.getName.endsWith(".split")
         }
       )
-      .toSeq ++ fs.listStatus(tableDir).filter(_.isDirectory).flatMap { partition =>
-      fs.listStatus(partition.getPath).filter(_.getPath.getName.endsWith(".split"))
+      .toSeq ++ fs.listStatus(tableDir).filter(_.isDirectory).toSeq.flatMap { partition =>
+      fs.listStatus(partition.getPath).filter(_.getPath.getName.endsWith(".split")).toSeq
     }
 
     println(s"\nTotal split files BEFORE drop: ${splitsBefore.length}")
@@ -704,9 +704,9 @@ class CloudS3PurgeBugReproTest extends CloudS3TestBase {
           override def accept(path: Path): Boolean = path.getName.endsWith(".split")
         }
       )
-      .toSeq ++ fs.listStatus(tableDir).filter(s => s.isDirectory && s.getPath.getName.startsWith("date=")).flatMap {
+      .toSeq ++ fs.listStatus(tableDir).filter(s => s.isDirectory && s.getPath.getName.startsWith("date=")).toSeq.flatMap {
       partition =>
-        if (fs.exists(partition.getPath)) fs.listStatus(partition.getPath).filter(_.getPath.getName.endsWith(".split"))
+        if (fs.exists(partition.getPath)) fs.listStatus(partition.getPath).filter(_.getPath.getName.endsWith(".split")).toSeq
         else Seq.empty
     }
     println(s"Total split files AFTER purge: ${splitsAfterPurge.length}")

--- a/src/test/scala/io/indextables/spark/util/ConfigUtilsHadoopCacheTest.scala
+++ b/src/test/scala/io/indextables/spark/util/ConfigUtilsHadoopCacheTest.scala
@@ -17,6 +17,8 @@
 
 package io.indextables.spark.util
 
+import scala.collection.parallel.CollectionConverters._
+
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.BeforeAndAfterEach


### PR DESCRIPTION
## Summary
- Drops Spark 3.5 and Scala 2.12 support; targets Spark 4.1.0 / Scala 2.13.17 / JDK 17.
- Main + test code compile cleanly.
- Smoke tests pass: `DateStringFilterValidationTest` (3/3), `BasicAggregatePushdownTest` (2/2). Full regression still pending.

## Dependency bumps (pom.xml)
- Spark 3.5.8 → **4.1.0**
- Scala 2.12.21 → **2.13.17**, JDK 11 → **17** (`maven.compiler.release=17`, scalac `-release 17`)
- Hadoop 3.3.4 → **3.4.1**, Delta 3.3.2 → **4.0.0**, Iceberg 1.6.1 → **1.9.0**
- ANTLR 4.9.3 → **4.13.1**, Arrow 12.0.1 → **18.3.0**
- Jackson pinned to **2.20.0** to match Spark's bundled version (forcing 2.21 caused `NoClassDefFoundError: JsonSerializeAs` at runtime)
- Added `scala-parallel-collections_2.13` — stdlib `.par` was removed in 2.13
- `s3mock_2.12` → `s3mock_${scala.compat.version}`

## Code changes
- `scala.collection.JavaConverters` → `scala.jdk.CollectionConverters` (5 main files)
- `Aggregate(...)` pattern in `V2BucketExpressionRule` gains `_` for new `hint` arg
- New `ParserInterface.parseRoutineParam` override in `IndexTables4SparkSqlParser`
- `.par` users add `import scala.collection.parallel.CollectionConverters._`
- Test fixes: `ArrayBuffer.toSeq.toDF`, `NoSuchTableException(ident)`, explicit `Array.toSeq` for type inference

## New: `IndexTablesColumnBridge`
`src/main/scala/org/apache/spark/sql/IndexTablesColumnBridge.scala` — public bridge to Spark 4's package-private `classic.ExpressionUtils.column(expr)` / `.expression(col)`. Spark 4 reworked `Column` to wrap `ColumnNode` rather than `Expression`, removing `new Column(expr)` and `col.expr`.

## Still to do (why this is draft)
- Wider test-suite run to surface ANSI-mode-default-on fallout (cast/date-parse failures, divide-by-zero behavior)
- Aggregate pushdown end-to-end validation under Spark 4's reworked planner
- `.github/workflows/ci.yml` bump to JDK 17
- Confirm `tantivy4java 0.34.4` is pure-Java (no Scala cross-build needed) — appears so given platform classifiers are for native libs

## Test plan
- [ ] `make test` clean run
- [ ] `make test-cloud` clean run
- [ ] Spot-check aggregate pushdown via Spark UI / `EXPLAIN`
- [ ] CI green on JDK 17

🤖 Generated with [Claude Code](https://claude.com/claude-code)