### PR TITLE
feat(auth): ambient Databricks cluster token auth mode for UC credential vending

### DIFF
--- a/docs/reference/cloud-configuration.md
+++ b/docs/reference/cloud-configuration.md
@@ -73,12 +73,33 @@ Access Unity Catalog-managed S3 paths using temporary credentials from the Datab
 
 | Property | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `spark.indextables.databricks.workspaceUrl` | Yes | - | Databricks workspace URL |
-| `spark.indextables.databricks.apiToken` | Yes | - | Databricks API token (PAT or OAuth) |
+| `spark.indextables.databricks.workspaceUrl` | No* | - | Databricks workspace URL (*auto-resolved on Databricks compute) |
+| `spark.indextables.databricks.apiToken` | No* | - | Databricks API token (PAT or OAuth) (*see auth modes below) |
+| `spark.indextables.databricks.clientId` | No | - | OAuth2 client ID (machine-to-machine auth) |
+| `spark.indextables.databricks.clientSecret` | No | - | OAuth2 client secret (machine-to-machine auth) |
 | `spark.indextables.databricks.credential.refreshBuffer.minutes` | No | 40 | Minutes before expiration to refresh |
 | `spark.indextables.databricks.cache.maxSize` | No | 100 | Maximum cached credential entries |
 | `spark.indextables.databricks.fallback.enabled` | No | true | Fallback to READ if READ_WRITE fails |
 | `spark.indextables.databricks.retry.attempts` | No | 3 | Retry attempts on API failure |
+
+### Authentication Modes
+
+Resolved in priority order:
+
+1. **OAuth2 client credentials** — `clientId` + `clientSecret` both set. Tokens are exchanged at the
+   workspace OIDC endpoint and refreshed automatically.
+2. **Static API token** — `apiToken` set (personal access token or pre-issued OAuth token).
+3. **Ambient cluster token** (zero-config, Databricks compute only) — when neither of the above is
+   configured and the job runs on a Databricks cluster, the provider falls back to the cluster-scoped
+   service token Databricks injects into SparkConf (`spark.databricks.token`). Because these UC API
+   calls originate from within the Databricks compute plane, they are not subject to the metastore's
+   `external_access_enabled` gate (no `EXTERNAL_ACCESS_DISABLED_ON_METASTORE` 403). In this mode the
+   workspace URL is also auto-resolved from `spark.databricks.workspaceUrl` when not explicitly set,
+   and the token is re-read on every call to tolerate Databricks token rotation. Note that UC
+   authorization is evaluated against the job's run-as identity, which needs the appropriate
+   privileges on the external location.
+
+Outside Databricks compute, either `apiToken` or `clientId`/`clientSecret` must be configured.
 
 ### Session-Level Configuration
 ```scala

--- a/docs/reference/cloud-configuration.md
+++ b/docs/reference/cloud-configuration.md
@@ -77,6 +77,8 @@ Access Unity Catalog-managed S3 paths using temporary credentials from the Datab
 | `spark.indextables.databricks.apiToken` | No* | - | Databricks API token (PAT or OAuth) (*see auth modes below) |
 | `spark.indextables.databricks.clientId` | No | - | OAuth2 client ID (machine-to-machine auth) |
 | `spark.indextables.databricks.clientSecret` | No | - | OAuth2 client secret (machine-to-machine auth) |
+| `spark.indextables.databricks.dbutilsTokenRefresh.enabled` | No | false | Opt-in: on a Databricks driver, seed + auto-refresh the apiToken from the dbutils notebook-context token (see auth modes) |
+| `spark.indextables.databricks.dbutilsTokenRefresh.intervalSeconds` | No | 1800 | Refresh cadence for the dbutils token (under its ~1h TTL) |
 | `spark.indextables.databricks.credential.refreshBuffer.minutes` | No | 40 | Minutes before expiration to refresh |
 | `spark.indextables.databricks.cache.maxSize` | No | 100 | Maximum cached credential entries |
 | `spark.indextables.databricks.fallback.enabled` | No | true | Fallback to READ if READ_WRITE fails |
@@ -100,6 +102,27 @@ Resolved in priority order:
    privileges on the external location.
 
 Outside Databricks compute, either `apiToken` or `clientId`/`clientSecret` must be configured.
+
+#### dbutils token refresh (opt-in, requires the SQL extensions)
+
+On SINGLE_USER Databricks clusters `spark.databricks.token` is absent, so the ambient mode above does not
+apply. There, the dbutils notebook-context token is available **on the driver** and — unlike an external
+OAuth token — bypasses the external-access gate, but it has a short (~1h) TTL. Setting
+`spark.indextables.databricks.dbutilsTokenRefresh.enabled=true` (with `IndexTables4SparkExtensions`
+registered) makes the extension read that token on the driver, publish it as
+`spark.indextables.databricks.apiToken` (tagged `apiToken.source=dbutils`), auto-resolve the workspace URL
+from `spark.databricks.workspaceUrl`, and start a background thread that refreshes it before expiry. The
+provider then re-reads the freshest token on every call rather than pinning it.
+
+This is entirely opt-in and additive — with the flag off (the default) nothing changes, and it never
+overrides an explicitly configured `apiToken`. It never takes priority over OAuth: if `clientId`/`clientSecret`
+are configured they still win, so on Databricks omit them when you want the dbutils token to be used.
+
+**Limitation:** dbutils and the driver session conf are driver-only; the token reaches executors only by
+being serialized into each plan's config map. Streaming micro-batches and multi-job pipelines re-plan and
+therefore pick up refreshed tokens, but a **single job/plan that runs longer than the token TTL** cannot
+refresh its executors' token and will fail once it expires. Chunk such workloads into sub-jobs that complete
+under the TTL.
 
 ### Session-Level Configuration
 ```scala

--- a/src/main/scala/io/indextables/spark/auth/unity/UnityCatalogAWSCredentialProvider.scala
+++ b/src/main/scala/io/indextables/spark/auth/unity/UnityCatalogAWSCredentialProvider.scala
@@ -46,14 +46,24 @@ import org.slf4j.LoggerFactory
  *
  * ===Auth Modes===
  *
- * Two mutually exclusive auth strategies are supported:
- *
- * '''Static API token''' (original mode):
- *   - spark.indextables.databricks.apiToken: Databricks personal access token
+ * Three mutually exclusive auth strategies are supported (highest priority first):
  *
  * '''OAuth2 Client Credentials''' (machine-to-machine, no personal token needed):
  *   - spark.indextables.databricks.clientId: OAuth2 client ID
  *   - spark.indextables.databricks.clientSecret: OAuth2 client secret
+ *
+ * '''Static API token''' (original mode):
+ *   - spark.indextables.databricks.apiToken: Databricks personal access token
+ *
+ * '''Ambient cluster token''' (zero-config, Databricks compute only): when neither of the above is configured, the
+ * provider falls back to the cluster-scoped service token that Databricks injects into every cluster's SparkConf as
+ * `spark.databricks.token`. UC API calls made with this token originate from within the Databricks compute plane, so
+ * they are not subject to the metastore's `external_access_enabled` gate (no EXTERNAL_ACCESS_DISABLED_ON_METASTORE
+ * 403). In this mode the workspace URL is also auto-resolved from `spark.databricks.workspaceUrl` when
+ * `spark.indextables.databricks.workspaceUrl` is not set (Databricks stores a bare hostname there — an `https://`
+ * scheme is prepended automatically). The token is re-read from SparkConf on every call since Databricks rotates it
+ * periodically. SparkConf is read via `SparkEnv.get.conf` reflection, which works on both the driver and executors
+ * without creating a SparkContext.
  *
  * When both OAuth keys are present they take precedence. Partial OAuth config (only one of the two keys) is an error.
  * OAuth tokens are exchanged via the workspace-level OIDC endpoint at `{workspaceUrl}/oidc/v1/token` using HTTP Basic
@@ -319,6 +329,12 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
   // Production deployments MUST use HTTPS workspace URLs.
   private[unity] val AllowInsecureOAuthKey = "oauth.allowInsecure"
 
