### PR TITLE
CI + setup: standardize on JDK 17 (setup-java@v5, pinned tantivy4java build)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ### First-Time Setup
 ```bash
-./scripts/setup.sh  # Installs Java 11, Maven, Rust, protoc, builds tantivy4java
+./scripts/setup.sh  # Installs Java 17, Maven, Rust, protoc, builds tantivy4java
 ```
 
 ### Build & Test

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,9 +11,10 @@
 
 ### Build & Test
 ```bash
-# JDK 11 is the default build target. JDK 17 is also supported — tests run
+# JDK 17 is the CI-validated build target (the macOS CI job provisions
+# Temurin 17 via actions/setup-java). JDK 11 is also supported — tests run
 # with the standard Spark `--add-opens` set wired into pom.xml.
-export JAVA_HOME=/opt/homebrew/opt/openjdk@11  # or openjdk@17
+export JAVA_HOME=/opt/homebrew/opt/openjdk@17  # or openjdk@11
 mvn clean compile                              # Build
 
 # Run local tests (excludes cloud tests, uses all CPU cores):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,16 @@ jobs:
   #   name: Build & Test (Linux X64)
   #   runs-on: [self-hosted, Linux, X64]
   #   environment: test-runners
-  #   env:
-  #     JAVA_HOME: /usr/lib/jvm/java-11-openjdk-amd64
   #
   #   steps:
   #     - name: Checkout
   #       uses: actions/checkout@v6
+  #
+  #     - name: Set up Java 17
+  #       uses: actions/setup-java@v4
+  #       with:
+  #         distribution: 'temurin'
+  #         java-version: '17'
   #
   #     - name: Setup dependencies
   #       run: ./scripts/setup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,18 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      # setup-java only adds the JDK to PATH; it does not restore Homebrew.
+      # Ensure brew/mvn/protoc are discoverable for the run: steps below,
+      # even when the runner's service environment omits Homebrew from PATH.
+      - name: Ensure Homebrew on PATH
+        run: |
+          for prefix in /opt/homebrew /usr/local; do
+            if [[ -x "$prefix/bin/brew" ]]; then
+              echo "$prefix/bin" >> "$GITHUB_PATH"
+              echo "$prefix/sbin" >> "$GITHUB_PATH"
+            fi
+          done
+
       - name: Setup dependencies
         run: ./scripts/setup.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -57,7 +57,7 @@ jobs:
   #       uses: actions/checkout@v6
   #
   #     - name: Set up Java 17
-  #       uses: actions/setup-java@v4
+  #       uses: actions/setup-java@v5
   #       with:
   #         distribution: 'temurin'
   #         java-version: '17'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,16 @@ jobs:
     name: Build & Test (macOS ARM64)
     runs-on: [self-hosted, macOS, ARM64]
     environment: test-runners
-    env:
-      JAVA_HOME: /opt/homebrew/opt/openjdk@11
-      PATH: /opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: Setup dependencies
         run: ./scripts/setup.sh

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ spark.sql("SELECT * FROM my_table WHERE status FIELDMATCH 'active'").show()
 ## Development
 
 ```bash
