### PR TITLE
chore(deps): aws-sdk 2.46.10 + azure-identity 1.18.4 + azure-storage-blob 12.35.0 (consolidates #355/#357/#358)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
             S3AFileSystem.initialize.
         -->
         <hadoop.version>3.3.4</hadoop.version>
-        <aws.sdk.version>2.46.5</aws.sdk.version>
+        <aws.sdk.version>2.46.10</aws.sdk.version>
         <scalatest.version>3.2.20</scalatest.version>
         <mockito.version>4.11.0</mockito.version>
         <antlr.version>4.9.3</antlr.version>
@@ -254,7 +254,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-identity</artifactId>
-            <version>1.18.3</version>
+            <version>1.18.4</version>
         </dependency>
 
         <!-- Logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-storage-blob</artifactId>
-            <version>12.33.4</version>
+            <version>12.35.0</version>
         </dependency>
 
         <!-- Azure Identity SDK for authentication -->


### PR DESCRIPTION
## Summary

Consolidates three routine dependabot dependency bumps into one PR (supersedes #355, #357, #358):

- **`aws.sdk.version` 2.46.5 → 2.46.10** (patch). The `apache5-client` exclusion + explicit `apache-client` dependency added in #353 carry forward via the shared property, so the SDK stays on Apache HttpClient 4 — no regression of the `TlsSocketStrategy` `NoClassDefFoundError` #353 fixed. Verified: tree resolves `apache-client 2.46.10 → httpclient 4.5.13`, `apache5-client` absent.
- **`com.azure:azure-identity` 1.18.3 → 1.18.4** (patch).
- **`com.azure:azure-storage-blob` 12.33.4 → 12.35.0** (minor; pulls azure-storage-common 12.34.0, resolves cleanly).

All three are independent of the Spark 3.5.x pins.

## Testing

`StorageProviderTest` passes locally (4/4) against AWS SDK 2.46.10; `mvn validate` passes with the azure bumps. CI runs the full suite.

Closes #355, #357, #358 (folded in here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