+  // Ambient Databricks cluster conf keys. Databricks injects these into every cluster's SparkConf
+  // at startup; they are not user-set. Used as the lowest-priority auth fallback so that jobs
+  // running on Databricks compute need zero explicit auth configuration.
+  private[unity] val AmbientTokenConfKey        = "spark.databricks.token"
+  private[unity] val AmbientWorkspaceUrlConfKey = "spark.databricks.workspaceUrl"
+
   // Default values
   private val DefaultRefreshBufferMinutes = 40
   private val DefaultCacheMaxSize         = 100
@@ -350,12 +366,54 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
   }
 
   /**
+   * Read a key from the active Spark runtime's SparkConf via reflection.
+   *
+   * Uses `SparkEnv.get.conf` rather than `SparkContext.getOrCreate`: SparkEnv exists on both the driver AND executors
+   * (this provider runs on executors during scan fan-out), and `get` returns null instead of side-effecting when no
+   * Spark runtime is active. Reflection keeps this class free of compile-time Spark dependencies, consistent with the
+   * rest of the file. Returns None when Spark is not on the classpath or no runtime is active (e.g. plain JVM tests).
+   */
+  private[unity] def readSparkEnvConf(key: String): Option[String] =
+    Try {
+      val envClass = Class.forName("org.apache.spark.SparkEnv")
+      Option(envClass.getMethod("get").invoke(null)).flatMap { env =>
+        val conf = envClass.getMethod("conf").invoke(env)
+        conf.getClass
+          .getMethod("getOption", classOf[String])
+          .invoke(conf, key)
+          .asInstanceOf[Option[String]]
+          .map(_.trim)
+          .filter(_.nonEmpty)
+      }
+    }.toOption.flatten
+
+  /** The cluster-scoped service token Databricks injects into SparkConf, when running on Databricks compute. */
+  private[unity] def resolveAmbientClusterToken(): Option[String] =
+    readSparkEnvConf(AmbientTokenConfKey)
+
+  /**
+   * The workspace URL Databricks injects into SparkConf. Databricks stores a bare hostname (no scheme), so the value is
+   * normalized to an https:// URL.
+   */
+  private[unity] def resolveAmbientWorkspaceUrl(): Option[String] =
+    readSparkEnvConf(AmbientWorkspaceUrlConfKey).map(normalizeWorkspaceUrl)
+
+  /** Prepend https:// when no scheme is present and strip any trailing slash. */
+  private[unity] def normalizeWorkspaceUrl(url: String): String = {
+    val withScheme =
+      if (url.startsWith("https://") || url.startsWith("http://")) url
+      else s"https://$url"
+    if (withScheme.endsWith("/")) withScheme.dropRight(1) else withScheme
+  }
+
+  /**
    * Resolve Databricks configuration from a Map[String, String]. This is the fast path that avoids Hadoop Configuration
    * creation.
    *
    * Auth mode priority:
    *   1. ClientCredentials — when clientId + clientSecret are both present 2. StaticToken — when apiToken is present 3.
-   *      Error — neither is configured
+   *      AmbientClusterToken — when running on Databricks compute (spark.databricks.token present in SparkConf) 4.
+   *      Error — none of the above
    */
   private def resolveConfigFromMap(config: Map[String, String]): (String, AuthMode, Int, Int) = {
     val sources: Seq[ConfigSource] = Seq(
@@ -363,14 +421,17 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
       MapConfigSource(config)
     )
 
-    val workspaceUrl = ConfigurationResolver
+    // Explicit workspace URL. Required for StaticToken and ClientCredentials modes (unchanged
+    // behavior); for AmbientClusterToken mode it falls back to spark.databricks.workspaceUrl below.
+    val explicitWorkspaceUrl = ConfigurationResolver
       .resolveString(WorkspaceUrlKey, sources)
       .map(url => if (url.endsWith("/")) url.dropRight(1) else url)
-      .getOrElse(
-        throw new IllegalStateException(
-          "Databricks workspace URL not configured. Set spark.indextables.databricks.workspaceUrl"
-        )
+
+    def requireExplicitWorkspaceUrl(): String = explicitWorkspaceUrl.getOrElse(
+      throw new IllegalStateException(
+        "Databricks workspace URL not configured. Set spark.indextables.databricks.workspaceUrl"
       )
+    )
 
     // Resolve OAuth keys through ConfigurationResolver for the same prefix-aware, case-insensitive,
     // and log-masked semantics as apiToken (bare-leaf keys + spark.indextables.databricks.* prefix).
@@ -379,6 +440,7 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
 
     val authMode: AuthMode = (clientId, clientSecret) match {
       case (Some(id), Some(secret)) if id.nonEmpty && secret.nonEmpty =>
+        val workspaceUrl = requireExplicitWorkspaceUrl()
         // HTTPS validation: Basic Auth sends base64-encoded credentials — must not go over plaintext.
         if (!workspaceUrl.startsWith("https://")) {
           val allowInsecure = ConfigurationResolver.resolveBoolean(AllowInsecureOAuthKey, sources, default = false)
@@ -409,15 +471,37 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
             "To use a static API token instead, remove both OAuth keys and set apiToken."
         )
       case _ =>
-        val token = ConfigurationResolver
-          .resolveString(TokenKey, sources, logMask = true)
+        ConfigurationResolver.resolveString(TokenKey, sources, logMask = true) match {
+          case Some(token) => StaticToken(token)
+          case None =>
+            resolveAmbientClusterToken() match {
+              case Some(token) =>
+                logger.info(
+                  "Using ambient Databricks cluster token (spark.databricks.token) for UC credential vending"
+                )
+                AmbientClusterToken(token)
+              case None =>
+                throw new IllegalStateException(
+                  "Databricks auth not configured. Set spark.indextables.databricks.apiToken, " +
+                    "spark.indextables.databricks.clientId/clientSecret, " +
+                    "or run on a Databricks cluster (spark.databricks.token is auto-detected)."
+                )
+            }
+        }
+    }
+
+    val workspaceUrl = authMode match {
+      case cc: ClientCredentials => cc.workspaceUrl
+      case _: AmbientClusterToken =>
+        explicitWorkspaceUrl
+          .orElse(resolveAmbientWorkspaceUrl())
           .getOrElse(
             throw new IllegalStateException(
-              "Databricks auth not configured. Set spark.indextables.databricks.apiToken " +
-                "or spark.indextables.databricks.clientId/clientSecret."
+              "Databricks workspace URL not configured. Set spark.indextables.databricks.workspaceUrl " +
+                "(auto-detection via spark.databricks.workspaceUrl found no value)"
             )
           )
-        StaticToken(token)
+      case _ => requireExplicitWorkspaceUrl()
     }
 
     val refreshBuffer = ConfigurationResolver
@@ -522,7 +606,18 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
    * thread executes the POST; all others block, then hit the cache on wake-up.
    */
   private[unity] def resolveToken(authMode: AuthMode): String = authMode match {
-    case StaticToken(token)    => token
+    case StaticToken(token)                => token
+    case AmbientClusterToken(initialToken) =>
+      // Re-read from SparkConf on every call — Databricks rotates the cluster token periodically,
+      // so caching it would eventually produce 401s on long-running clusters. The AWS credential
+      // cache (keyed by a fixed ambient identity) still prevents redundant UC API calls.
+      resolveAmbientClusterToken().getOrElse {
+        logger.warn(
+          "Ambient Databricks cluster token no longer readable from SparkConf; " +
+            "falling back to the token captured at provider construction"
+        )
+        initialToken
+      }
     case cc: ClientCredentials =>
       // Fast path (unsynchronized) — avoids lock contention on the common case.
       val cached = if (globalOAuthTokenCache != null) globalOAuthTokenCache.getIfPresent(cc.clientId) else null
@@ -673,6 +768,9 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
   private def authIdentity(authMode: AuthMode): String = authMode match {
     case StaticToken(token)                         => token
     case ClientCredentials(clientId, _, _, _, _, _) => clientId
+    // Fixed identity: there is exactly one cluster token per JVM and the cache is process-global,
+    // so a stable string keeps cache entries valid across token rotations (like clientId for OAuth).
+    case _: AmbientClusterToken => "ambient-cluster-token"
   }
 
   /**
@@ -1060,9 +1158,16 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
     defaults
   }
 
-  /** Authentication mode — either a static API token or OAuth client credentials. */
+  /** Authentication mode — static API token, OAuth client credentials, or ambient Databricks cluster token. */
   sealed private[unity] trait AuthMode
   private[unity] case class StaticToken(token: String) extends AuthMode
+
+  /**
+   * Ambient Databricks cluster token auth (zero-config fallback). `initialToken` is the value of
+   * `spark.databricks.token` captured at provider construction; resolveToken() re-reads the live value from SparkConf
+   * on every call and only uses `initialToken` if the Spark runtime becomes unreachable.
+   */
+  private[unity] case class AmbientClusterToken(initialToken: String) extends AuthMode
   private[unity] case class ClientCredentials(
     clientId: String,
     clientSecret: String,

--- a/src/main/scala/io/indextables/spark/auth/unity/UnityCatalogAWSCredentialProvider.scala
+++ b/src/main/scala/io/indextables/spark/auth/unity/UnityCatalogAWSCredentialProvider.scala
@@ -335,6 +335,19 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
   private[unity] val AmbientTokenConfKey        = "spark.databricks.token"
   private[unity] val AmbientWorkspaceUrlConfKey = "spark.databricks.workspaceUrl"
 
+  // dbutils-managed apiToken. On SINGLE_USER Databricks clusters `spark.databricks.token` is absent
+  // (see PR #374), but the dbutils notebook-context token IS available on the DRIVER and bypasses the
+  // metastore external-access gate. IndexTables4SparkExtensions reads that token, writes it to
+  // `spark.indextables.databricks.apiToken`, sets `apiToken.source=dbutils` as a marker, and starts a
+  // background thread that refreshes the token (~1h TTL) before it expires. When the marker is set the
+  // provider selects DbutilsRefreshedToken mode and re-reads the freshest token on every call.
+  //   - TokenSourceKey  : bare-leaf marker, resolved via ConfigurationResolver like apiToken
+  //   - DbutilsSourceValue : the marker value that activates DbutilsRefreshedToken mode
+  //   - FullTokenKey    : fully-qualified apiToken key, read directly from the driver's runtime SQLConf
+  private[unity] val TokenSourceKey     = "apiToken.source"
+  private[unity] val DbutilsSourceValue = "dbutils"
+  private[unity] val FullTokenKey       = "spark.indextables.databricks.apiToken"
+
   // Default values
   private val DefaultRefreshBufferMinutes = 40
   private val DefaultCacheMaxSize         = 100
@@ -387,6 +400,28 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
       }
     }.toOption.flatten
 
+  /**
+   * Read a key from the active driver SparkSession's runtime SQLConf via reflection.
+   *
+   * This is distinct from [[readSparkEnvConf]]: values set at runtime through `session.conf.set(...)` (as
+   * IndexTables4SparkExtensions does for the dbutils token) live in the RuntimeConfig/SQLConf, NOT in the immutable
+   * startup `SparkConf` that `SparkEnv.get.conf` exposes. `SparkSession.active` exists only on the driver and throws
+   * when no session is active, so on executors (and in plain-JVM tests) this returns None and callers fall back to the
+   * token captured in the per-plan config map.
+   */
+  private[unity] def readActiveSessionConf(key: String): Option[String] =
+    Try {
+      val sessionClass = Class.forName("org.apache.spark.sql.SparkSession")
+      val active       = sessionClass.getMethod("active").invoke(null)
+      val conf         = active.getClass.getMethod("conf").invoke(active)
+      conf.getClass
+        .getMethod("getOption", classOf[String])
+        .invoke(conf, key)
+        .asInstanceOf[Option[String]]
+        .map(_.trim)
+        .filter(_.nonEmpty)
+    }.toOption.flatten
+
   /** The cluster-scoped service token Databricks injects into SparkConf, when running on Databricks compute. */
   private[unity] def resolveAmbientClusterToken(): Option[String] =
     readSparkEnvConf(AmbientTokenConfKey)
@@ -411,8 +446,9 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
    * creation.
    *
    * Auth mode priority:
-   *   1. ClientCredentials — when clientId + clientSecret are both present 2. StaticToken — when apiToken is present 3.
-   *      AmbientClusterToken — when running on Databricks compute (spark.databricks.token present in SparkConf) 4.
+   *   1. ClientCredentials — when clientId + clientSecret are both present 2. apiToken present — DbutilsRefreshedToken
+   *      when the apiToken.source=dbutils marker is set (managed by IndexTables4SparkExtensions), otherwise StaticToken
+   *      3. AmbientClusterToken — when running on Databricks compute (spark.databricks.token present in SparkConf) 4.
    *      Error — none of the above
    */
   private def resolveConfigFromMap(config: Map[String, String]): (String, AuthMode, Int, Int) = {
@@ -472,7 +508,21 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
         )
       case _ =>
         ConfigurationResolver.resolveString(TokenKey, sources, logMask = true) match {
-          case Some(token) => StaticToken(token)
+          case Some(token) =>
+            // A dbutils-managed apiToken carries an apiToken.source=dbutils marker set by
+            // IndexTables4SparkExtensions (which reads the dbutils notebook-context token on the driver
+            // and refreshes it on a background thread). In that case use DbutilsRefreshedToken so
+            // resolveToken() re-reads the freshest value on every call rather than pinning the token
+            // captured at construction (StaticToken never refreshes). This is purely additive: without
+            // the marker — i.e. for every existing config — resolution is unchanged StaticToken.
+            val isDbutilsManaged = ConfigurationResolver
+              .resolveString(TokenSourceKey, sources)
+              .contains(DbutilsSourceValue)
+            if (isDbutilsManaged) {
+              logger.info("Using dbutils-managed refreshed apiToken for UC credential vending")
+              DbutilsRefreshedToken(token)
+            } else
+              StaticToken(token)
           case None =>
             resolveAmbientClusterToken() match {
               case Some(token) =>
@@ -501,6 +551,9 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
                 "(auto-detection via spark.databricks.workspaceUrl found no value)"
             )
           )
+      // StaticToken and DbutilsRefreshedToken both require an explicit workspace URL. For dbutils mode
+      // IndexTables4SparkExtensions sets it (auto-derived from spark.databricks.workspaceUrl) at the same
+      // time it injects the token, so it is present in the config map here.
       case _ => requireExplicitWorkspaceUrl()
     }
 
@@ -618,6 +671,14 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
         )
         initialToken
       }
