### PR TITLE
Fix companion sync: order partition path by declared column order

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>io.indextables</groupId>
             <artifactId>tantivy4java</artifactId>
-            <version>0.34.4</version>
+            <version>0.34.4.1</version>
             <classifier>${platform.classifier}</classifier>
         </dependency>
 

--- a/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
+++ b/src/main/scala/io/indextables/spark/sql/SyncToExternalCommand.scala
@@ -477,7 +477,7 @@ case class SyncToExternalCommand(
       var allFiles       = collectedFiles
       allFiles = applyWhereFilter(allFiles, partitionColumns, sparkSession, fullSchema = sourceSchemaOpt)
       val maxGroupSize = targetInputSize.getOrElse(DEFAULT_TARGET_INPUT_SIZE)
-      val groups       = planIndexingGroups(allFiles, maxGroupSize)
+      val groups       = planIndexingGroups(allFiles, maxGroupSize, partitionColumns)
       val durationMs   = System.currentTimeMillis() - startTime
       return Seq(
         Row(
@@ -1151,7 +1151,7 @@ case class SyncToExternalCommand(
 
       // 8. Plan indexing groups (respecting partition boundaries and target size)
       val maxGroupSize = targetInputSize.getOrElse(DEFAULT_TARGET_INPUT_SIZE)
-      val groups       = planIndexingGroups(parquetFilesToIndex, maxGroupSize)
+      val groups       = planIndexingGroups(parquetFilesToIndex, maxGroupSize, partitionColumns)
 
       logger.info(
         s"Sync plan: ${groups.size} indexing groups, " +
@@ -1333,7 +1333,8 @@ case class SyncToExternalCommand(
           parquetFiles = plan.files.map(f => resolveAbsolutePath(f.path, effectiveParquetTableRoot)),
           parquetTableRoot = effectiveParquetTableRoot,
           partitionValues = plan.partitionValues,
-          groupIndex = idx
+          groupIndex = idx,
+          partitionColumns = plan.partitionColumns
         )
     }
 
@@ -1808,7 +1809,8 @@ case class SyncToExternalCommand(
   /** Group parquet files into indexing groups, respecting partition boundaries and target input size. */
   private def planIndexingGroups(
     files: Seq[CompanionSourceFile],
-    maxGroupSize: Long
+    maxGroupSize: Long,
+    partitionColumns: Seq[String] = Seq.empty
   ): Seq[SyncIndexingGroupPlan] = {
     // Group by partition values
     val byPartition = files.groupBy(_.partitionValues)
@@ -1820,7 +1822,7 @@ case class SyncToExternalCommand(
 
         if (numGroups == 1) {
           // All files fit in one group
-          Seq(SyncIndexingGroupPlan(partFiles.toSeq, partValues))
+          Seq(SyncIndexingGroupPlan(partFiles.toSeq, partValues, partitionColumns))
         } else {
           // Distribute files evenly: target per group = totalBytes / numGroups
           val targetPerGroup = totalBytes.toDouble / numGroups
@@ -1853,7 +1855,7 @@ case class SyncToExternalCommand(
               s"Partition $partValues: $numGroups groups, target ${targetPerGroup / 1024 / 1024}MB each, actual: [$sizesStr]"
             )
           }
-          nonEmpty.map(g => SyncIndexingGroupPlan(g.toSeq, partValues)).toSeq
+          nonEmpty.map(g => SyncIndexingGroupPlan(g.toSeq, partValues, partitionColumns)).toSeq
         }
     }.toSeq
   }
@@ -2081,4 +2083,5 @@ case class SyncToExternalCommand(
 /** Internal grouping plan for BUILD COMPANION operation (driver-side only, not serialized). */
 private[sql] case class SyncIndexingGroupPlan(
   files: Seq[CompanionSourceFile],
-  partitionValues: Map[String, String])
+  partitionValues: Map[String, String],
+  partitionColumns: Seq[String] = Seq.empty)

--- a/src/main/scala/io/indextables/spark/sync/DeltaLogReader.scala
+++ b/src/main/scala/io/indextables/spark/sync/DeltaLogReader.scala
@@ -145,14 +145,25 @@ class DeltaLogReader(deltaTablePath: String, sourceCredentials: Map[String, Stri
   }
 
   /**
-   * Get partition columns from Delta table file entries. Column mapping (physical→logical) is handled by tantivy4java
-   * 0.31.0 in listFiles(), so partition value keys are already logical names.
+   * Get the table's declared partition columns, in declared order (not alphabetical). Prefers Delta metadata via
+   * getSnapshotInfo() over the first listed file's partition-value-map keys — that approach (the old implementation)
+   * discarded declared order entirely, since Map key iteration has no defined ordering. getSnapshotInfo() requires a
+   * `_last_checkpoint`, which small/freshly-written tables don't have yet, so this falls back to the already-fetched
+   * `fileEntries` (alphabetical, matching prior behavior) when it's unavailable, rather than failing the sync.
+   * Column mapping (physical→logical) is applied natively by tantivy4java before this returns, matching the logical
+   * names already used in getAllFiles()'s partition values.
    */
-  def partitionColumns(): Seq[String] = {
-    val entries = fileEntries
-    if (entries.isEmpty) return Seq.empty
-    entries.get(0).getPartitionValues.keySet.asScala.toSeq.sorted
-  }
+  def partitionColumns(): Seq[String] =
+    try {
+      val snapshotInfo = DeltaTableReader.getSnapshotInfo(deltaKernelPath, deltaConfig)
+      snapshotInfo.getPartitionColumns.asScala.toSeq
+    } catch {
+      case e: Exception =>
+        logger.debug(s"getSnapshotInfo unavailable for declared partition-column order, falling back to first file's keys (alphabetical): ${e.getMessage}")
+        val entries = fileEntries
+        if (entries.isEmpty) Seq.empty
+        else entries.get(0).getPartitionValues.keySet.asScala.toSeq.sorted
+    }
 
   /** Get the schema from Delta table metadata as a Spark StructType. */
   def schema(): StructType = {

--- a/src/main/scala/io/indextables/spark/sync/DistributedSourceScanner.scala
+++ b/src/main/scala/io/indextables/spark/sync/DistributedSourceScanner.scala
@@ -765,8 +765,14 @@ class DistributedSourceScanner(spark: SparkSession) {
                 .asScala
             }.toSeq
             val storageRoot = newEntries.headOption.map(e => SyncTaskExecutor.extractTableBasePath(e.getPath))
-            val partCols =
+            // Declared spec order (not alphabetical) from the snapshot's partition-spec JSON; fall back to
+            // alphabetical-from-first-entry if unavailable, preserving prior behavior in that edge case.
+            val specOrderCols = IcebergSourceReader.parsePartitionSpecFieldNames(snapshotInfo.getPartitionSpecJson)
+            val partCols = if (specOrderCols.nonEmpty) {
+              specOrderCols
+            } else {
               newEntries.headOption.map(_.getPartitionValues.keySet.asScala.toSeq.sorted).getOrElse(Seq.empty)
+            }
             val files = newEntries.map(e => icebergEntryToCompanionFile(e, storageRoot, dateCols)).toSeq
             logger.info(s"Iceberg incremental: ${files.size} new files from ${newEntries.size} new manifest entries")
             val sc = spark.sparkContext
@@ -800,7 +806,14 @@ class DistributedSourceScanner(spark: SparkSession) {
     val firstEntry          = firstManifestEntries.headOption
     val computedStorageRoot = firstEntry.map(e => SyncTaskExecutor.extractTableBasePath(e.getPath))
     val sampleFilePath      = firstEntry.map(_.getPath)
-    val partitionColumns    = firstEntry.map(_.getPartitionValues.keySet.asScala.toSeq.sorted).getOrElse(Seq.empty)
+    // Declared spec order (not alphabetical) from the snapshot's partition-spec JSON; fall back to
+    // alphabetical-from-first-entry if unavailable, preserving prior behavior in that edge case.
+    val specOrderCols  = IcebergSourceReader.parsePartitionSpecFieldNames(snapshotInfo.getPartitionSpecJson)
+    val partitionColumns = if (specOrderCols.nonEmpty) {
+      specOrderCols
+    } else {
+      firstEntry.map(_.getPartitionValues.keySet.asScala.toSeq.sorted).getOrElse(Seq.empty)
+    }
 
     // Distributed: read all manifests on executors
     val sc                = spark.sparkContext

--- a/src/main/scala/io/indextables/spark/sync/IcebergSourceReader.scala
+++ b/src/main/scala/io/indextables/spark/sync/IcebergSourceReader.scala
@@ -52,6 +52,32 @@ object IcebergSourceReader {
   private val decimalPattern = """decimal\((\d+),\s*(\d+)\)""".r
   private val fixedPattern   = """fixed\[(\d+)\]""".r
 
+  /**
+   * Extract partition column names, in declared spec order, from Iceberg's `partition-spec` JSON (as returned by
+   * `IcebergSnapshotInfo.getPartitionSpecJson()`), e.g. `{"spec-id":0,"fields":[{"name":"region",...},
+   * {"name":"day",...}]}` -> `Seq("region", "day")`. Returns empty (rather than throwing) on null/blank/malformed
+   * input, so callers can fall back to alphabetical ordering — matching prior behavior — instead of failing sync.
+   */
+  def parsePartitionSpecFieldNames(partitionSpecJson: String): Seq[String] =
+    if (partitionSpecJson == null || partitionSpecJson.isBlank) {
+      Seq.empty
+    } else {
+      try {
+        val fields = JsonUtil.mapper.readTree(partitionSpecJson).get("fields")
+        if (fields == null || !fields.isArray) {
+          Seq.empty
+        } else {
+          (0 until fields.size()).flatMap { i =>
+            Option(fields.get(i).get("name")).map(_.asText())
+          }
+        }
+      } catch {
+        case e: Exception =>
+          logger.warn(s"Failed to parse Iceberg partition-spec JSON for column ordering: ${e.getMessage}")
+          Seq.empty
+      }
+    }
+
   /** Parse schema JSON to Spark StructType, trying Spark format first and falling back to Iceberg format conversion. */
   def parseSchemaJson(schemaJson: String): StructType =
     try
@@ -288,10 +314,26 @@ class IcebergSourceReader(
     }
   }
 
-  override def partitionColumns(): Seq[String] =
-    getAllFiles().headOption
-      .map(_.partitionValues.keys.toSeq.sorted)
-      .getOrElse(Seq.empty)
+  /**
+   * Declared partition columns, in spec order — sourced from the snapshot's partition-spec JSON rather than an
+   * arbitrary file entry's partition-value-map keys (which has no defined order and was previously sorted
+   * alphabetically, discarding the true declared order). Falls back to alphabetical-from-first-file if the spec
+   * JSON is unavailable or unparsable, preserving prior behavior in that edge case.
+   */
+  override def partitionColumns(): Seq[String] = {
+    val info = snapshotId match {
+      case Some(id) => IcebergTableReader.getSnapshotInfo(catalogName, namespace, tableName, icebergConfig, id)
+      case None     => IcebergTableReader.getSnapshotInfo(catalogName, namespace, tableName, icebergConfig)
+    }
+    val declaredOrder = IcebergSourceReader.parsePartitionSpecFieldNames(info.getPartitionSpecJson)
+    if (declaredOrder.nonEmpty) {
+      declaredOrder
+    } else {
+      getAllFiles().headOption
+        .map(_.partitionValues.keys.toSeq.sorted)
+        .getOrElse(Seq.empty)
+    }
+  }
 
   /**
    * Extract Hive-style partition values from a file path relative to a base path. E.g., for base="s3://bucket/data" and

--- a/src/main/scala/io/indextables/spark/sync/ParquetDirectoryReader.scala
+++ b/src/main/scala/io/indextables/spark/sync/ParquetDirectoryReader.scala
@@ -233,11 +233,27 @@ class ParquetDirectoryReader(
     partitions.toMap
   }
 
-  /** Discover partition columns from the first file's relative path. */
+  /**
+   * Discover partition columns from the first file's relative path, in the order the `key=value` segments actually
+   * appear in the directory structure (the declared order for Hive-style partitioning) — not alphabetically, since
+   * that order was already lost once by routing through `partitionValues.keys` (a Map, whose key iteration order is
+   * not defined).
+   */
   private def discoverPartitionColumns(): Seq[String] =
     discoveredFiles.headOption
-      .map(_.partitionValues.keys.toSeq.sorted)
+      .map(f => extractPartitionKeysInOrder(f.path))
       .getOrElse(Seq.empty)
+
+  /** Extract Hive-style partition key names from a relative path, in path-segment order. */
+  private def extractPartitionKeysInOrder(relativePath: String): Seq[String] =
+    relativePath
+      .split("/")
+      .dropRight(1) // exclude filename
+      .flatMap { component =>
+        val eqIdx = component.indexOf('=')
+        if (eqIdx > 0) Some(component.substring(0, eqIdx)) else None
+      }
+      .toSeq
 
   /**
    * Read schema from a single parquet file via tantivy4java's ParquetSchemaReader.

--- a/src/main/scala/io/indextables/spark/sync/SyncTaskExecutor.scala
+++ b/src/main/scala/io/indextables/spark/sync/SyncTaskExecutor.scala
@@ -55,7 +55,8 @@ case class SyncIndexingGroup(
   parquetFiles: Seq[String],
   parquetTableRoot: String,
   partitionValues: Map[String, String],
-  groupIndex: Int)
+  groupIndex: Int,
+  partitionColumns: Seq[String] = Seq.empty)
     extends Serializable
 
 /** Result of indexing a single group of parquet files into a companion split. Returned from executor to driver. */
@@ -207,13 +208,7 @@ object SyncTaskExecutor {
       )
 
       // 4. Upload companion split to destination
-      val partitionPrefix = if (group.partitionValues.nonEmpty) {
-        group.partitionValues.toSeq.sorted
-          .map { case (k, v) => s"$k=$v" }
-          .mkString("/") + "/"
-      } else {
-        ""
-      }
+      val partitionPrefix = buildPartitionPrefix(group.partitionValues, group.partitionColumns)
       val destSplitPath = s"${config.splitTablePath.stripSuffix("/")}/$partitionPrefix$splitFileName"
       val splitSize     = uploadSplit(localSplitPath, destSplitPath, config.storageConfig, config.splitTablePath)
 
@@ -269,6 +264,23 @@ object SyncTaskExecutor {
     tempDir.mkdirs()
     tempDir
   }
+
+  /**
+   * Build the Hive-style partition path prefix (e.g. "a=1/b=2/") for a companion split, ordering segments by the
+   * table's declared partition-column order rather than alphabetically. Falls back to alphabetical-by-key when
+   * `partitionColumns` is empty (declared order unavailable — e.g. Iceberg sources today), which preserves the
+   * previous behavior exactly. A `partitionValues` key absent from `partitionColumns` is defensively dropped rather
+   * than crashing (should not normally happen). Pure and Spark-independent — safe to unit test directly.
+   */
+  private[sync] def buildPartitionPrefix(partitionValues: Map[String, String], partitionColumns: Seq[String]): String =
+    if (partitionValues.isEmpty) {
+      ""
+    } else {
+      val orderedKeys = if (partitionColumns.nonEmpty) partitionColumns else partitionValues.keys.toSeq.sorted
+      orderedKeys
+        .flatMap(k => partitionValues.get(k).map(v => s"$k=$v"))
+        .mkString("/") + "/"
+    }
 
   private def extractRelativePath(absolutePath: String, tableRoot: String): String = {
     val normalizedPath = absolutePath.stripSuffix("/")

--- a/src/test/scala/io/indextables/spark/sync/CompanionSyncPartitionPathOrderTest.scala
+++ b/src/test/scala/io/indextables/spark/sync/CompanionSyncPartitionPathOrderTest.scala
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.indextables.spark.sync
+
+import java.io.File
+import java.nio.file.Files
+
+import org.apache.spark.sql.SparkSession
+
+import org.apache.hadoop.fs.Path
+
+import io.indextables.spark.transaction.TransactionLogFactory
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
+
+/**
+ * Regression tests for GitHub issue #393: companion split S3 paths were ordered alphabetically by partition-column
+ * name instead of by the table's declared partition-column order (e.g. `partitionBy("zone", "date")` should produce
+ * `zone=.../date=.../...split`, not `date=.../zone=.../...split`).
+ *
+ * Covers both the pure ordering logic in `SyncTaskExecutor.buildPartitionPrefix` and an end-to-end local-filesystem
+ * companion sync where "date" sorts alphabetically before "zone" but is declared second.
+ */
+class CompanionSyncPartitionPathOrderTest
+    extends AnyFunSuite
+    with Matchers
+    with BeforeAndAfterAll
+    with io.indextables.spark.testutils.FileCleanupHelper {
+
+  protected var spark: SparkSession = _
+
+  override def beforeAll(): Unit = {
+    SparkSession.getActiveSession.foreach(_.stop())
+    SparkSession.getDefaultSession.foreach(_.stop())
+
+    spark = SparkSession
+      .builder()
+      .appName("CompanionSyncPartitionPathOrderTest")
+      .master("local[2]")
+      .config("spark.sql.warehouse.dir", Files.createTempDirectory("spark-warehouse").toString)
+      .config("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+      .config("spark.driver.host", "127.0.0.1")
+      .config("spark.driver.bindAddress", "127.0.0.1")
+      .config(
+        "spark.sql.extensions",
+        "io.indextables.spark.extensions.IndexTables4SparkExtensions," +
+          "io.delta.sql.DeltaSparkSessionExtension"
+      )
+      .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+      .config("spark.sql.adaptive.enabled", "false")
+      .config("spark.sql.adaptive.coalescePartitions.enabled", "false")
+      .config("spark.indextables.aws.accessKey", "test-default-access-key")
+      .config("spark.indextables.aws.secretKey", "test-default-secret-key")
+      .config("spark.indextables.aws.sessionToken", "test-default-session-token")
+      .config("spark.indextables.s3.pathStyleAccess", "true")
+      .config("spark.indextables.aws.region", "us-east-1")
+      .config("spark.indextables.s3.endpoint", "http://localhost:10101")
+      .getOrCreate()
+
+    spark.sparkContext.setLogLevel("WARN")
+
+    _root_.io.indextables.spark.storage.SplitConversionThrottle.initialize(
+      maxParallelism = Runtime.getRuntime.availableProcessors() max 1
+    )
+  }
+
+  override def afterAll(): Unit =
+    if (spark != null) {
+      spark.stop()
+    }
+
+  private def withTempPath(f: String => Unit): Unit = {
+    val path = Files.createTempDirectory("tantivy4spark-partorder").toString
+    try {
+      try {
+        import _root_.io.indextables.spark.storage.{DriverSplitLocalityManager, GlobalSplitCacheManager}
+        GlobalSplitCacheManager.flushAllCaches()
+        DriverSplitLocalityManager.clear()
+      } catch {
+        case _: Exception =>
+      }
+      f(path)
+    } finally
+      deleteRecursively(new File(path))
+  }
+
+  // -------------------------------------------------------
+  //  Pure unit tests: SyncTaskExecutor.buildPartitionPrefix
+  // -------------------------------------------------------
+
+  test("buildPartitionPrefix orders by declared partitionColumns, not alphabetically") {
+    val values  = Map("zone" -> "east", "date" -> "2024-01-01")
+    val columns = Seq("zone", "date")
+
+    SyncTaskExecutor.buildPartitionPrefix(values, columns) shouldBe "zone=east/date=2024-01-01/"
+  }
+
+  test("buildPartitionPrefix falls back to alphabetical when partitionColumns is empty") {
+    val values = Map("zone" -> "east", "date" -> "2024-01-01")
+
+    SyncTaskExecutor.buildPartitionPrefix(values, Seq.empty) shouldBe "date=2024-01-01/zone=east/"
+  }
+
+  test("buildPartitionPrefix drops a partitionValues key missing from partitionColumns") {
+    val values  = Map("zone" -> "east", "date" -> "2024-01-01", "extra" -> "unexpected")
+    val columns = Seq("zone", "date") // "extra" deliberately omitted
+
+    SyncTaskExecutor.buildPartitionPrefix(values, columns) shouldBe "zone=east/date=2024-01-01/"
+  }
+
+  test("buildPartitionPrefix returns empty string for unpartitioned data") {
+    SyncTaskExecutor.buildPartitionPrefix(Map.empty, Seq("zone", "date")) shouldBe ""
+  }
+
+  test("buildPartitionPrefix handles three-column declared order") {
+    val values  = Map("year" -> "2024", "month" -> "01", "day" -> "15")
+    val columns = Seq("day", "year", "month") // deliberately non-alphabetical declared order
+
+    SyncTaskExecutor.buildPartitionPrefix(values, columns) shouldBe "day=15/year=2024/month=01/"
+  }
+
+  // -------------------------------------------------------
+  //  Pure unit tests: IcebergSourceReader.parsePartitionSpecFieldNames
+  // -------------------------------------------------------
+
+  test("parsePartitionSpecFieldNames extracts field names in declared spec order") {
+    val json =
+      """{"spec-id":0,"fields":[{"source-id":2,"field-id":1000,"transform":"identity","name":"zone"},
+        |{"source-id":1,"field-id":1001,"transform":"day","name":"date"}]}""".stripMargin
+
+    IcebergSourceReader.parsePartitionSpecFieldNames(json) shouldBe Seq("zone", "date")
+  }
+
+  test("parsePartitionSpecFieldNames returns empty for null, blank, or malformed JSON") {
+    IcebergSourceReader.parsePartitionSpecFieldNames(null) shouldBe Seq.empty
+    IcebergSourceReader.parsePartitionSpecFieldNames("") shouldBe Seq.empty
+    IcebergSourceReader.parsePartitionSpecFieldNames("not json") shouldBe Seq.empty
+    IcebergSourceReader.parsePartitionSpecFieldNames("""{"spec-id":0}""") shouldBe Seq.empty
+  }
+
+  // -------------------------------------------------------
+  //  End-to-end: local Delta table, two-column partitioning
+  // -------------------------------------------------------
+
+  test("companion sync of a two-column-partitioned Delta table orders paths by declared column order") {
+    withTempPath { tempDir =>
+      val deltaPath = new File(tempDir, "delta_ordered").getAbsolutePath
+      val indexPath = new File(tempDir, "companion_ordered").getAbsolutePath
+
+      // "date" sorts alphabetically before "zone", but is declared SECOND — this is exactly the
+      // scenario from issue #393 (alphabetically-earlier column not first in declared order).
+      val ss = spark
+      import ss.implicits._
+      Seq(
+        ("east", "2024-01-01", 1L),
+        ("west", "2024-01-02", 2L)
+      ).toDF("zone", "date", "id")
+        .write
+        .format("delta")
+        .partitionBy("zone", "date")
+        .save(deltaPath)
+
+      // Force a checkpoint so getSnapshotInfo() (the declared-order source) is available —
+      // matches the pattern used by DistributedDeltaSyncIntegrationTest's "(with checkpoint)" tests.
+      val deltaLog = org.apache.spark.sql.delta.DeltaLog.forTable(spark, deltaPath)
+      deltaLog.checkpoint()
+
+      val result = spark.sql(
+        s"BUILD INDEXTABLES COMPANION FOR DELTA '$deltaPath' AT LOCATION '$indexPath'"
+      )
+      val rows = result.collect()
+      rows.length shouldBe 1
+      rows(0).getString(2) shouldBe "success"
+
+      val txLog = TransactionLogFactory.create(new Path(indexPath), spark)
+      try {
+        val files = txLog.listFiles()
+        files should not be empty
+        files.foreach { file =>
+          val zoneIdx = file.path.indexOf("zone=")
+          val dateIdx = file.path.indexOf("date=")
+          withClue(s"split path was '${file.path}': ") {
+            zoneIdx should be >= 0
+            dateIdx should be >= 0
+            zoneIdx should be < dateIdx // declared order (zone, date), not alphabetical (date, zone)
+          }
+        }
+      } finally
+        txLog.close()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

`SyncTaskExecutor.execute()` built the S3 path prefix for companion splits by alphabetically
sorting `partitionValues`' `Map` keys, ignoring the table's actual declared `partitionBy(...)`
order. On multi-column-partitioned tables this silently reordered path segments whenever the
alphabetically-first column wasn't declared first — e.g. producing `date=.../zone=.../...split`
instead of `zone=.../date=.../...split`.

## Change

**Fix A** — thread the declared partition-column order from the driver down to the executor:
`SyncIndexingGroupPlan` and `SyncIndexingGroup` both gained a `partitionColumns: Seq[String]`
field, populated from the reader's/scanner's declared column list at both `planIndexingGroups()`
call sites.

**Fix B** — `SyncTaskExecutor.buildPartitionPrefix()` (new, `private[sync]`, pure and directly
unit-tested) orders path segments by `partitionColumns` when available, falling back to the old
alphabetical behavior only when it isn't.

**Went one level deeper than the original issue text assumed.** Issue #393 stated that
`CompanionSourceReader.partitionColumns()` "already returns the correctly-ordered column list" —
that turned out to be false for all three source types: `DeltaLogReader`, `IcebergSourceReader`,
and `ParquetDirectoryReader` were themselves sorting a partition-value `Map`'s keys alphabetically.
Fixed each at its actual source of truth instead:
- **Delta**: `DeltaTableReader.getSnapshotInfo(...).getPartitionColumns()` (Delta's own
  `metaData.partitionColumns`, declared order). `getSnapshotInfo` requires a `_last_checkpoint`,
  which a freshly-written/small table won't have yet — falls back to the prior
  alphabetical-from-first-file behavior when it's unavailable, rather than failing the sync.
- **Iceberg**: parses the snapshot's `partition-spec` JSON (`fields[].name`, in spec order) —
  both in `IcebergSourceReader.partitionColumns()` and the two equivalent spots in
  `DistributedSourceScanner`'s Iceberg scan path.
- **Parquet directory**: extracts `key=value` segment order directly from a discovered file's
  relative path, instead of sorting `partitionValues.keys`.

A `partitionValues` key absent from the declared column list is defensively dropped rather than
crashing. No migration of already-written companion splits is included. Both are explicit,
deliberate scope decisions from issue #393, not oversights.

## pom.xml

Also bumps the pinned `tantivy4java` version to `0.34.4.1`, matching #392 — which already carries
that bump ahead of `0.34.4.1` being tagged upstream — so this branch's pom config doesn't regress
to the stale pinned version. Unrelated to the partition-order fix itself.

## A bug found (not fixed) while testing this

The first version of the end-to-end test used a bare (non-Delta) Parquet directory with two
partition columns and failed — not with the wrong order, but with the second column (`date=`)
missing from the path *entirely*. Root-caused to `tantivy4java`'s
`ParquetTableReader.getTableInfo()`: its distributed-scan directory listing
(`native/src/parquet_reader/distributed.rs`) uses a non-recursive, single-level
`list_with_delimiter` call, so it only ever discovers the first level of Hive partition
directories for a bare Parquet directory. This is a separate, pre-existing native bug — every
existing bare-Parquet test in this repo only ever used one partition column, consistent with this
gap never having been exercised before. Filed upstream as
[tantivy4java#203](https://github.com/indextables/tantivy4java/issues/203) and intentionally left
unfixed here; the end-to-end test uses Delta instead (with a forced checkpoint, matching the
pattern in `DistributedDeltaSyncIntegrationTest`).

## Test plan

New file `CompanionSyncPartitionPathOrderTest.scala` (8 tests, none existing tests modified):
- [x] `buildPartitionPrefix` orders by declared columns, not alphabetically
- [x] `buildPartitionPrefix` falls back to alphabetical when the declared order is unavailable
- [x] `buildPartitionPrefix` drops a value key missing from the declared columns
- [x] `buildPartitionPrefix` on unpartitioned data / three-column declared order
- [x] `IcebergSourceReader.parsePartitionSpecFieldNames` on valid/null/blank/malformed JSON
- [x] End-to-end: two-column-partitioned Delta table (checkpointed) → split path segments in
      declared order, not alphabetical

Regression (existing tests, unmodified): `LocalSyncIntegrationTest`, `LocalParquetSyncIntegrationTest`,
`CompanionPartitionFilterBugTest`, `CompanionMultiPartitionFilterBugTest` — 59/59 passing, including
one test that exercises the checkpoint-less `DeltaLogReader.partitionColumns()` fallback path and
confirmed it still falls back correctly rather than failing the sync.

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)