-export JAVA_HOME=/opt/homebrew/opt/openjdk@11  # Java 11 required
+export JAVA_HOME=/opt/homebrew/opt/openjdk@17  # Java 17 (setup.sh installs this)
 mvn clean compile                              # Build
 mvn test                                       # Run tests
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -276,6 +276,10 @@ install_macos() {
                 break
             fi
         done
+        if [[ -z "$required_home" ]]; then
+            error "openjdk@${REQUIRED_JAVA_MAJOR} not found after 'brew install' (unexpected Homebrew prefix?)."
+            exit 1
+        fi
         ok "OpenJDK $REQUIRED_JAVA_MAJOR installed"
     fi
     # Default JAVA_HOME to the pinned JDK when the caller hasn't set one.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,10 +13,13 @@ set -euo pipefail
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-# Minimum supported Java major version. We target JDK 11 bytecode but tests
-# also run cleanly under JDK 17 (Spark 4 baseline) thanks to the --add-opens
-# argLine in pom.xml.
-REQUIRED_JAVA_MAJOR=11
+# Java major version that setup installs and pins the tantivy4java build to.
+# We provision and build against JDK 17 (the version CI uses via
+# actions/setup-java); the project still targets JDK 11 bytecode via the pom
+# release flag, and tests run cleanly under 17 (Spark 4 baseline) thanks to the
+# --add-opens argLine in pom.xml. SUPPORTED_JAVA_MAJORS lists versions the
+# project can run under; REQUIRED_JAVA_MAJOR is the specific one we install.
+REQUIRED_JAVA_MAJOR=17
 SUPPORTED_JAVA_MAJORS=(11 17)
 
 # Protoc version to install from GitHub releases (Linux only).
@@ -79,7 +82,7 @@ while [[ $# -gt 0 ]]; do
             echo "Install and verify development dependencies for IndexTables4Spark."
             echo ""
             echo "Dependencies installed:"
-            echo "  - Java 11 (OpenJDK 11)"
+            echo "  - Java ${REQUIRED_JAVA_MAJOR} (OpenJDK ${REQUIRED_JAVA_MAJOR})"
             echo "  - Maven"
             echo "  - Rust toolchain (rustc, cargo via rustup)"
             echo "  - Protobuf compiler (protoc)"
@@ -251,29 +254,33 @@ install_macos() {
     fi
     ok "Homebrew found: $(brew --prefix)"
 
-    # On macOS, openjdk@11 is keg-only and may not be on PATH.
-    # Check the Homebrew keg path directly before deciding to install.
-    if [[ -z "${JAVA_HOME:-}" ]]; then
-        for brew_prefix in /opt/homebrew /usr/local; do
-            local keg_java="${brew_prefix}/opt/openjdk@11/bin/java"
-            if [[ -x "$keg_java" ]]; then
-                local keg_major
-                keg_major=$(get_java_major_version "$keg_java")
-                if [[ "$keg_major" == "$REQUIRED_JAVA_MAJOR" ]]; then
-                    export JAVA_HOME="${brew_prefix}/opt/openjdk@11"
-                    break
-                fi
-            fi
-        done
-    fi
-
-    # --- Java 11 ---
-    if check_java; then
-        ok "Java $REQUIRED_JAVA_MAJOR already installed"
+    # --- Java (pinned build JDK: openjdk@${REQUIRED_JAVA_MAJOR}) ---
+    # The tantivy4java native build is pinned to this exact JDK, so ensure the
+    # specific keg is installed rather than accepting "any supported JDK".
+    # Homebrew JDKs are keg-only and may not be on PATH, so probe the keg path.
+    local required_home=""
+    for brew_prefix in /opt/homebrew /usr/local; do
+        if [[ -x "${brew_prefix}/opt/openjdk@${REQUIRED_JAVA_MAJOR}/bin/java" ]]; then
+            required_home="${brew_prefix}/opt/openjdk@${REQUIRED_JAVA_MAJOR}"
+            break
+        fi
+    done
+    if [[ -n "$required_home" ]]; then
+        ok "OpenJDK $REQUIRED_JAVA_MAJOR already installed"
     else
         info "Installing OpenJDK $REQUIRED_JAVA_MAJOR via Homebrew..."
-        brew install openjdk@11
+        brew install "openjdk@${REQUIRED_JAVA_MAJOR}"
+        for brew_prefix in /opt/homebrew /usr/local; do
+            if [[ -x "${brew_prefix}/opt/openjdk@${REQUIRED_JAVA_MAJOR}/bin/java" ]]; then
+                required_home="${brew_prefix}/opt/openjdk@${REQUIRED_JAVA_MAJOR}"
+                break
+            fi
+        done
         ok "OpenJDK $REQUIRED_JAVA_MAJOR installed"
+    fi
+    # Default JAVA_HOME to the pinned JDK when the caller hasn't set one.
+    if [[ -z "${JAVA_HOME:-}" && -n "$required_home" ]]; then
+        export JAVA_HOME="$required_home"
     fi
 
     # --- Maven ---
@@ -334,7 +341,7 @@ install_linux() {
         fi
     }
 
-    # --- Java 11 ---
+    # --- Java (OpenJDK ${REQUIRED_JAVA_MAJOR}) ---
     if check_java; then
         ok "Java $REQUIRED_JAVA_MAJOR already installed"
     else
@@ -342,13 +349,13 @@ install_linux() {
         case "$pkg_mgr" in
             apt-get)
                 ensure_apt_updated
-                $sudo_cmd apt-get install -y openjdk-11-jdk
+                $sudo_cmd apt-get install -y "openjdk-${REQUIRED_JAVA_MAJOR}-jdk"
                 ;;
             dnf)
-                $sudo_cmd dnf install -y java-11-openjdk-devel
+                $sudo_cmd dnf install -y "java-${REQUIRED_JAVA_MAJOR}-openjdk-devel"
                 ;;
             yum)
-                $sudo_cmd yum install -y java-11-openjdk-devel
+                $sudo_cmd yum install -y "java-${REQUIRED_JAVA_MAJOR}-openjdk-devel"
                 ;;
         esac
         ok "OpenJDK $REQUIRED_JAVA_MAJOR installed"
@@ -505,7 +512,7 @@ install_tantivy4java() {
     fi
 
     info "Building tantivy4java ${TANTIVY4JAVA_VERSION} from source..."
-    info "This requires Rust, protoc, Java 11, and Maven (already verified above)."
+    info "This requires Rust, protoc, JDK ${REQUIRED_JAVA_MAJOR}, and Maven (already verified above)."
 
     # Create temp build directory
     local build_dir
@@ -550,15 +557,24 @@ install_tantivy4java() {
         fi
     fi
 
-    # Set JAVA_HOME for the Maven build
+    # Pin the tantivy4java native build to the JDK that setup installs
+    # (openjdk@${REQUIRED_JAVA_MAJOR}), rather than whatever JAVA_HOME happens to
+    # point at, so the JNI JAR is always built against a known, fixed JDK. On
+    # macOS the keg is keg-only, so resolve its path directly (it was ensured
+    # installed above); elsewhere use the validated JAVA_HOME.
     local build_java_home="${JAVA_HOME:-}"
     if [[ "$PLATFORM" == "macos" ]]; then
+        build_java_home=""
         for brew_prefix in /opt/homebrew /usr/local; do
-            if [[ -d "${brew_prefix}/opt/openjdk@11" ]]; then
-                build_java_home="${brew_prefix}/opt/openjdk@11"
+            if [[ -x "${brew_prefix}/opt/openjdk@${REQUIRED_JAVA_MAJOR}/bin/java" ]]; then
+                build_java_home="${brew_prefix}/opt/openjdk@${REQUIRED_JAVA_MAJOR}"
                 break
             fi
         done
+        if [[ -z "$build_java_home" ]]; then
+            error "openjdk@${REQUIRED_JAVA_MAJOR} not found; expected setup to have installed it above."
+            exit 1
+        fi
     fi
 
     # Ensure cargo is on PATH for the Maven subprocess
@@ -571,7 +587,7 @@ install_tantivy4java() {
     info "Running Maven build (this may take several minutes on first build)..."
     (
         cd "$build_dir/tantivy4java"
-        export JAVA_HOME="$build_java_home"
+        [[ -n "$build_java_home" ]] && export JAVA_HOME="$build_java_home"
         export PATH="$build_path"
         mvn clean install -DskipTests
     )
@@ -630,9 +646,9 @@ ERRORS=0
 
 # Validate Java
 # On macOS with Homebrew, set JAVA_HOME hint if not already pointing to a
-# supported JDK. Prefer 11 (default build target), fall back to 17.
+# supported JDK. Prefer the pinned build JDK (openjdk@17), fall back to 11.
 if [[ "$PLATFORM" == "macos" ]] && [[ -z "${JAVA_HOME:-}" ]]; then
-    for keg in openjdk@11 openjdk@17; do
+    for keg in openjdk@17 openjdk@11; do
         for brew_prefix in /opt/homebrew /usr/local; do
             if [[ -d "${brew_prefix}/opt/${keg}" ]]; then
                 export JAVA_HOME="${brew_prefix}/opt/${keg}"


### PR DESCRIPTION
## Summary

Standardizes the project on **JDK 17** and makes CI self-contained. Two coordinated parts:

1. **CI workflow** — runners no longer need Java pre-installed at a hardcoded path; Java is provisioned per-run.
2. **setup.sh** — installs JDK 17 and pins the tantivy4java native build to it.

## CI workflow (`.github/workflows/ci.yml`)

For `build-and-test-macos`:
- Removed the hardcoded `JAVA_HOME: /opt/homebrew/opt/openjdk@11` and `PATH` from the `env` block.
- Added **Set up Java 17** using `actions/setup-java@v5` (`temurin`, `17`). v5 (not v4) runs on Node 24, matching `actions/checkout@v6` and avoiding the Node 20 deprecation force-upgraded on 2026-06-16.
- Added **Ensure Homebrew on PATH** so `brew`/`mvn`/`protoc` stay discoverable after the `env.PATH` override was removed (adds Homebrew `bin`/`sbin` to `$GITHUB_PATH` — narrower than the old full-PATH override, Java stays decoupled).
- The commented-out Linux job got the same treatment, still commented out, ready to re-enable once bluegill is upgraded.

## setup.sh — install + pin JDK 17

- **`REQUIRED_JAVA_MAJOR` 11 → 17**; install branches provision `openjdk@17` (Homebrew keg on macOS, `openjdk-17` packages on Linux), driven by the constant instead of hardcoded `11`. `SUPPORTED_JAVA_MAJORS=(11 17)` unchanged for runtime validation; project still targets JDK 11 bytecode via the pom `release` flag.
- macOS install probes the `openjdk@17` keg *specifically* and installs it if absent (not 'any supported JDK'), so the pinned keg is guaranteed present.
- `install_tantivy4java` resolves the `openjdk@17` keg directly on macOS and **errors if missing**, instead of silently overriding/falling back to the active JDK — so the JNI JAR always builds against a fixed, known JDK. The `export` is guarded so an empty value can't clobber mvn's PATH-based discovery.

## Docs

- `.claude/CLAUDE.md`: JDK 17 is the CI-validated build target; `setup.sh` installs Java 17 (11 still supported).
- `README.md`: dev snippet updated to `openjdk@17`.

## Notes

- **JDK 11 → 17** is intentional. Per discussion, CI stays 17-only (no 11 matrix).
- **Behavior change**: because the build pins to the Homebrew `openjdk@17` keg specifically, a macOS dev who already has a *different* JDK 17 (Temurin/SDKMAN) will also get a Homebrew `openjdk@17` installed. This is the deliberate 'pin to a specific installed version' model.
- Consolidated from a previously-separate setup.sh PR (#361, now closed) into this single PR.