+    case DbutilsRefreshedToken(initialToken) =>
+      // Re-read the freshest token on every call. The refresh thread in IndexTables4SparkExtensions
+      // rewrites `spark.indextables.databricks.apiToken` in the driver's runtime SQLConf before the
+      // ~1h dbutils token expires, so driver-side flows always read a live value here. On executors
+      // there is no active SparkSession, so readActiveSessionConf returns None and we fall back to the
+      // token captured in the per-plan config map — which is itself fresh, because each scan re-plans
+      // on the driver and re-serializes the current token into the task config map.
+      readActiveSessionConf(FullTokenKey).getOrElse(initialToken)
     case cc: ClientCredentials =>
       // Fast path (unsynchronized) — avoids lock contention on the common case.
       val cached = if (globalOAuthTokenCache != null) globalOAuthTokenCache.getIfPresent(cc.clientId) else null
@@ -771,6 +832,9 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
     // Fixed identity: there is exactly one cluster token per JVM and the cache is process-global,
     // so a stable string keeps cache entries valid across token rotations (like clientId for OAuth).
     case _: AmbientClusterToken => "ambient-cluster-token"
+    // Same rationale: one dbutils-managed identity per JVM, so a fixed key keeps cached AWS
+    // credentials valid across the background thread's token refreshes.
+    case _: DbutilsRefreshedToken => "dbutils-refreshed-token"
   }
 
   /**
@@ -1158,7 +1222,7 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
     defaults
   }
 
-  /** Authentication mode — static API token, OAuth client credentials, or ambient Databricks cluster token. */
+  /** Authentication mode — static API token, OAuth client credentials, ambient cluster token, or dbutils token. */
   sealed private[unity] trait AuthMode
   private[unity] case class StaticToken(token: String) extends AuthMode
 
@@ -1168,6 +1232,16 @@ object UnityCatalogAWSCredentialProvider extends io.indextables.spark.utils.Tabl
    * on every call and only uses `initialToken` if the Spark runtime becomes unreachable.
    */
   private[unity] case class AmbientClusterToken(initialToken: String) extends AuthMode
