### PR TITLE
feat: reject wildcard and range IndexQuery on exact_only fields

### DIFF
--- a/src/main/scala/io/indextables/spark/core/FiltersToQueryConverter.scala
+++ b/src/main/scala/io/indextables/spark/core/FiltersToQueryConverter.scala
@@ -1185,6 +1185,7 @@ object FiltersToQueryConverter {
       // Note: Field validation happens earlier in isMixedFilterValidForSchema
       case indexQuery: IndexQueryFilter =>
         queryLog(s"Converting custom IndexQueryFilter: ${indexQuery.columnName} indexquery '${indexQuery.queryString}'")
+        validateIndexQueryOnExactOnlyField(indexQuery.columnName, indexQuery.queryString, schema)
 
         // Use parseQuery with the specified field
         val fieldNames = List(indexQuery.columnName).asJava
@@ -1245,6 +1246,7 @@ object FiltersToQueryConverter {
     filter match {
       case MixedIndexQuery(indexQueryFilter) =>
         queryLog(s"MixedBooleanFilter->Query: Converting MixedIndexQuery: ${indexQueryFilter.columnName} indexquery '${indexQueryFilter.queryString}'")
+        validateIndexQueryOnExactOnlyField(indexQueryFilter.columnName, indexQueryFilter.queryString, schema)
         val fieldNames = List(indexQueryFilter.columnName).asJava
         withTemporaryIndex(schema) { index =>
           try
@@ -1318,6 +1320,36 @@ object FiltersToQueryConverter {
         logger.warn(s"Could not determine field type for '$fieldName', defaulting to TEXT: ${e.getMessage}")
         FieldType.TEXT
     }
+
+  /**
+   * Reject wildcard and range patterns on exact_only fields before the native layer is called.
+   * exact_only stores values as U64 hashes so only exact match is meaningful -- wildcard and range
+   * queries produce meaningless results or cryptic JNI errors after exhausting task retries.
+   * Best-effort: checks for common patterns (* ? and [ TO ]).
+   */
+  private def validateIndexQueryOnExactOnlyField(
+    columnName: String,
+    queryString: String,
+    schema: Schema
+  ): Unit = {
+    if (getFieldType(schema, columnName) != FieldType.UNSIGNED) return
+
+    val trimmed     = queryString.trim
+    val hasWildcard = trimmed.contains("*") || trimmed.contains("?")
+    val hasRange    = (trimmed.contains("[") || trimmed.contains("{")) && trimmed.toUpperCase.contains(" TO ")
+
+    if (hasWildcard || hasRange) {
+      val kind = if (hasWildcard) "Wildcard" else "Range"
+      throw new IndexQueryParseException(
+        queryString,
+        Some(columnName),
+        new UnsupportedOperationException(
+          s"$kind queries are not supported on exact_only field '$columnName': " +
+            "values are stored as U64 hashes, only exact match (EqualTo) is meaningful."
+        )
+      )
+    }
+  }
 
   /** Check if a field type is numeric (should use range queries instead of term queries for equality) */
   private def isNumericFieldType(fieldType: FieldType): Boolean =
@@ -1957,7 +1989,7 @@ object FiltersToQueryConverter {
         // Parse the custom IndexQuery using the split searcher with field-specific parsing
         // Note: Field validation happens earlier in isMixedFilterValidForSchema
         // Note: Driver-side validation should have already caught syntax errors
-        //
+        validateIndexQueryOnExactOnlyField(columnName, queryString, schema)
         // Transform leading wildcard queries (e.g., *Configuration) to use explicit field syntax
         // (e.g., columnName:*Configuration) which Tantivy's wildcard query builder supports
         val transformedQuery = transformLeadingWildcardQuery(queryString, columnName)
@@ -2017,7 +2049,7 @@ object FiltersToQueryConverter {
         // Handle V2 IndexQuery expressions from temp views
         // Note: Field validation happens earlier in isMixedFilterValidForSchema
         // Note: Driver-side validation should have already caught syntax errors
-        //
+        validateIndexQueryOnExactOnlyField(indexQueryV2.columnName, indexQueryV2.queryString, schema)
         // Transform leading wildcard queries (e.g., *Configuration) to use explicit field syntax
         val transformedQuery = transformLeadingWildcardQuery(indexQueryV2.queryString, indexQueryV2.columnName)
         queryLog(
@@ -2092,6 +2124,7 @@ object FiltersToQueryConverter {
     filter match {
       case MixedIndexQuery(indexQueryFilter) =>
         // Delegate to existing IndexQueryFilter handling
+        validateIndexQueryOnExactOnlyField(indexQueryFilter.columnName, indexQueryFilter.queryString, schema)
         // Transform leading wildcard queries (e.g., *Configuration) to use explicit field syntax
         val transformedQuery = transformLeadingWildcardQuery(indexQueryFilter.queryString, indexQueryFilter.columnName)
         queryLog(

--- a/src/main/scala/io/indextables/spark/core/FiltersToQueryConverter.scala
+++ b/src/main/scala/io/indextables/spark/core/FiltersToQueryConverter.scala
@@ -1322,10 +1322,9 @@ object FiltersToQueryConverter {
     }
 
   /**
-   * Reject wildcard and range patterns on exact_only fields before the native layer is called.
-   * exact_only stores values as U64 hashes so only exact match is meaningful -- wildcard and range
-   * queries produce meaningless results or cryptic JNI errors after exhausting task retries.
-   * Best-effort: checks for common patterns (* ? and [ TO ]).
+   * Reject wildcard and range patterns on exact_only fields before the native layer is called. exact_only stores values
+   * as U64 hashes so only exact match is meaningful -- wildcard and range queries produce meaningless results or
+   * cryptic JNI errors after exhausting task retries. Best-effort: checks for common patterns (* ? and [ TO ]).
    */
   private def validateIndexQueryOnExactOnlyField(
     columnName: String,

--- a/src/test/scala/io/indextables/spark/sync/CompanionCompactStringTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionCompactStringTest.scala
@@ -1291,4 +1291,60 @@ class CompanionCompactStringTest
       groupMap("tech") shouldBe 2L
     }
   }
+
+  test("wildcard IndexQuery on exact_only field should throw a clear error") {
+    withTempPath { tempDir =>
+      val parquetPath = new File(tempDir, "parquet_wildcard").getAbsolutePath
+      val indexPath   = new File(tempDir, "companion_wildcard").getAbsolutePath
+
+      createUuidParquetData(parquetPath, numRows = 5)
+
+      spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' " +
+            s"INDEXING MODES ('trace_id':'exact_only') " +
+            s"AT LOCATION '$indexPath'"
+        )
+        .collect()
+
+      spark.read
+        .format(io.indextables.spark.TestBase.INDEXTABLES_FORMAT)
+        .load(indexPath)
+        .createOrReplaceTempView("exact_only_wildcard_test")
+
+      val ex = intercept[Exception] {
+        spark.sql("SELECT * FROM exact_only_wildcard_test WHERE trace_id indexquery 'abc*'").collect()
+      }
+      assert(ex.getMessage.contains("Wildcard queries are not supported on exact_only field"))
+      assert(ex.getMessage.contains("trace_id"))
+    }
+  }
+
+  test("range IndexQuery on exact_only field should throw a clear error") {
+    withTempPath { tempDir =>
+      val parquetPath = new File(tempDir, "parquet_range_iq").getAbsolutePath
+      val indexPath   = new File(tempDir, "companion_range_iq").getAbsolutePath
+
+      createUuidParquetData(parquetPath, numRows = 5)
+
+      spark
+        .sql(
+          s"BUILD INDEXTABLES COMPANION FOR PARQUET '$parquetPath' " +
+            s"INDEXING MODES ('trace_id':'exact_only') " +
+            s"AT LOCATION '$indexPath'"
+        )
+        .collect()
+
+      spark.read
+        .format(io.indextables.spark.TestBase.INDEXTABLES_FORMAT)
+        .load(indexPath)
+        .createOrReplaceTempView("exact_only_range_iq_test")
+
+      val ex = intercept[Exception] {
+        spark.sql("SELECT * FROM exact_only_range_iq_test WHERE trace_id indexquery '[a TO z]'").collect()
+      }
+      assert(ex.getMessage.contains("Range queries are not supported on exact_only field"))
+      assert(ex.getMessage.contains("trace_id"))
+    }
+  }
 }


### PR DESCRIPTION
exact_only fields store values as U64 xxHash64 hashes. A wildcard or
range IndexQuery on such a field -- e.g. `trace_id indexquery 'abc*'` --
passes Spark filter validation, reaches the native Tantivy layer, fails,
and then retries up to four times before the job aborts with a raw JNI
stack trace.

This adds validateIndexQueryOnExactOnlyField() to FiltersToQueryConverter.
The check fires across all five IndexQuery handler paths before parseQuery
is called. If the field is UNSIGNED (exact_only) and the query string
contains a wildcard (* ?) or range ([ TO ] / { TO }) pattern, it throws
IndexQueryParseException with a message that names the field and explains
why the operation is not supported.

Two new integration tests in CompanionCompactStringTest cover the wildcard
and range cases on an exact_only companion field.

Closes #186 (remaining nice-to-have: IndexQuery path validation).