+
+  /**
+   * dbutils-managed refreshed token auth. Activated when `spark.indextables.databricks.apiToken.source=dbutils` is
+   * present (set by IndexTables4SparkExtensions, which reads the dbutils notebook-context token on the driver and
+   * refreshes it on a background thread). `initialToken` is the value captured from the per-plan config map at
+   * construction; resolveToken() prefers the live value in the driver's runtime SQLConf and falls back to
+   * `initialToken` on executors (where no SparkSession is active). Unlike StaticToken, this mode never pins a token —
+   * it tracks the background thread's rotations so indefinitely-running streaming jobs keep vending past the ~1h TTL.
+   */
+  private[unity] case class DbutilsRefreshedToken(initialToken: String) extends AuthMode
   private[unity] case class ClientCredentials(
     clientId: String,
     clientSecret: String,

--- a/src/main/scala/io/indextables/spark/extensions/DbutilsTokenManager.scala
+++ b/src/main/scala/io/indextables/spark/extensions/DbutilsTokenManager.scala
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.extensions
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import scala.util.Try
+
+import org.apache.spark.sql.SparkSession
+
+import org.slf4j.LoggerFactory
+
+/**
+ * Opt-in bootstrap for Databricks dbutils-managed API-token auth.
+ *
+ * Background: on SINGLE_USER Databricks clusters `spark.databricks.token` is absent, but the dbutils notebook-context
+ * token IS available on the DRIVER and — unlike an external OAuth client-credentials token — bypasses the metastore's
+ * external-access gate (no `EXTERNAL_ACCESS_DISABLED_ON_METASTORE` 403). That token has a short (~1h) TTL, which is
+ * insufficient for indefinitely-running streaming/companion jobs.
+ *
+ * This manager, when explicitly enabled, reads the dbutils token on the driver, writes it to
+ * `spark.indextables.databricks.apiToken` in the session's runtime conf, tags it with
+ * `spark.indextables.databricks.apiToken.source=dbutils` (which makes
+ * [[io.indextables.spark.auth.unity.UnityCatalogAWSCredentialProvider]] select its DbutilsRefreshedToken mode), and
+ * starts a single daemon thread that rewrites the token before it expires. Because scan/write planning re-reads the
+ * session conf on every invocation, each streaming micro-batch serializes the current token to its executors — so the
+ * refreshed token reaches the workers via normal per-plan config propagation.
+ *
+ * IMPORTANT — footprint: this is entirely opt-in and additive. It does nothing unless
+ * `spark.indextables.databricks.dbutilsTokenRefresh.enabled=true` AND a dbutils token is actually readable (i.e. a
+ * Databricks driver). It never overrides an explicitly configured apiToken, and it changes no default behaviour for any
+ * existing deployment or non-Databricks environment.
+ *
+ * Known limitation: dbutils and the driver session conf are driver-only, and the token reaches executors only by being
+ * serialized into a plan's config map. A single Spark job/plan that runs longer than the token TTL cannot refresh the
+ * token on its executors (there is no new plan and no executor-side way to mint one). This mechanism therefore covers
+ * many-plan workloads (streaming micro-batches, multi-job pipelines) but not a single run-to-completion batch that
+ * exceeds the TTL.
+ */
+object DbutilsTokenManager {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /** Opt-in switch. When absent/false (the default), every method below is a no-op. */
+  val EnabledKey = "spark.indextables.databricks.dbutilsTokenRefresh.enabled"
+
+  /** Refresh cadence override (seconds). Default 1800 (30 min); comfortably under the ~1h dbutils TTL. */
+  val IntervalKey = "spark.indextables.databricks.dbutilsTokenRefresh.intervalSeconds"
+
+  val ApiTokenKey       = "spark.indextables.databricks.apiToken"
+  val ApiTokenSourceKey = "spark.indextables.databricks.apiToken.source"
+  val WorkspaceUrlKey   = "spark.indextables.databricks.workspaceUrl"
+
+  /** Ambient hostname Databricks injects; normalized to https:// when used as the workspace URL. */
+  val AmbientWorkspaceUrlKey = "spark.databricks.workspaceUrl"
+
+  /** Marker value written to [[ApiTokenSourceKey]] and recognized by the credential provider. */
+  val DbutilsSourceValue = "dbutils"
+
+  val DefaultIntervalSeconds = 1800L
+
+  // One refresh thread per JVM, regardless of how many sessions bootstrap.
+  private val refreshThreadStarted = new AtomicBoolean(false)
+
+  /** True only when the opt-in flag is explicitly set to "true" (case-insensitive). */
+  def isEnabled(session: SparkSession): Boolean =
+    session.conf.getOption(EnabledKey).exists(_.trim.equalsIgnoreCase("true"))
+
+  def intervalSeconds(session: SparkSession): Long =
+    session.conf
+      .getOption(IntervalKey)
+      .flatMap(v => Try(v.trim.toLong).toOption)
+      .filter(_ > 0)
+      .getOrElse(DefaultIntervalSeconds)
+
+  /**
+   * Idempotent, side-effecting bootstrap. Safe to call on any cluster and multiple times.
+   *
+   * No-ops unless the opt-in flag is set and the injected `tokenReader` yields a token. Never overrides an explicitly
+   * configured apiToken. `startThread` is exposed so unit tests can bootstrap without spawning the daemon thread.
+   */
+  def bootstrap(
+    session: SparkSession,
+    tokenReader: () => Option[String] = () => readDbutilsApiToken(),
+    startThread: Boolean = true
+  ): Unit = {
+    if (!isEnabled(session)) return
+
+    // Respect an operator-configured token — dbutils only fills the zero-config gap.
+    if (session.conf.getOption(ApiTokenKey).exists(_.trim.nonEmpty)) {
+      logger.info(
+        s"$EnabledKey is set but $ApiTokenKey is already configured; leaving the explicit token in place"
+      )
+      return
+    }
+
+    tokenReader() match {
+      case Some(token) if token.trim.nonEmpty =>
+        session.conf.set(ApiTokenKey, token)
+        session.conf.set(ApiTokenSourceKey, DbutilsSourceValue)
+        if (session.conf.getOption(WorkspaceUrlKey).forall(_.trim.isEmpty))
+          readAmbientWorkspaceUrl(session).foreach { url =>
+            session.conf.set(WorkspaceUrlKey, url)
+            logger.info(s"Auto-resolved $WorkspaceUrlKey from $AmbientWorkspaceUrlKey")
+          }
+        logger.info(s"Injected dbutils-managed apiToken into session conf ($ApiTokenSourceKey=$DbutilsSourceValue)")
+        if (startThread) startRefreshThread(session, tokenReader, intervalSeconds(session))
+      case _ =>
+        logger.info(
+          s"$EnabledKey is set but no dbutils token is available (not a Databricks driver?); no token injected"
+        )
+    }
+  }
+
+  /**
+   * Read the dbutils notebook-context API token on the DRIVER via reflection. Returns None off Databricks (class
+   * absent) or on executors (no notebook context). Reflection keeps this module free of a compile-time Databricks
+   * dependency. Method chain confirmed present on SINGLE_USER driver probes:
+   * `DBUtilsHolder.dbutils.notebook.getContext.apiToken`.
+   */
+  def readDbutilsApiToken(): Option[String] =
+    Try {
+      val holderClass = Class.forName("com.databricks.dbutils_v1.DBUtilsHolder")
+      val dbutils     = holderClass.getMethod("dbutils").invoke(null)
+      val notebook    = dbutils.getClass.getMethod("notebook").invoke(dbutils)
+      val ctx         = notebook.getClass.getMethod("getContext").invoke(notebook)
+      ctx.getClass
+        .getMethod("apiToken")
+        .invoke(ctx)
+        .asInstanceOf[Option[String]]
+        .map(_.trim)
+        .filter(_.nonEmpty)
+    }.toOption.flatten
+
+  /** Read `spark.databricks.workspaceUrl` (a bare hostname) and normalize to an https:// URL. */
+  def readAmbientWorkspaceUrl(session: SparkSession): Option[String] =
+    session.conf
+      .getOption(AmbientWorkspaceUrlKey)
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .map(url => if (url.startsWith("https://") || url.startsWith("http://")) url else s"https://$url")
+
+  /**
+   * Start the single per-JVM daemon refresh thread. Returns the started thread, or None if one was already started. The
+   * reader and interval are injected so tests can drive the loop deterministically.
+   */
+  def startRefreshThread(
+    session: SparkSession,
+    tokenReader: () => Option[String],
+    intervalSeconds: Long
+  ): Option[Thread] =
+    if (!refreshThreadStarted.compareAndSet(false, true)) {
+      logger.debug("dbutils token refresh thread already started for this JVM; not starting another")
+      None
+    } else {
+      val thread = new Thread(
+        new Runnable {
+          override def run(): Unit = refreshLoop(session, tokenReader, intervalSeconds)
+        },
+        "indextables-dbutils-token-refresh"
+      )
+      thread.setDaemon(true)
+      thread.start()
+      logger.info(s"Started dbutils token refresh thread (interval=${intervalSeconds}s)")
+      Some(thread)
+    }
+
+  private def refreshLoop(
+    session: SparkSession,
+    tokenReader: () => Option[String],
+    intervalSeconds: Long
+  ): Unit =
+    while (!Thread.currentThread().isInterrupted)
+      try {
+        Thread.sleep(intervalSeconds * 1000L)
+        refreshOnce(session, tokenReader)
+      } catch {
+        case _: InterruptedException =>
+          Thread.currentThread().interrupt()
+        case e: Throwable =>
+          // Never let a transient failure kill the thread — the current token stays in place and we retry.
+          logger.warn("dbutils token refresh iteration failed; keeping previous token and retrying", e)
+      }
+
+  /**
+   * One refresh step, extracted for unit testing without threads. Re-reads the token and rewrites the session conf; on
+   * an empty read it keeps the previous value rather than clobbering a working token with nothing.
+   */
+  def refreshOnce(session: SparkSession, tokenReader: () => Option[String]): Boolean =
+    tokenReader() match {
+      case Some(token) if token.trim.nonEmpty =>
+        session.conf.set(ApiTokenKey, token)
+        session.conf.set(ApiTokenSourceKey, DbutilsSourceValue)
+        logger.debug("Refreshed dbutils-managed apiToken in session conf")
+        true
+      case _ =>
+        logger.warn("dbutils token refresh returned no token; keeping previous value")
+        false
+    }
+
+  /** Test-only: reset the per-JVM thread guard so a subsequent startRefreshThread will start a new thread. */
+  private[extensions] def resetForTests(): Unit = refreshThreadStarted.set(false)
+}

--- a/src/main/scala/io/indextables/spark/extensions/IndexTables4SparkExtensions.scala
+++ b/src/main/scala/io/indextables/spark/extensions/IndexTables4SparkExtensions.scala
@@ -223,6 +223,18 @@ class IndexTables4SparkExtensions extends (SparkSessionExtensions => Unit) {
       )
     )
 
+    // Opt-in Databricks dbutils token bootstrap. Piggybacked on a check-rule builder because
+    // SparkSessionExtensions has no dedicated on-session-start callback: the builder function runs once,
+    // at session-state (analyzer) construction, with a live SparkSession, which is exactly where we need
+    // to read dbutils and seed the session conf. The returned checker is inert (runs per query, does
+    // nothing). DbutilsTokenManager.bootstrap is idempotent and a strict no-op unless
+    // spark.indextables.databricks.dbutilsTokenRefresh.enabled=true AND a dbutils token is readable
+    // (a Databricks driver) — so this changes nothing for existing or non-Databricks deployments.
+    extensions.injectCheckRule { session =>
+      DbutilsTokenManager.bootstrap(session)
+      _ => ()
+    }
+
     // Future: Add planning strategies
     // extensions.injectPlannerStrategy { session =>
     //   // Custom planner strategies can go here

--- a/src/test/scala/io/indextables/spark/auth/unity/UnityCatalogAmbientTokenAuthTest.scala
+++ b/src/test/scala/io/indextables/spark/auth/unity/UnityCatalogAmbientTokenAuthTest.scala
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.auth.unity
+
+import java.net.{InetSocketAddress, URI}
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.spark.SparkEnv
+
+import com.sun.net.httpserver.{HttpExchange, HttpServer}
+import io.indextables.spark.TestBase
+
+/**
+ * Tests for the AmbientClusterToken auth mode: when neither apiToken nor OAuth client credentials are configured, the
+ * provider falls back to the cluster-scoped token Databricks injects into SparkConf as `spark.databricks.token`.
+ *
+ * Extends TestBase so a real local SparkContext (and therefore a real SparkEnv) is running — this exercises the actual
+ * `SparkEnv.get.conf` reflection path used in production, not a mock. Ambient conf keys are injected into the live
+ * SparkEnv conf per-test and removed afterwards.
+ */
+class UnityCatalogAmbientTokenAuthTest extends TestBase {
+
+  private var mockServer: HttpServer               = _
+  private var serverPort: Int                      = _
+  private val requestLog: ArrayBuffer[MockRequest] = ArrayBuffer.empty
+
+  case class MockRequest(
+    method: String,
+    path: String,
+    body: String,
+    headers: Map[String, String])
+
+  private def ambientConf = SparkEnv.get.conf
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    mockServer = HttpServer.create(new InetSocketAddress(0), 0)
+    serverPort = mockServer.getAddress.getPort
+    mockServer.setExecutor(null)
+    mockServer.start()
+  }
+
+  override def afterAll(): Unit = {
+    if (mockServer != null) mockServer.stop(0)
+    super.afterAll()
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    requestLog.clear()
+    UnityCatalogAWSCredentialProvider.clearCache()
+    removeAmbientKeys()
+    Seq("/api/2.1/unity-catalog/temporary-path-credentials", "/oidc/v1/token").foreach { path =>
+      try mockServer.removeContext(path)
+      catch { case _: IllegalArgumentException => }
+    }
+  }
+
+  override def afterEach(): Unit = {
+    // Always remove ambient keys from the shared SparkEnv conf so other suites in the same JVM
+    // never see a stray spark.databricks.token.
+    removeAmbientKeys()
+    UnityCatalogAWSCredentialProvider.clearCache()
+    super.afterEach()
+  }
+
+  private def removeAmbientKeys(): Unit = {
+    ambientConf.remove("spark.databricks.token")
+    ambientConf.remove("spark.databricks.workspaceUrl")
+  }
+
+  private def setupHandler(path: String, responseBody: String): Unit = {
+    try mockServer.removeContext(path)
+    catch { case _: IllegalArgumentException => }
+    mockServer.createContext(
+      path,
+      (exchange: HttpExchange) => {
+        val body = new String(exchange.getRequestBody.readAllBytes())
+        val headers = {
+          import scala.jdk.CollectionConverters._
+          exchange.getRequestHeaders.asScala.map { case (k, v) => k -> v.get(0) }.toMap
+        }
+        requestLog += MockRequest(exchange.getRequestMethod, exchange.getRequestURI.getPath, body, headers)
+        exchange.sendResponseHeaders(200, responseBody.length)
+        val os = exchange.getResponseBody
+        os.write(responseBody.getBytes)
+        os.close()
+      }
+    )
+  }
+
+  private def credentialResponse(key: String = "AMBIENT_KEY"): String =
+    s"""{
+       |  "aws_temp_credentials": {
+       |    "access_key_id": "$key",
+       |    "secret_access_key": "test-secret",
+       |    "session_token": "test-session"
+       |  },
+       |  "expiration_time": ${System.currentTimeMillis() + 3600000}
+       |}""".stripMargin
+
+  private def oauthTokenResponse(token: String): String =
+    s"""{"access_token": "$token", "token_type": "Bearer", "expires_in": 3600}"""
+
+  private def credentialRequests: Seq[MockRequest] =
+    requestLog.filter(_.path.contains("temporary-path-credentials")).toSeq
+
+  private def bearerOf(req: MockRequest): String =
+    req.headers.getOrElse("Authorization", "")
+
+  // ==================== Happy path ====================
+
+  test("ambient cluster token is used when no explicit auth is configured") {
+    ambientConf.set("spark.databricks.token", "ambient-token-abc")
+    setupHandler("/api/2.1/unity-catalog/temporary-path-credentials", credentialResponse())
+
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      Map("spark.indextables.databricks.workspaceUrl" -> s"http://localhost:$serverPort")
+    )
+
+    val credentials = provider.getCredentials()
+    assert(credentials.getAWSAccessKeyId == "AMBIENT_KEY")
+    assert(bearerOf(credentialRequests.head) == "Bearer ambient-token-abc")
+  }
+
+  test("workspace URL is auto-resolved from spark.databricks.workspaceUrl in ambient mode") {
+    ambientConf.set("spark.databricks.token", "ambient-token-abc")
+    ambientConf.set("spark.databricks.workspaceUrl", s"http://localhost:$serverPort")
+    setupHandler("/api/2.1/unity-catalog/temporary-path-credentials", credentialResponse())
+
+    // Zero explicit configuration — both token and workspace URL come from the ambient conf.
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      Map.empty[String, String]
+    )
+
+    val credentials = provider.getCredentials()
+    assert(credentials.getAWSAccessKeyId == "AMBIENT_KEY")
+    assert(bearerOf(credentialRequests.head) == "Bearer ambient-token-abc")
+  }
+
+  test("normalizeWorkspaceUrl prepends https:// to bare hostnames and strips trailing slash") {
+    import UnityCatalogAWSCredentialProvider.normalizeWorkspaceUrl
+    // Databricks stores spark.databricks.workspaceUrl as a bare hostname, no scheme.
+    assert(normalizeWorkspaceUrl("my-workspace.cloud.databricks.com") == "https://my-workspace.cloud.databricks.com")
+    assert(normalizeWorkspaceUrl("my-workspace.cloud.databricks.com/") == "https://my-workspace.cloud.databricks.com")
+    assert(normalizeWorkspaceUrl("https://already-scheme.com") == "https://already-scheme.com")
+    assert(normalizeWorkspaceUrl("http://localhost:8080") == "http://localhost:8080")
+  }
+
+  // ==================== Priority ====================
+
+  test("explicit apiToken takes precedence over ambient token") {
+    ambientConf.set("spark.databricks.token", "ambient-token-abc")
+    setupHandler("/api/2.1/unity-catalog/temporary-path-credentials", credentialResponse())
+
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      Map(
+        "spark.indextables.databricks.workspaceUrl" -> s"http://localhost:$serverPort",
+        "spark.indextables.databricks.apiToken"     -> "explicit-static-token"
+      )
+    )
+
+    provider.getCredentials()
+    assert(bearerOf(credentialRequests.head) == "Bearer explicit-static-token")
+  }
+
+  test("OAuth client credentials take precedence over ambient token") {
+    ambientConf.set("spark.databricks.token", "ambient-token-abc")
+    setupHandler("/oidc/v1/token", oauthTokenResponse("oauth-access-token"))
+    setupHandler("/api/2.1/unity-catalog/temporary-path-credentials", credentialResponse())
+
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      Map(
+        "spark.indextables.databricks.workspaceUrl"        -> s"http://localhost:$serverPort",
+        "spark.indextables.databricks.clientId"            -> "test-client",
+        "spark.indextables.databricks.clientSecret"        -> "test-secret",
+        "spark.indextables.databricks.oauth.allowInsecure" -> "true"
+      )
+    )
+
+    provider.getCredentials()
+    assert(requestLog.exists(_.path == "/oidc/v1/token"), "OIDC endpoint should have been called")
+    assert(bearerOf(credentialRequests.head) == "Bearer oauth-access-token")
+  }
+
+  // ==================== Token rotation ====================
+
+  test("ambient token is re-read from SparkConf on each credential fetch (rotation)") {
+    ambientConf.set("spark.databricks.token", "rotating-token-1")
+    setupHandler("/api/2.1/unity-catalog/temporary-path-credentials", credentialResponse())
+
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      Map("spark.indextables.databricks.workspaceUrl" -> s"http://localhost:$serverPort")
+    )
+
+    provider.getCredentials()
+    assert(bearerOf(credentialRequests.head) == "Bearer rotating-token-1")
+
+    // Databricks rotates the token; force a re-fetch and verify the NEW token is sent.
+    ambientConf.set("spark.databricks.token", "rotating-token-2")
+    UnityCatalogAWSCredentialProvider.clearCache()
+    provider.getCredentials()
+    assert(bearerOf(credentialRequests(1)) == "Bearer rotating-token-2")
+  }
+
+  test("AWS credential cache survives ambient token rotation (fixed cache identity)") {
+    ambientConf.set("spark.databricks.token", "rotating-token-1")
+    setupHandler("/api/2.1/unity-catalog/temporary-path-credentials", credentialResponse())
+
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      Map("spark.indextables.databricks.workspaceUrl" -> s"http://localhost:$serverPort")
+    )
+
+    provider.getCredentials()
+    assert(credentialRequests.size == 1)
+
+    // Rotation must NOT invalidate the cached AWS credentials — the cache is keyed by a fixed
+    // ambient identity, not the transient token (same behavior as clientId for OAuth).
+    ambientConf.set("spark.databricks.token", "rotating-token-2")
+    provider.getCredentials()
+    assert(credentialRequests.size == 1, "cached AWS credentials should be reused after token rotation")
+  }
+
+  // ==================== Failure modes ====================
+
+  test("clear error when no auth is configured and no ambient token is present") {
+    // SparkEnv IS active here (TestBase), but spark.databricks.token is absent — same outcome as
+    // running outside Databricks.
+    val ex = intercept[IllegalStateException] {
+      UnityCatalogAWSCredentialProvider.fromConfig(
+        new URI("s3://test-bucket/path"),
+        Map("spark.indextables.databricks.workspaceUrl" -> s"http://localhost:$serverPort")
+      )
+    }
+    assert(ex.getMessage.contains("databricks.apiToken"))
+    assert(ex.getMessage.contains("spark.databricks.token"))
+  }
+
+  test("clear error when ambient token present but no workspace URL is resolvable") {
+    ambientConf.set("spark.databricks.token", "ambient-token-abc")
+
+    val ex = intercept[IllegalStateException] {
+      UnityCatalogAWSCredentialProvider.fromConfig(
+        new URI("s3://test-bucket/path"),
+        Map.empty[String, String]
+      )
+    }
+    assert(ex.getMessage.contains("workspaceUrl"))
+  }
+
+  test("empty ambient token is treated as absent") {
+    ambientConf.set("spark.databricks.token", "   ")
+
+    val ex = intercept[IllegalStateException] {
+      UnityCatalogAWSCredentialProvider.fromConfig(
+        new URI("s3://test-bucket/path"),
+        Map("spark.indextables.databricks.workspaceUrl" -> s"http://localhost:$serverPort")
+      )
+    }
+    assert(ex.getMessage.contains("databricks.apiToken"))
+  }
+}

--- a/src/test/scala/io/indextables/spark/auth/unity/UnityCatalogDbutilsTokenAuthTest.scala
+++ b/src/test/scala/io/indextables/spark/auth/unity/UnityCatalogDbutilsTokenAuthTest.scala
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.auth.unity
+
+import java.net.{InetSocketAddress, URI}
+
+import scala.collection.mutable.ArrayBuffer
+
+import com.sun.net.httpserver.{HttpExchange, HttpServer}
+import io.indextables.spark.TestBase
+
+/**
+ * Tests for the DbutilsRefreshedToken auth mode: selected when the apiToken carries an `apiToken.source=dbutils` marker
+ * (set by IndexTables4SparkExtensions.DbutilsTokenManager). resolveToken re-reads the freshest token from the driver's
+ * runtime SQLConf on every call, falling back to the token captured in the per-plan config map when the session key is
+ * absent (the executor path).
+ *
+ * Extends TestBase so a real driver SparkSession is active, exercising the actual `SparkSession.active.conf` reflection
+ * path rather than a mock.
+ */
+class UnityCatalogDbutilsTokenAuthTest extends TestBase {
+
+  private var mockServer: HttpServer               = _
+  private var serverPort: Int                      = _
+  private val requestLog: ArrayBuffer[MockRequest] = ArrayBuffer.empty
+
+  case class MockRequest(
+    method: String,
+    path: String,
+    body: String,
+    headers: Map[String, String])
+
+  private val ApiTokenKey       = "spark.indextables.databricks.apiToken"
+  private val ApiTokenSourceKey = "spark.indextables.databricks.apiToken.source"
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    mockServer = HttpServer.create(new InetSocketAddress(0), 0)
+    serverPort = mockServer.getAddress.getPort
+    mockServer.setExecutor(null)
+    mockServer.start()
+  }
+
+  override def afterAll(): Unit = {
+    if (mockServer != null) mockServer.stop(0)
+    super.afterAll()
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    requestLog.clear()
+    UnityCatalogAWSCredentialProvider.clearCache()
+    clearSessionTokenKeys()
+    try mockServer.removeContext("/api/2.1/unity-catalog/temporary-path-credentials")
+    catch { case _: IllegalArgumentException => }
+  }
+
+  override def afterEach(): Unit = {
+    clearSessionTokenKeys()
+    UnityCatalogAWSCredentialProvider.clearCache()
+    super.afterEach()
+  }
+
+  private def clearSessionTokenKeys(): Unit = {
+    spark.conf.unset(ApiTokenKey)
+    spark.conf.unset(ApiTokenSourceKey)
+  }
+
+  private def setupHandler(responseBody: String): Unit = {
+    val path = "/api/2.1/unity-catalog/temporary-path-credentials"
+    try mockServer.removeContext(path)
+    catch { case _: IllegalArgumentException => }
+    mockServer.createContext(
+      path,
+      (exchange: HttpExchange) => {
+        val body = new String(exchange.getRequestBody.readAllBytes())
+        val headers = {
+          import scala.jdk.CollectionConverters._
+          exchange.getRequestHeaders.asScala.map { case (k, v) => k -> v.get(0) }.toMap
+        }
+        requestLog += MockRequest(exchange.getRequestMethod, exchange.getRequestURI.getPath, body, headers)
+        exchange.sendResponseHeaders(200, responseBody.length)
+        val os = exchange.getResponseBody
+        os.write(responseBody.getBytes)
+        os.close()
+      }
+    )
+  }
+
+  private def credentialResponse(key: String = "DBUTILS_KEY"): String =
+    s"""{
+       |  "aws_temp_credentials": {
+       |    "access_key_id": "$key",
+       |    "secret_access_key": "test-secret",
+       |    "session_token": "test-session"
+       |  },
+       |  "expiration_time": ${System.currentTimeMillis() + 3600000}
+       |}""".stripMargin
+
+  private def credentialRequests: Seq[MockRequest] =
+    requestLog.filter(_.path.contains("temporary-path-credentials")).toSeq
+
+  private def bearerOf(req: MockRequest): String = req.headers.getOrElse("Authorization", "")
+
+  /** Config map as it would arrive from a per-plan extraction: token + dbutils marker + workspace URL. */
+  private def dbutilsConfig(token: String): Map[String, String] = Map(
+    "spark.indextables.databricks.workspaceUrl" -> s"http://localhost:$serverPort",
+    "spark.indextables.databricks.apiToken"     -> token,
+    ApiTokenSourceKey                           -> "dbutils"
+  )
+
+  // ==================== Mode selection ====================
+
+  test("dbutils marker selects DbutilsRefreshedToken and vends with the token") {
+    setupHandler(credentialResponse())
+
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      dbutilsConfig("plan-token-1")
+    )
+
+    val creds = provider.getCredentials()
+    assert(creds.getAWSAccessKeyId == "DBUTILS_KEY")
+    // No session override set, so resolveToken falls back to the config-map token (executor path).
+    assert(bearerOf(credentialRequests.head) == "Bearer plan-token-1")
+  }
+
+  test("apiToken without the dbutils marker stays StaticToken (unchanged behavior)") {
+    setupHandler(credentialResponse())
+
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      Map(
+        "spark.indextables.databricks.workspaceUrl" -> s"http://localhost:$serverPort",
+        "spark.indextables.databricks.apiToken"     -> "plain-static-token"
+      )
+    )
+
+    provider.getCredentials()
+    assert(bearerOf(credentialRequests.head) == "Bearer plain-static-token")
+  }
+
+  // ==================== Driver re-read vs executor fallback ====================
+
+  test("driver re-read: resolveToken prefers the live session token over the config-map token") {
+    setupHandler(credentialResponse())
+    // Simulate the background refresh thread having written a fresher token into the driver session conf.
+    spark.conf.set(ApiTokenKey, "session-fresh-token")
+
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      dbutilsConfig("plan-token-stale")
+    )
+
+    provider.getCredentials()
+    assert(bearerOf(credentialRequests.head) == "Bearer session-fresh-token")
+  }
+
+  test("executor fallback: with no live session token, the captured config-map token is used") {
+    setupHandler(credentialResponse())
+    // Session key absent (unset in beforeEach) — mimics an executor where SparkSession.active has no token.
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      dbutilsConfig("plan-token-captured")
+    )
+
+    provider.getCredentials()
+    assert(bearerOf(credentialRequests.head) == "Bearer plan-token-captured")
+  }
+
+  test("resolveToken re-reads on every call — rotation in the session conf is picked up") {
+    setupHandler(credentialResponse())
+    spark.conf.set(ApiTokenKey, "rotating-1")
+
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      dbutilsConfig("plan-token")
+    )
+
+    provider.getCredentials()
+    assert(bearerOf(credentialRequests.head) == "Bearer rotating-1")
+
+    // Rotate the session token, force a re-fetch, and confirm the new value is sent.
+    spark.conf.set(ApiTokenKey, "rotating-2")
+    UnityCatalogAWSCredentialProvider.clearCache()
+    provider.getCredentials()
+    assert(bearerOf(credentialRequests(1)) == "Bearer rotating-2")
+  }
+
+  // ==================== Cache identity ====================
+
+  test("AWS credential cache survives token rotation (fixed dbutils identity)") {
+    setupHandler(credentialResponse())
+    spark.conf.set(ApiTokenKey, "rotating-1")
+
+    val provider = UnityCatalogAWSCredentialProvider.fromConfig(
+      new URI("s3://test-bucket/path"),
+      dbutilsConfig("plan-token")
+    )
+
+    provider.getCredentials()
+    assert(credentialRequests.size == 1)
+
+    // Rotation must NOT invalidate cached AWS credentials — the cache key is a fixed dbutils identity,
+    // not the transient token.
+    spark.conf.set(ApiTokenKey, "rotating-2")
+    provider.getCredentials()
+    assert(credentialRequests.size == 1, "cached AWS credentials should be reused across token rotation")
+  }
+}

--- a/src/test/scala/io/indextables/spark/extensions/DbutilsTokenManagerTest.scala
+++ b/src/test/scala/io/indextables/spark/extensions/DbutilsTokenManagerTest.scala
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.extensions
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import io.indextables.spark.TestBase
+
+/**
+ * Unit tests for DbutilsTokenManager. Uses a stub token-reader so no real dbutils (or Databricks classpath) is
+ * required, and drives the extracted refresh step directly so no thread timing is involved. Extends TestBase for a real
+ * driver SparkSession to write runtime conf into.
+ */
+class DbutilsTokenManagerTest extends TestBase {
+
+  import DbutilsTokenManager._
+
+  private val AmbientWorkspaceKey = AmbientWorkspaceUrlKey
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    clearKeys()
+    resetForTests()
+  }
+
+  override def afterEach(): Unit = {
+    clearKeys()
+    resetForTests()
+    super.afterEach()
+  }
+
+  private def clearKeys(): Unit =
+    Seq(EnabledKey, IntervalKey, ApiTokenKey, ApiTokenSourceKey, WorkspaceUrlKey, AmbientWorkspaceKey)
+      .foreach(spark.conf.unset)
+
+  private def reader(token: Option[String]): () => Option[String] = () => token
+
+  // ==================== Flag / interval parsing ====================
+
+  test("isEnabled is false by default and true only for an explicit true") {
+    assert(!isEnabled(spark))
+    spark.conf.set(EnabledKey, "false")
+    assert(!isEnabled(spark))
+    spark.conf.set(EnabledKey, "TRUE")
+    assert(isEnabled(spark))
+  }
+
+  test("intervalSeconds defaults to 1800 and honors a positive override") {
+    assert(intervalSeconds(spark) == 1800L)
+    spark.conf.set(IntervalKey, "600")
+    assert(intervalSeconds(spark) == 600L)
+    spark.conf.set(IntervalKey, "0") // non-positive ignored
+    assert(intervalSeconds(spark) == 1800L)
+    spark.conf.set(IntervalKey, "not-a-number")
+    assert(intervalSeconds(spark) == 1800L)
+  }
+
+  // ==================== bootstrap gating ====================
+
+  test("bootstrap is a no-op when the flag is off (even with a token available)") {
+    bootstrap(spark, reader(Some("dbutils-token")), startThread = false)
+    assert(spark.conf.getOption(ApiTokenKey).isEmpty)
+    assert(spark.conf.getOption(ApiTokenSourceKey).isEmpty)
+  }
+
+  test("bootstrap does not override an explicitly configured apiToken") {
+    spark.conf.set(EnabledKey, "true")
+    spark.conf.set(ApiTokenKey, "operator-token")
+    bootstrap(spark, reader(Some("dbutils-token")), startThread = false)
+    assert(spark.conf.get(ApiTokenKey) == "operator-token")
+    // No marker written, so the provider keeps StaticToken semantics for the operator token.
+    assert(spark.conf.getOption(ApiTokenSourceKey).isEmpty)
+  }
+
+  test("bootstrap is a no-op when enabled but no dbutils token is available") {
+    spark.conf.set(EnabledKey, "true")
+    bootstrap(spark, reader(None), startThread = false)
+    assert(spark.conf.getOption(ApiTokenKey).isEmpty)
+    assert(spark.conf.getOption(ApiTokenSourceKey).isEmpty)
+  }
+
+  // ==================== bootstrap happy path ====================
+
+  test("bootstrap injects the token and the dbutils marker when enabled") {
+    spark.conf.set(EnabledKey, "true")
+    bootstrap(spark, reader(Some("dbutils-token")), startThread = false)
+    assert(spark.conf.get(ApiTokenKey) == "dbutils-token")
+    assert(spark.conf.get(ApiTokenSourceKey) == DbutilsSourceValue)
+  }
+
+  test("bootstrap auto-resolves workspaceUrl from spark.databricks.workspaceUrl (https prepended)") {
+    spark.conf.set(EnabledKey, "true")
+    spark.conf.set(AmbientWorkspaceKey, "my-workspace.cloud.databricks.com")
+    bootstrap(spark, reader(Some("dbutils-token")), startThread = false)
+    assert(spark.conf.get(WorkspaceUrlKey) == "https://my-workspace.cloud.databricks.com")
+  }
+
+  test("bootstrap does not overwrite an explicit workspaceUrl") {
+    spark.conf.set(EnabledKey, "true")
+    spark.conf.set(WorkspaceUrlKey, "https://explicit.example.com")
+    spark.conf.set(AmbientWorkspaceKey, "ambient.cloud.databricks.com")
+    bootstrap(spark, reader(Some("dbutils-token")), startThread = false)
+    assert(spark.conf.get(WorkspaceUrlKey) == "https://explicit.example.com")
+  }
+
+  // ==================== refreshOnce ====================
+
+  test("refreshOnce rewrites the token and returns true") {
+    spark.conf.set(ApiTokenKey, "old")
+    val ok = refreshOnce(spark, reader(Some("new-token")))
+    assert(ok)
+    assert(spark.conf.get(ApiTokenKey) == "new-token")
+    assert(spark.conf.get(ApiTokenSourceKey) == DbutilsSourceValue)
+  }
+
+  test("refreshOnce keeps the previous token and returns false on an empty read") {
+    spark.conf.set(ApiTokenKey, "keep-me")
+    val ok = refreshOnce(spark, reader(None))
+    assert(!ok)
+    assert(spark.conf.get(ApiTokenKey) == "keep-me")
+  }
+
+  // ==================== refresh thread guard ====================
+
+  test("startRefreshThread starts exactly one thread per JVM guard") {
+    val calls                   = new AtomicInteger(0)
+    val r: () => Option[String] = () => { calls.incrementAndGet(); Some("t") }
+
+    // Large interval so the loop sleeps immediately without refreshing during the test.
+    val t1 = startRefreshThread(spark, r, 3600L)
+    val t2 = startRefreshThread(spark, r, 3600L)
+    try {
+      assert(t1.isDefined, "first call should start a thread")
+      assert(t2.isEmpty, "second call should be suppressed by the per-JVM guard")
+    } finally
+      t1.foreach(_.interrupt())
+  }
+}


### PR DESCRIPTION
## Problem

`UnityCatalogAWSCredentialProvider` requires either an explicit API token (`spark.indextables.databricks.apiToken`) or OAuth2 client credentials (`clientId`/`clientSecret`) to call the Unity Catalog credential vending API. When running inside a Databricks job cluster with a service principal token, the UC API call is classified as originating from an **external** compute environment, producing:

```
HTTP 403 EXTERNAL_ACCESS_DISABLED_ON_METASTORE
External Data Access from non Databricks Compute environment is disabled
```

The only workaround is a metastore admin enabling `external_access_enabled = true` on the production metastore — a change that widens the attack surface and typically requires security review.

## Solution

Databricks injects two keys into every cluster's SparkConf at startup:

| Key | Value |
|-----|-------|
| `spark.databricks.token` | Short-lived cluster-scoped service token |
| `spark.databricks.workspaceUrl` | Workspace hostname (bare, no scheme) |

UC API calls made with this token originate from within the Databricks compute plane and are not subject to the `external_access_enabled` gate. This PR adds a third auth mode — **`AmbientClusterToken`** — used automatically when neither explicit mode is configured:

1. **OAuth2 client credentials** — `clientId` + `clientSecret` (existing, highest priority)
2. **Static API token** — `apiToken` (existing)
3. **Ambient cluster token** — `spark.databricks.token` from SparkConf (new)
4. **Error** — none available (existing, updated message)

In ambient mode the workspace URL is also auto-resolved from `spark.databricks.workspaceUrl` (with `https://` prepended, since Databricks stores a bare hostname), so jobs running on Databricks need **zero auth configuration**.

## Implementation notes

- **SparkConf is read via `SparkEnv.get.conf` reflection**, not `SparkContext.getOrCreate`: `SparkEnv` exists on both the driver **and executors** (this provider runs on executors during scan fan-out), and `SparkEnv.get` returns null rather than side-effecting when no Spark runtime is active. Reflection keeps the provider free of compile-time Spark dependencies, consistent with its existing design.
- **Token rotation**: the ambient token is re-read from SparkConf on every `resolveToken()` call rather than captured once, tolerating Databricks' periodic rotation. If the conf becomes unreadable, the initially captured token is used as a fallback.
- **Cache identity**: the AWS credential cache is keyed by a fixed `"ambient-cluster-token"` identity (there is exactly one cluster token per JVM), so cached AWS credentials survive token rotations — the same pattern already used for OAuth (keyed by `clientId`, not the transient access token).
- **No behavior change for existing configs**: explicit `apiToken` and OAuth configs resolve exactly as before, including error messages for missing `workspaceUrl` and partial OAuth config.

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| Explicit `clientId`/`clientSecret` | Works | Unchanged |
| Explicit `apiToken` | Works | Unchanged |
| Inside Databricks, no auth config | 403 / error | Auto-resolved |
| Outside Databricks, no auth config | Error | Error (updated message) |
| `workspaceUrl` unset, inside Databricks | Error | Auto-resolved |

Deployment note: UC authorization in ambient mode is evaluated against the job's run-as identity, which needs the appropriate privileges on the external location.

## Testing

- New suite `UnityCatalogAmbientTokenAuthTest` (10 tests) runs against a **real local SparkEnv** (via `TestBase`), exercising the actual reflection path rather than a mock: happy path, zero-config URL auto-resolution, URL normalization, precedence of both explicit modes over ambient, token rotation re-read, cache stability across rotation, and all failure modes.
- All 41 existing `UnityCatalogAWSCredentialProviderTest` tests pass unchanged, plus the `DatabricksConfigPropagationTest` / `UnityCatalogConfigPropagationEndToEndTest` suites (30 tests).
- `spotless:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
